### PR TITLE
fix(#198): improve empty attribute behavior

### DIFF
--- a/.changeset/short-bats-hammer.md
+++ b/.changeset/short-bats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve behavior of empty expressions in body and attributes, where `{}` is equivalent to `{undefined}`

--- a/.changeset/short-bats-hammer.md
+++ b/.changeset/short-bats-hammer.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Improve behavior of empty expressions in body and attributes, where `{}` is equivalent to `{undefined}`
+Improve behavior of empty expressions in body and attributes, where `{}` is equivalent to `{(void 0)}`

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -294,7 +294,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		if n.FirstChild != nil {
 			p.print("${")
 		} else {
-			p.print("${undefined")
+			p.print("${(void 0)")
 		}
 
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -293,6 +293,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	if n.Expression {
 		if n.FirstChild != nil {
 			p.print("${")
+		} else {
+			p.print("${undefined")
 		}
 
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -168,7 +168,7 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 			p.print(":")
 			p.addSourceMapping(a.ValLoc)
 			if a.Val == "" {
-				p.print(`(undefined)`)
+				p.print(`(void 0)`)
 			} else {
 				p.print(`(` + a.Val + `)`)
 			}
@@ -233,7 +233,7 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 		p.print(fmt.Sprintf("${%s(", ADD_ATTRIBUTE))
 		p.addSourceMapping(attr.ValLoc)
 		if strings.TrimSpace(attr.Val) == "" {
-			p.print("undefined")
+			p.print("(void 0)")
 		} else {
 			p.print(strings.TrimSpace(attr.Val))
 		}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -167,7 +167,11 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 			p.print(`"` + a.Key + `"`)
 			p.print(":")
 			p.addSourceMapping(a.ValLoc)
-			p.print(`(` + a.Val + `)`)
+			if a.Val == "" {
+				p.print(`(undefined)`)
+			} else {
+				p.print(`(` + a.Val + `)`)
+			}
 		case astro.SpreadAttribute:
 			p.addSourceMapping(loc.Loc{Start: a.KeyLoc.Start - 3})
 			p.print(`...(` + strings.TrimSpace(a.Key) + `)`)
@@ -228,7 +232,11 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 	case astro.ExpressionAttribute:
 		p.print(fmt.Sprintf("${%s(", ADD_ATTRIBUTE))
 		p.addSourceMapping(attr.ValLoc)
-		p.print(strings.TrimSpace(attr.Val))
+		if strings.TrimSpace(attr.Val) == "" {
+			p.print("undefined")
+		} else {
+			p.print(strings.TrimSpace(attr.Val))
+		}
 		p.addSourceMapping(attr.KeyLoc)
 		p.print(`, "` + strings.TrimSpace(attr.Key) + `")}`)
 	case astro.SpreadAttribute:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1280,6 +1280,20 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: fmt.Sprintf(`${$$renderComponent($$result,'XElement',XElement,{...(attrs)})}${onLoadString ? $$render%s<script></script>%s : null }`, BACKTICK, BACKTICK),
 			},
 		},
+		{
+			name:   "Empty expression",
+			source: "<body>({})</body>",
+			want: want{
+				code: `<html><head></head><body>(${undefined})</body></html>`,
+			},
+		},
+		{
+			name:   "Empty attribute expression",
+			source: "<body attr={}></body>",
+			want: want{
+				code: `<html><head></head><body${$$addAttribute(undefined, "attr")}></body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1284,14 +1284,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "Empty expression",
 			source: "<body>({})</body>",
 			want: want{
-				code: `<html><head></head><body>(${undefined})</body></html>`,
+				code: `<html><head></head><body>(${(void 0)})</body></html>`,
 			},
 		},
 		{
 			name:   "Empty attribute expression",
 			source: "<body attr={}></body>",
 			want: want{
-				code: `<html><head></head><body${$$addAttribute(undefined, "attr")}></body></html>`,
+				code: `<html><head></head><body${$$addAttribute((void 0), "attr")}></body></html>`,
 			},
 		},
 	}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -211,6 +211,11 @@ open brace {
 </Markdown>`, "`", "`", "`", "`", "`", "`"),
 			[]TokenType{StartTagToken, TextToken, TextToken, TextToken, TextToken, EndTagToken},
 		},
+		{
+			"Empty expression",
+			"({})",
+			[]TokenType{TextToken, StartExpressionToken, EndExpressionToken, TextToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)


### PR DESCRIPTION
## Changes

- Closes #198
- Treats `{}` as valid to avoid generating invalid JS when encountered
- It is treated equivalent to `{undefined}`

Curious what folks think the correct behavior is here? Should we handle this as `${undefined}` or `${}` (invalid JS) or throw a panic?

## Testing

Tests added

## Docs

No docs, this isn't an official feature
