### PR TITLE
fix(#224): address issue with expression tokenization

### DIFF
--- a/.changeset/twenty-gorillas-burn.md
+++ b/.changeset/twenty-gorillas-burn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix a logical error with expression tokenization when using nested functions. Previously, only the first brace pair would be respected and following pairs would be treated as expression boundaries.

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -410,6 +410,34 @@ $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
 			},
 		},
 		{
+			name: "expressions with multiple curly braces",
+			source: `
+<div>
+{
+	() => {
+		let generate = (input) => {
+			let a = () => { return; };
+			let b = () => { return; };
+			let c = () => { return; };
+		};
+	}
+}
+</div>`,
+			want: want{
+				code: `<html><head></head><body><div>
+${
+	() => {
+		let generate = (input) => {
+			let a = () => { return; };
+			let b = () => { return; };
+			let c = () => { return; };
+		};
+	}
+}
+</div></body></html>`,
+			},
+		},
+		{
 			name: "slots (basic)",
 			source: `---
 import Component from "test";

--- a/internal/token.go
+++ b/internal/token.go
@@ -1674,9 +1674,9 @@ expression_loop:
 				z.tt = TextToken
 				return z.tt
 			}
-			z.openBraceIsExpressionStart = true
 			z.expressionStack[len(z.expressionStack)-1]--
 			if z.expressionStack[len(z.expressionStack)-1] == -1 {
+				z.openBraceIsExpressionStart = true
 				z.expressionStack = z.expressionStack[0 : len(z.expressionStack)-1]
 				z.data.End = z.raw.End
 				z.tt = EndExpressionToken

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -123,6 +123,17 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"expression with multiple returns",
+			`<div>{() => {
+	let generate = (input) => {
+		let a = () => { return; };
+		let b = () => { return; };
+		let c = () => { return; };
+	};
+}}</div>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
+		},
+		{
 			"attribute expression with quoted braces",
 			`<div value={"{"} />`,
 			[]TokenType{SelfClosingTagToken},


### PR DESCRIPTION
## Changes

- Closes #224
- Fixes logical error in expression tokenization step. It worked in most situations but #224 was a reproducible edge case where it failed.

## Testing

Added tokenizer and printer tests to verify that the case in the issue works. Existing tests ensure this is not a regression.

## Docs

N/A, bug fix only.