### PR TITLE
Better hoisted script types

### DIFF
--- a/.changeset/shiny-singers-call.md
+++ b/.changeset/shiny-singers-call.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improved types for TransformResult with hoisted scripts

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -15,11 +15,13 @@ export interface TransformOptions {
   experimentalStaticExtraction?: boolean;
 }
 
-export interface HoistedScript {
-  src?: string;
-  code?: string;
-  type: 'external' | 'inline';
-}
+export type HoistedScript = { type: string } & ({
+  type: 'external';
+  src: string;
+} | {
+  type: 'inline';
+  code: string;
+});
 
 export interface TransformResult {
   css: string[];

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -15,13 +15,16 @@ export interface TransformOptions {
   experimentalStaticExtraction?: boolean;
 }
 
-export type HoistedScript = { type: string } & ({
-  type: 'external';
-  src: string;
-} | {
-  type: 'inline';
-  code: string;
-});
+export type HoistedScript = { type: string } & (
+  | {
+      type: 'external';
+      src: string;
+    }
+  | {
+      type: 'inline';
+      code: string;
+    }
+);
 
 export interface TransformResult {
   css: string[];


### PR DESCRIPTION
## Changes

- Small improvement for the types on hoisted scripts in the TransformResult. Makes it so that if you know the `type` then the corresponding other prop is not possibly undefined.

## Testing

N/A

## Docs

N/A