### PR TITLE
fix(#221): fix tokenization of `/` inside expression attributes

### DIFF
--- a/.changeset/fair-goats-obey.md
+++ b/.changeset/fair-goats-obey.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix tokenization of attribute expression containing the solidus (`/`) character

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -128,6 +128,16 @@ func TestBasic(t *testing.T) {
 			[]TokenType{SelfClosingTagToken},
 		},
 		{
+			"attribute expression with solidus",
+			`<div value={100 / 2} />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"attribute expression with solidus no spaces",
+			`<div value={(100/2)} />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
 			"attribute expression with quote",
 			`<div value={/* hello */} />`,
 			[]TokenType{SelfClosingTagToken},


### PR DESCRIPTION
## Changes

- Closes #221
- Fixes tokenization of expression attributes when `/` is used (now breaks on closing `}`, if it exists)

## Testing

Tests added

## Docs

Bug fix only