### PR TITLE
fix(#223): Do not prefix values inside of declarations

### DIFF
--- a/.changeset/large-owls-serve.md
+++ b/.changeset/large-owls-serve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix bug where named grid columns (like `[content-start]`) would be scoped, producing invalid CSS

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -35,6 +35,7 @@ outer:
 
 		isKeyframes := false    // if we’re inside @keyframes, there’s nothing to scope
 		keyframeCurlyCount := 0 // keep track of open "{"s inside @keyframes
+		declaration := ""
 
 	walk:
 		for {
@@ -69,6 +70,7 @@ outer:
 					}
 				case css.DeclarationGrammar:
 					out += string(data) + ":"
+					declaration = string(data)
 				default:
 				}
 
@@ -122,8 +124,9 @@ outer:
 						isBracket = true
 						isElement = false
 						isPseudoState = false
-						// if there is no selector before an attribute selector, then assume "*"
-						if n == 0 {
+
+						// if there is no selector before an attribute selector and we're not in a delcaration, assume "*"
+						if n == 0 && declaration == "" {
 							out += scopeRule("", opts)
 						}
 						out += strVal
@@ -191,6 +194,7 @@ outer:
 						// reset state
 						isElement = true
 						isPseudoState = false
+						declaration = ""
 					}
 				}
 

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -194,6 +194,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   ":root{padding:calc(var(--space) * 2);}",
 		},
 		{
+			name:   "grid-template-columns",
+			source: "div{grid-template-columns: [content-start] 1fr [content-end];}",
+			want:   "div.astro-XXXXXX{grid-template-columns:[content-start] 1fr [content-end];}",
+		},
+		{
 			name:   "charset",
 			source: "@charset \"utf-8\";",
 			want:   "@charset \"utf-8\";",


### PR DESCRIPTION
## Changes

- Fixes #223
- Improves our scoping algorithm to not touch values inside of declaration rules (like `grid-template-column`.

## Testing

Test added

## Docs

Bug fix only