### PR TITLE
Do not scope the `:root` selector

### DIFF
--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -237,7 +237,8 @@ func globalElement(id string) bool {
 		"noscript",
 		"script",
 		"style",
-		"title":
+		"title",
+		":root":
 		return true
 	default:
 		return false

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -153,6 +153,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   "html,body{}",
 		},
 		{
+			name:   ":root",
+			source: ":root{}",
+			want:   ":root{}",
+		},
+		{
 			name:   "escaped characters",
 			source: ".class\\:class:focus{}",
 			want:   ".class\\:class.astro-XXXXXX:focus{}",


### PR DESCRIPTION
## Changes

- This changes the compiler to not scope the `:root` selector.

## Testing

A test is added to `scope-css_test.go` alongside the "_html and body_" tests.

## Docs

bug fix only