### PR TITLE
fix(#213): @keyframes breaks following scoping

### DIFF
--- a/.changeset/forty-pillows-sleep.md
+++ b/.changeset/forty-pillows-sleep.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix bug with `@keyframes` scoping

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -85,6 +85,17 @@ outer:
 
 					// if inside @keyframes, don’t transform what’s there
 					if isKeyframes {
+						if strVal == "{" {
+							keyframeCurlyCount++
+						} else if strVal == "}" {
+							keyframeCurlyCount--
+						}
+
+						// Inside of this case, we only want to break out when keyframeCurlyCount is -1
+						// since 0 is the default
+						if keyframeCurlyCount < 0 {
+							isKeyframes = false
+						}
 						out += strVal
 						continue
 					}
@@ -131,12 +142,16 @@ outer:
 						isBracket = false
 						out += strVal
 					case "{":
-						keyframeCurlyCount++
+						if isKeyframes {
+							keyframeCurlyCount++
+						}
 						isElement = true
 						isPseudoState = false
 						out += strVal
 					case "}":
-						keyframeCurlyCount--
+						if isKeyframes {
+							keyframeCurlyCount--
+						}
 						if keyframeCurlyCount == 0 {
 							isKeyframes = false
 						}

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -189,6 +189,21 @@ func TestScopeStyle(t *testing.T) {
 			want:   "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
 		},
 		{
+			name:   "keyframes start",
+			source: "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}} h1{} h2{}",
+			want:   "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}h1.astro-XXXXXX{}h2.astro-XXXXXX{}",
+		},
+		{
+			name:   "keyframes middle",
+			source: "h1{} @keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}} h2{}",
+			want:   "h1.astro-XXXXXX{}@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}h2.astro-XXXXXX{}",
+		},
+		{
+			name:   "keyframes end",
+			source: "h1{} h2{} @keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
+			want:   "h1.astro-XXXXXX{}h2.astro-XXXXXX{}@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
+		},
+		{
 			name:   "calc",
 			source: ":root{padding:calc(var(--space) * 2);}",
 			want:   ":root{padding:calc(var(--space) * 2);}",


### PR DESCRIPTION
## Changes

- Fixes #213
- Previously, any rules following `@keyframes` would not be scoped. This fixes that!

## Testing

Multiple tests add

## Docs

Bug fix only