### PR TITLE
fix(#199): fragment shorthand syntax with preceeding text

### DIFF
--- a/.changeset/happy-bikes-hug.md
+++ b/.changeset/happy-bikes-hug.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix `<>` syntax edge case inside of expressions

--- a/internal/token.go
+++ b/internal/token.go
@@ -1367,6 +1367,18 @@ loop:
 			break loop
 		}
 
+		// Empty <> Fragment start tag
+		if c == '>' {
+			if x := z.raw.End - len("<>"); z.raw.Start < x {
+				z.raw.End = x
+				z.data.End = x
+				z.tt = TextToken
+				return z.tt
+			}
+			z.tt = StartTagToken
+			return z.tt
+		}
+
 		// We're in an element again, so open braces should open an expression
 		z.openBraceIsExpressionStart = true
 		switch {
@@ -1378,10 +1390,6 @@ loop:
 			// We use CommentToken to mean any of "<!--actual comments-->",
 			// "<!DOCTYPE declarations>" and "<?xml processing instructions?>".
 			tokenType = CommentToken
-		case c == '>':
-			// Empty <> Fragment start tag
-			z.tt = StartTagToken
-			return z.tt
 		default:
 			raw := z.Raw()
 			// Error: encountered an attempted use of <> syntax with attributes, like `< slot="named">Hello world!</>`

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -193,6 +193,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"fragment shorthand",
+			`<h1>A{cond && <>item <span>B{text}</span></>}</h1>`,
+			[]TokenType{StartTagToken, TextToken, StartExpressionToken, TextToken, StartTagToken, TextToken, StartTagToken, TextToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, EndTagToken, EndExpressionToken, EndTagToken},
+		},
+		{
 			"fragment",
 			`<Fragment>foo</Fragment>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},


### PR DESCRIPTION
## Changes

- Fixes #199
- We had an edge case where Fragment shorthand syntax (`<>`) was not properly handled inside of an expression with preceding text.
- The fix was to return the preceding text as a `TextToken` _before_ consuming the `StartTagToken`.

## Testing

Minimal test case added

## Docs

Bug fix only