### PR TITLE
Pass projectRoot through to `createAstro`

### DIFF
--- a/.changeset/stale-hornets-add.md
+++ b/.changeset/stale-hornets-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Passes projectRoot to createAstro

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -60,6 +60,11 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 		site = "https://astro.build"
 	}
 
+	projectRoot := jsString(options.Get("projectRoot"))
+	if projectRoot == "" {
+		projectRoot = "."
+	}
+
 	preprocessStyle := options.Get("preprocessStyle")
 
 	return transform.TransformOptions{
@@ -69,6 +74,7 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 		InternalURL:     internalURL,
 		SourceMap:       sourcemap,
 		Site:            site,
+		ProjectRoot:     projectRoot,
 		PreprocessStyle: preprocessStyle,
 	}
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -260,7 +260,7 @@ func (p *printer) addNilSourceMapping() {
 }
 
 func (p *printer) printTopLevelAstro() {
-	p.println(fmt.Sprintf("const $$Astro = %s(import.meta.url, '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, p.opts.Site))
+	p.println(fmt.Sprintf("const $$Astro = %s(import.meta.url, '%s', '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, p.opts.Site, p.opts.ProjectRoot))
 }
 
 func (p *printer) printComponentMetadata(doc *astro.Node, source []byte) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -37,7 +37,7 @@ var STYLE_PRELUDE = "const STYLES = [\n"
 var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE);\n"
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
 var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT);\n"
-var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build');\nconst Astro = $$Astro;"
+var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
 
 // SPECIAL TEST FIXTURES
 var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[];:'\",.?")
@@ -1274,6 +1274,7 @@ const items = ["Dog", "Cat", "Platipus"];
 				Scope:       "astro-XXXX",
 				Site:        "https://astro.build",
 				InternalURL: "http://localhost:3000/",
+				ProjectRoot: ".",
 			})
 			output := string(result.Output)
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -17,6 +17,7 @@ type TransformOptions struct {
 	InternalURL     string
 	SourceMap       string
 	Site            string
+	ProjectRoot     string
 	PreprocessStyle interface{}
 }
 

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -9,6 +9,7 @@ export interface TransformOptions {
   sourcefile?: string;
   sourcemap?: boolean | 'inline' | 'external' | 'both';
   as?: 'document' | 'fragment';
+  projectRoot?: string;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => Promise<PreprocessorResult>;
 }
 


### PR DESCRIPTION
## Changes

- Passes `projectRoot` through to the `createAstro` function in internals.
- This will be used to make URLs created by `Astro.resolve` be projectRoot relative
- `/src/...` instead of `/Users/name/...`

## Testing

Tested in Astro mostly, tests updated here.

## Docs

N/A
