### PR TITLE
Add invalid CSS tests

### DIFF
--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -208,6 +208,19 @@ func TestScopeStyle(t *testing.T) {
 			source: "@import url(\"./my-file.css\");",
 			want:   "@import url(\"./my-file.css\");",
 		},
+		{
+			name:   "valid CSS, madeup syntax",
+			source: "@tailwind base;",
+			want:   "@tailwind base;",
+		},
+		{
+			name: "invalid CSS (missing semi)",
+			source: `.foo {
+  color: blue
+  font-size: 18px;
+}`,
+			want: `.foo.astro-XXXXXX{color:blue font-size:18px;}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Changes

I was tracking down some compiler weirdness with CSS and wanted to add some tests for invalid CSS. Fortunately, these pass! So I think it’s worth adding just to track against regressions here.

No code changes.

## Testing

test only

## Docs

no docs