### PR TITLE
Fix `textarea` edge case

### DIFF
--- a/.changeset/odd-kiwis-shave.md
+++ b/.changeset/odd-kiwis-shave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with textarea inside expression

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1260,7 +1260,7 @@ func inBodyIM(p *parser) bool {
 			return false
 		case a.Textarea:
 			p.addElement()
-			p.setOriginalIM()
+			p.originalIM = inBodyIM
 			p.framesetOK = false
 			p.im = textIM
 		case a.Xmp:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1287,6 +1287,13 @@ const value = 'test';
 			},
 		},
 		{
+			name:   "textarea inside expression",
+			source: `{bool && <textarea>{value}</textarea>} {!bool && <input>}`,
+			want: want{
+				code: `<html><head></head><body>${bool && $$render` + BACKTICK + `<textarea>${value}</textarea>` + BACKTICK + `} ${!bool && $$render` + BACKTICK + `<input>` + BACKTICK + `}</body></html>`,
+			},
+		},
+		{
 			name: "table expressions (no implicit tbody)",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -169,6 +169,14 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"textarea inside expression",
+			`
+				{bool && <textarea>It was a dark and stormy night...</textarea>}
+				{bool && <input>}
+			`,
+			[]TokenType{StartExpressionToken, TextToken, StartTagToken, TextToken, EndTagToken, EndExpressionToken, TextToken, StartExpressionToken, TextToken, SelfClosingTagToken, EndExpressionToken, TextToken},
+		},
+		{
 			"Markdown Inside markdown backtick treated as a string",
 			"<Markdown>`{}`</Markdown>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},


### PR DESCRIPTION
## Changes

- Fixes #238
- This fixes an issue where `setOriginalIM()` was throwing because it was already set

## Testing

Tokenizer test added to protect against regressions, printer test added to verify behavior

## Docs

Bug fix only
