### PR TITLE
fix(#225): Do not treat `noscript` as raw

### DIFF
--- a/.changeset/red-olives-camp.md
+++ b/.changeset/red-olives-camp.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of components and expressions inside of `<noscript>`

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -228,8 +228,7 @@ import * as ns from '../components';
 	<noscript>
 		${` + RENDER_COMPONENT + `($$result,'Component',Component,{})}
 	</noscript>
-  </body>
-</html>`,
+  </body></html>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -211,6 +211,28 @@ import * as ns from '../components';
 			},
 		},
 		{
+			name: "noscript component",
+			source: `
+<html>
+  <head></head>
+  <body>
+	<noscript>
+		<Component />
+	</noscript>
+  </body>
+</html>`,
+			want: want{
+				code: `<html>
+  <head></head>
+  <body>
+	<noscript>
+		${` + RENDER_COMPONENT + `($$result,'Component',Component,{})}
+	</noscript>
+  </body>
+</html>`,
+			},
+		},
+		{
 			name: "client:only component (default)",
 			source: `---
 import Component from '../components';

--- a/internal/token.go
+++ b/internal/token.go
@@ -957,7 +957,7 @@ func (z *Tokenizer) readStartTag() TokenType {
 	case 'i':
 		raw = z.startTagIn("iframe")
 	case 'n':
-		raw = z.startTagIn("noembed", "noframes", "noscript")
+		raw = z.startTagIn("noembed", "noframes")
 	case 'p':
 		raw = z.startTagIn("plaintext")
 	case 's':
@@ -1857,7 +1857,7 @@ func NewTokenizerFragment(r io.Reader, contextTag string) *Tokenizer {
 	}
 	if contextTag != "" {
 		switch s := strings.ToLower(contextTag); s {
-		case "iframe", "noembed", "noframes", "noscript", "plaintext", "script", "style", "title", "textarea", "xmp":
+		case "iframe", "noembed", "noframes", "plaintext", "script", "style", "title", "textarea", "xmp":
 			z.rawTag = s
 		}
 	}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -45,6 +45,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken},
 		},
 		{
+			"noscript component",
+			`<noscript><Component /></noscript>`,
+			[]TokenType{StartTagToken, SelfClosingTagToken, EndTagToken},
+		},
+		{
 			"end tag",
 			`</html>`,
 			[]TokenType{EndTagToken},


### PR DESCRIPTION
## Changes

- Closes #225
- Removes `noscript` from the list of tags to tokenize as raw text

## Testing

Tests added in tokenizer and printer

## Docs

Bug fix only
