### PR TITLE
Add hoisted scripts to TransformResult

### DIFF
--- a/.changeset/silly-laws-smoke.md
+++ b/.changeset/silly-laws-smoke.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Adds a new scripts property to the TransformResult
+Adds a new property, `scripts`, to `TransformResult`

--- a/.changeset/silly-laws-smoke.md
+++ b/.changeset/silly-laws-smoke.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Adds a new scripts property to the TransformResult

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -196,7 +196,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE);", RESULT))
 				}
 
-				if len(n.Parent.Scripts) > 0 {
+				if !opts.opts.StaticExtraction && len(n.Parent.Scripts) > 0 {
 					p.println("const SCRIPTS = [")
 					for _, script := range n.Parent.Scripts {
 						p.printStyleOrScript(script)
@@ -238,7 +238,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			p.addNilSourceMapping()
 			p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE);", RESULT))
 		}
-		if len(n.Parent.Scripts) > 0 {
+		if !opts.opts.StaticExtraction && len(n.Parent.Scripts) > 0 {
 			p.println("const SCRIPTS = [")
 			for _, script := range n.Parent.Scripts {
 				p.printStyleOrScript(script)

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -18,7 +18,7 @@ export interface TransformOptions {
 export interface HoistedScript {
   src?: string;
   code?: string;
-  type: 'external' | 'inline'
+  type: 'external' | 'inline';
 }
 
 export interface TransformResult {

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -15,8 +15,15 @@ export interface TransformOptions {
   experimentalStaticExtraction?: boolean;
 }
 
+export interface HoistedScript {
+  src?: string;
+  code?: string;
+  type: 'external' | 'inline'
+}
+
 export interface TransformResult {
   css: string[];
+  scripts: HoistedScript[];
   code: string;
   map: string;
 }


### PR DESCRIPTION
## Changes

- This adds hoisted scripts to the `TransformResult`. In the static build these will work like styles, where in dev they are all external. For example `/src/components/Counter.astro?astro&type=script&index=0` will be one path.
- A change on the Astro side will bundle these in production (static build only).

## Testing

No added tests needed, only a change to the wasm API.

## Docs

N/A
