### PR TITLE
test(#197): add test for Markdown codeblock

### DIFF
--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -197,6 +197,15 @@ func TestBasic(t *testing.T) {
 			`<Fragment>foo</Fragment>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
+		{
+			"Markdown codeblock",
+			fmt.Sprintf(`<Markdown>
+%s%s%s
+open brace {
+%s%s%s
+</Markdown>`, "`", "`", "`", "`", "`", "`"),
+			[]TokenType{StartTagToken, TextToken, TextToken, TextToken, TextToken, EndTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)


### PR DESCRIPTION
## Changes

- Closes #197 
- No code changes

## Testing

- Adds regression test to ensure Tokenizer can handle Markdown code block

## Docs

Test only