### PR TITLE
Fix expressions inside `<template>`

### DIFF
--- a/.changeset/polite-planes-shake.md
+++ b/.changeset/polite-planes-shake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix bug when fragment parsing frontmatter is missing

--- a/.changeset/polite-planes-shake.md
+++ b/.changeset/polite-planes-shake.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Fix bug when fragment parsing frontmatter is missing
+Fix fragment parsing bugs when frontmatter is missing or top-level expressions are present

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ astro-wasm: cmd/astro/*.go internal/*/*.go go.mod
 	tinygo build -no-debug -o ./lib/compiler/astro.wasm -target wasm ./cmd/astro-wasm/astro-wasm.go
 	cp ./lib/compiler/astro.wasm ./lib/compiler/deno/astro.wasm
 
+# alias to make astro-wasm
+wasm:
+	make astro-wasm
+
+# useful for local debugging, retains go stacktrace for panics
+debug: cmd/astro/*.go internal/*/*.go go.mod
+	tinygo build -o ./lib/compiler/astro.wasm -target wasm ./cmd/astro-wasm/astro-wasm.go
+	cp ./lib/compiler/astro.wasm ./lib/compiler/deno/astro.wasm
+
 publish-node: 
 	make astro-wasm
 	cd lib/compiler && npm run build

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1654,7 +1654,6 @@ func textIM(p *parser) bool {
 		if p.context != nil {
 			return inBodyIM(p)
 		}
-		break
 	case TextToken:
 		d := p.tok.Data
 		if n := p.oe.top(); n != nil && n.DataAtom == a.Textarea && n.FirstChild == nil {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1434,9 +1434,9 @@ func inBodyIM(p *parser) bool {
 	case StartExpressionToken:
 		p.reconstructActiveFormattingElements()
 		p.addExpression()
-		p.setOriginalIM()
+		p.originalIM = inBodyIM
 		p.im = inExpressionIM
-		return false
+		return true
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()
@@ -1651,7 +1651,10 @@ func (p *parser) inBodyEndTagOther(tagAtom a.Atom, tagName string) {
 func textIM(p *parser) bool {
 	switch p.tok.Type {
 	case ErrorToken:
-		return inBodyIM(p)
+		if p.context != nil {
+			return inBodyIM(p)
+		}
+		break
 	case TextToken:
 		d := p.tok.Data
 		if n := p.oe.top(); n != nil && n.DataAtom == a.Textarea && n.FirstChild == nil {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -729,7 +729,7 @@ func beforeHeadIM(p *parser) bool {
 		p.parseImpliedToken(StartTagToken, a.Head, a.Head.String())
 		p.addExpression()
 		p.setOriginalIM()
-		p.im = expressionIM
+		p.im = inExpressionIM
 		return true
 	}
 	p.parseImpliedToken(StartTagToken, a.Head, a.Head.String())
@@ -891,7 +891,7 @@ func inHeadIM(p *parser) bool {
 	case StartExpressionToken:
 		p.addExpression()
 		p.setOriginalIM()
-		p.im = expressionIM
+		p.im = inExpressionIM
 		return true
 	case EndExpressionToken:
 		p.addLoc()
@@ -1434,7 +1434,9 @@ func inBodyIM(p *parser) bool {
 	case StartExpressionToken:
 		p.reconstructActiveFormattingElements()
 		p.addExpression()
-		return true
+		p.setOriginalIM()
+		p.im = inExpressionIM
+		return false
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()
@@ -1649,10 +1651,10 @@ func (p *parser) inBodyEndTagOther(tagAtom a.Atom, tagName string) {
 func textIM(p *parser) bool {
 	switch p.tok.Type {
 	case ErrorToken:
-		break
+		return inBodyIM(p)
 	case TextToken:
 		d := p.tok.Data
-		if n := p.oe.top(); n.DataAtom == a.Textarea && n.FirstChild == nil {
+		if n := p.oe.top(); n != nil && n.DataAtom == a.Textarea && n.FirstChild == nil {
 			// Ignore a newline at the start of a <textarea> block.
 			if d != "" && d[0] == '\r' {
 				d = d[1:]
@@ -1694,7 +1696,7 @@ func inTableIM(p *parser) bool {
 	case StartExpressionToken:
 		p.addExpression()
 		p.setOriginalIM()
-		p.im = expressionIM
+		p.im = inExpressionIM
 		return true
 	case StartTagToken:
 		switch p.tok.DataAtom {
@@ -2129,7 +2131,7 @@ func inSelectIM(p *parser) bool {
 	case StartExpressionToken:
 		p.addExpression()
 		p.setOriginalIM()
-		p.im = expressionIM
+		p.im = inExpressionIM
 		return true
 	case EndExpressionToken:
 		p.addLoc()
@@ -2207,6 +2209,12 @@ func inTemplateIM(p *parser) bool {
 			p.im = inBodyIM
 			return false
 		}
+	case StartExpressionToken:
+		p.addExpression()
+		p.templateStack.pop()
+		p.templateStack = append(p.templateStack, inExpressionIM)
+		p.im = inExpressionIM
+		return true
 	case EndTagToken:
 		switch p.tok.DataAtom {
 		case a.Template:
@@ -2486,7 +2494,7 @@ func frontmatterIM(p *parser) bool {
 	}
 }
 
-func expressionIM(p *parser) bool {
+func inExpressionIM(p *parser) bool {
 	switch p.tok.Type {
 	case ErrorToken:
 		p.oe.pop()
@@ -2504,7 +2512,7 @@ func expressionIM(p *parser) bool {
 				origIm := p.originalIM
 				p.originalIM = nil
 				ret := inHeadIM(p)
-				p.im = expressionIM
+				p.im = inExpressionIM
 				p.originalIM = origIm
 				return ret
 			default:
@@ -2516,7 +2524,7 @@ func expressionIM(p *parser) bool {
 						p.parseImpliedToken(StartTagToken, a.Body, a.Body.String())
 						n.Parent.RemoveChild(n)
 						p.addChild(n)
-						p.im = expressionIM
+						p.im = inExpressionIM
 						break
 					}
 

--- a/internal/token.go
+++ b/internal/token.go
@@ -215,6 +215,12 @@ func (t Token) String() string {
 		return "<!--" + t.Data + "-->"
 	case DoctypeToken:
 		return "<!DOCTYPE " + t.Data + ">"
+	case FrontmatterFenceToken:
+		return "---"
+	case StartExpressionToken:
+		return "{"
+	case EndExpressionToken:
+		return "}"
 	}
 	return "Invalid(" + strconv.Itoa(int(t.Type)) + ")"
 }

--- a/lib/compiler/test/script-fragment.test.mjs
+++ b/lib/compiler/test/script-fragment.test.mjs
@@ -12,7 +12,9 @@ async function run() {
     internalURL: 'astro/internal',
   });
 
-  console.log(result.code);
+  if (!result.code) {
+    throw new Error('Unable to compile script fragment!');
+  }
 }
 
 await run();

--- a/lib/compiler/test/slotted-api.test.mjs
+++ b/lib/compiler/test/slotted-api.test.mjs
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+import { transform } from '@astrojs/compiler';
+
+const contents = `
+{Astro.slots.a && <div id="a">
+  <slot name="a" />
+</div>}
+`
+
+async function run() {
+  const result = await transform(contents, {
+    sourcemap: true,
+    as: 'fragment',
+    site: undefined,
+    sourcefile: 'MoreMenu.astro',
+    sourcemap: 'both',
+    internalURL: 'astro/internal',
+  });
+
+  console.log(result.code);
+}
+
+await run();

--- a/lib/compiler/test/slotted-api.test.mjs
+++ b/lib/compiler/test/slotted-api.test.mjs
@@ -5,7 +5,7 @@ const contents = `
 {Astro.slots.a && <div id="a">
   <slot name="a" />
 </div>}
-`
+`;
 
 async function run() {
   const result = await transform(contents, {

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -4,3 +4,4 @@ import './component-only.test.mjs';
 import './empty-style.test.mjs';
 import './output.test.mjs';
 import './script-fragment.test.mjs';
+import './slotted-api.test.mjs';

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -4,4 +4,4 @@ import './component-only.test.mjs';
 import './empty-style.test.mjs';
 import './output.test.mjs';
 import './script-fragment.test.mjs';
-import './slotted-api.test.mjs';
+import './top-level-expression.test.mjs';

--- a/lib/compiler/test/top-level-expression.test.mjs
+++ b/lib/compiler/test/top-level-expression.test.mjs
@@ -17,7 +17,9 @@ async function run() {
     internalURL: 'astro/internal',
   });
 
-  console.log(result.code);
+  if (!result.code) {
+    throw new Error('Unable to compile top-level expression!');
+  }
 }
 
 await run();


### PR DESCRIPTION
## Changes

- Fix infinite loop in `fragment` mode
- Expressions were not being handled inside of `template`, which was causing an infinite loop on top-level expressions without a parent element.

## Testing

WASM test added

## Docs

Bug fix only