### PR TITLE
Improve handling of expressions inside of `<table>`

### DIFF
--- a/.changeset/lucky-cups-rhyme.md
+++ b/.changeset/lucky-cups-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix some edge cases with expressions inside of `<table>` elements

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1955,6 +1955,13 @@ func inTableBodyIM(p *parser) bool {
 			Loc:  p.generateLoc(),
 		})
 		return true
+	case StartExpressionToken:
+		p.addExpression()
+		p.afe = append(p.afe, &scopeMarker)
+		return true
+	case EndExpressionToken:
+		p.oe.pop()
+		return true
 	}
 
 	return inTableIM(p)
@@ -2006,6 +2013,13 @@ func inRowIM(p *parser) bool {
 			// Ignore the token.
 			return true
 		}
+	case StartExpressionToken:
+		p.addExpression()
+		p.afe = append(p.afe, &scopeMarker)
+		return true
+	case EndExpressionToken:
+		p.oe.pop()
+		return true
 	}
 
 	return inTableIM(p)
@@ -2014,6 +2028,13 @@ func inRowIM(p *parser) bool {
 // Section 12.2.6.4.15.
 func inCellIM(p *parser) bool {
 	switch p.tok.Type {
+	case StartExpressionToken:
+		p.addExpression()
+		p.afe = append(p.afe, &scopeMarker)
+		return true
+	case EndExpressionToken:
+		p.oe.pop()
+		return true
 	case StartTagToken:
 		switch p.tok.DataAtom {
 		case a.Caption, a.Col, a.Colgroup, a.Tbody, a.Td, a.Tfoot, a.Th, a.Thead, a.Tr:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1309,6 +1309,17 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name: "tbody expressions 2",
+			source: `---
+const items = ["Dog", "Cat", "Platipus"];
+---
+<table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td><td>{item + 's'}</td></tr>))}</table>`,
+			want: want{
+				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
+				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td><td>${item + 's'}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
+			},
+		},
+		{
 			name:   "td expressions",
 			source: `<table><tr><td><h2>Row 1</h2></td><td>{title}</td></tr></table>`,
 			want: want{


### PR DESCRIPTION
## Changes

- Closes #235 
- Fixes edge cases with expressions inside of `<table>` children (which have their own insertion mode).

## Testing

Test added

## Docs

Bug fix only
