### PR TITLE
Bugfix: fix CSS “and” selector scoping

### DIFF
--- a/.changeset/sweet-rivers-invent.md
+++ b/.changeset/sweet-rivers-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Bugfix: CSS and selector scoping

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -170,7 +170,9 @@ outer:
 						}
 
 						// scope class
-						if gt == css.BeginRulesetGrammar && val.TokenType == css.IdentToken && // only scope scope-able tokens
+						isCssSelector := gt == css.BeginRulesetGrammar || gt == css.QualifiedRuleGrammar
+						if val.TokenType == css.IdentToken && // only scope scope-able tokens
+							isCssSelector && // don’t scope @media and other non-class specifiers
 							!isPseudoState && // don’t scope pseudostates
 							!isGlobal && // don’t scope in :global() scope
 							!isGlobalElement &&

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -33,6 +33,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   ".class.astro-XXXXXX+.class.astro-XXXXXX{}",
 		},
 		{
+			name:   "and selector",
+			source: ".class,.class{}",
+			want:   ".class.astro-XXXXXX,.class.astro-XXXXXX{}",
+		},
+		{
 			name:   "children universal",
 			source: ".class *{}",
 			want:   ".class.astro-XXXXXX .astro-XXXXXX{}",
@@ -153,6 +158,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   ".class\\:class.astro-XXXXXX:focus{}",
 		},
 		// the following tests assert we leave valid CSS alone
+		{
+			name:   "attributes",
+			source: "body{background-image:url('/assets/bg.jpg');clip-path:polygon(0% 0%,100% 0%,100% 100%,0% 100%);}",
+			want:   "body{background-image:url('/assets/bg.jpg');clip-path:polygon(0% 0%,100% 0%,100% 100%,0% 100%);}",
+		},
 		{
 			name:   "keyframes",
 			source: "@keyframes shuffle{from{transform:rotate(0deg);}to{transform:rotate(360deg);}}",


### PR DESCRIPTION
## Changes

Bug in CSS scoping: we weren’t testing for `.classA, .classB`. Now we are!

## Testing


Tests added

## Docs

No docs needed
