### PR TITLE
Bugfix: handle RegExp in Astro syntax

### DIFF
--- a/.changeset/dull-pandas-move.md
+++ b/.changeset/dull-pandas-move.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Bugfix: handle RegExp in Astro files

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -198,6 +198,14 @@ func TestFrontmatter(t *testing.T) {
 			`,
 			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken},
 		},
+		{
+			"RegExp",
+			`---
+const RegExp = /---< > > { }; import thing from "thing"; /
+---
+			{html}`,
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken, TextToken, StartExpressionToken, TextToken, EndExpressionToken},
+		},
 		// {
 		// 	"less than with no space isn’t a tag",
 		// 	`


### PR DESCRIPTION
Tests added! Was investigating our `Code` internal component and realized this broke the compiler:

```
  // Replace "shiki" css variable naming with "astro".
  html = html.replace(/style="(background-)?color: var\(--shiki-/g, 'style="$1color: var(--astro-code-');
```