### PR TITLE
Pass opts.Pathname to top-level createAstro

### DIFF
--- a/.changeset/ninety-yaks-hide.md
+++ b/.changeset/ninety-yaks-hide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Passes the Pathname to createAstro instead of import.meta.url

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -135,7 +135,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					preprocessed := js_scanner.HoistExports([]byte(c.Data))
 
 					// 1. After imports put in the top-level Astro.
-					p.printTopLevelAstro()
+					p.printTopLevelAstro(opts.opts)
 
 					if len(preprocessed.Hoisted) > 0 {
 						for _, hoisted := range preprocessed.Hoisted {
@@ -168,7 +168,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					// 1. Component imports, if any exist.
 					p.printComponentMetadata(n.Parent, opts.opts, []byte(importStatements))
 					// 2. Top-level Astro global.
-					p.printTopLevelAstro()
+					p.printTopLevelAstro(opts.opts)
 
 					if len(preprocessed.Hoisted) > 0 {
 						for _, hoisted := range preprocessed.Hoisted {
@@ -220,7 +220,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		return
 	} else if !p.hasFuncPrelude {
 		p.printComponentMetadata(n.Parent, opts.opts, []byte{})
-		p.printTopLevelAstro()
+		p.printTopLevelAstro(opts.opts)
 
 		// Render func prelude. Will only run for the first non-frontmatter node
 		// TODO: use the proper component name

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -282,8 +282,15 @@ func (p *printer) addNilSourceMapping() {
 	p.builder.AddSourceMapping(loc.Loc{Start: 0}, p.output)
 }
 
-func (p *printer) printTopLevelAstro() {
-	p.println(fmt.Sprintf("const $$Astro = %s(import.meta.url, '%s', '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, p.opts.Site, p.opts.ProjectRoot))
+func (p *printer) printTopLevelAstro(opts transform.TransformOptions) {
+	patharg := opts.Pathname
+	if patharg == "" {
+		patharg = "import.meta.url"
+	} else {
+		patharg = fmt.Sprintf("\"%s\"", patharg)
+	}
+
+	p.println(fmt.Sprintf("const $$Astro = %s(%s, '%s', '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, patharg, p.opts.Site, p.opts.ProjectRoot))
 }
 
 func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.TransformOptions, source []byte) {


### PR DESCRIPTION
## Changes

- Changes createAstro from `createAstro(import.meta.url)` to `createAstro("/src/components/Foo.astro")`.
  - This aligns with what createMetadata receives.
  - This is needed because in the static build (and eventually SSR) `import.meta.url` points to the build JS files and not the original source location. Since we want to resolve browser URLs, passing the pathname string makes more sense.
## Testing

No tests needed updating

## Docs

N/A