### PR TITLE
Fix edge case with conditional scripts

### DIFF
--- a/.changeset/unlucky-queens-accept.md
+++ b/.changeset/unlucky-queens-accept.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with conditional scripts

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -780,7 +780,9 @@ func inHeadIM(p *parser) bool {
 			return true
 		case a.Script, a.Title:
 			p.addElement()
-			p.setOriginalIM()
+			if p.originalIM == nil {
+				p.setOriginalIM()
+			}
 			p.im = textIM
 			if p.hasSelfClosingToken {
 				p.addLoc()
@@ -2551,6 +2553,9 @@ func inExpressionIM(p *parser) bool {
 		return true
 	}
 	p.im = p.originalIM
+	if p.im == nil {
+		p.im = inBodyIM
+	}
 	p.originalIM = nil
 	return p.tok.Type == EndTagToken
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1273,6 +1273,13 @@ const items = ["Dog", "Cat", "Platipus"];
 </table></body></html>`, BACKTICK, BACKTICK, BACKTICK, BACKTICK, BACKTICK, BACKTICK),
 			},
 		},
+		{
+			name:   "XElement",
+			source: `<XElement {...attrs}></XElement>{onLoadString ? <script></script> : null }`,
+			want: want{
+				code: fmt.Sprintf(`${$$renderComponent($$result,'XElement',XElement,{...(attrs)})}${onLoadString ? $$render%s<script></script>%s : null }`, BACKTICK, BACKTICK),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- `XElement` was breaking because it had an expression with a `script` in it.
- This fixes that edge case

## Testing

Minimal test added

## Docs

Bug fix only