### PR TITLE
Fix component name bug

### DIFF
--- a/.changeset/little-bags-drop.md
+++ b/.changeset/little-bags-drop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Bugfix: fix component detection bug in parser

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -392,7 +392,7 @@ func isComponent(data string) bool {
 	if strings.Contains(data, ".") {
 		return true
 	}
-	return !isFragment(data) && data[0] > 'A' && data[0] < 'Z'
+	return !isFragment(data) && data[0] >= 'A' && data[0] <= 'Z'
 }
 
 func isCustomElement(data string) bool {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -719,6 +719,33 @@ let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');`},
 				code:   "<html><head></head><body><div>testing</div></body></html>",
 			},
 		},
+		{
+			name: "Component names A-Z",
+			source: `---
+import AComponent from '../components/AComponent.jsx';
+import ZComponent from '../components/ZComponent.jsx';
+---
+
+<body>
+  <AComponent />
+  <ZComponent />
+</body>`,
+			want: want{
+				imports: "",
+				frontmatter: []string{
+					`import AComponent from '../components/AComponent.jsx';
+import ZComponent from '../components/ZComponent.jsx';
+
+import * as $$module1 from '../components/AComponent.jsx';
+import * as $$module2 from '../components/ZComponent.jsx';`},
+				metadata: `{ modules: [{ module: $$module1, specifier: '../components/AComponent.jsx' }, { module: $$module2, specifier: '../components/ZComponent.jsx' }], hydratedComponents: [], hoisted: [] }`,
+				styles:   []string{},
+				code: `<html><head></head><body>
+  ${` + RENDER_COMPONENT + `($$result,'AComponent',AComponent,{})}
+  ${` + RENDER_COMPONENT + `($$result,'ZComponent',ZComponent,{})}
+</body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

Bugfix: components couldn’t start with `A` or `Z` 🤪 

```diff
- return !isFragment(data) && data[0] > 'A' && data[0] < 'Z'
+ return !isFragment(data) && data[0] >= 'A' && data[0] <= 'Z'
```

## Testing

Tests added!

## Docs
No docs needed