### PR TITLE
Add awareness of void tags

### DIFF
--- a/.changeset/rich-wombats-tap.md
+++ b/.changeset/rich-wombats-tap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Bugfix: allow for detection of void tags (e.g. <img>)

--- a/internal/token.go
+++ b/internal/token.go
@@ -1017,10 +1017,17 @@ func (z *Tokenizer) readStartTag() TokenType {
 	if raw {
 		z.rawTag = string(z.buf[z.data.Start:z.data.End])
 	}
-	// Look for a self-closing token like "<br/>".
+
+	// HTML void tags list: https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
+	// Note: self-closing tags in SVG and MathML work differently; handled below
+	if z.startTagIn("area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr") {
+		return SelfClosingTagToken
+	}
+	// Look for a self-closing token that’s not in the list above (e.g. "<svg><path/></svg>")
 	if z.err == nil && z.buf[z.raw.End-2] == '/' {
 		return SelfClosingTagToken
 	}
+
 	return StartTagToken
 }
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -43,9 +43,24 @@ func TestBasic(t *testing.T) {
 			[]TokenType{EndTagToken},
 		},
 		{
-			"self-closing tag",
+			"self-closing tag (slash)",
 			`<meta charset="utf-8" />`,
 			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"self-closing tag (no slash)",
+			`<img width="480" height="320">`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"SVG (self-closing)",
+			`<svg><path/></svg>`,
+			[]TokenType{StartTagToken, SelfClosingTagToken, EndTagToken},
+		},
+		{
+			"SVG (left open)",
+			`<svg><path></svg>`, // note: this test isn’t “ideal” it’s just testing current behavior
+			[]TokenType{StartTagToken, StartTagToken, EndTagToken},
 		},
 		{
 			"text",


### PR DESCRIPTION
## Changes

Fixes when the compiler encounters an `<img>` tag without a trailing slash. According to spec, the slash is optional, so our tokenizer should catch that.

Our parser is correct, but this is a fix for the tokenizer.

## Testing

Tests added

## Docs

No docs needed