### PR TITLE
Fix #250: Update string handler

### DIFF
--- a/.changeset/gentle-tips-lick.md
+++ b/.changeset/gentle-tips-lick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+changing raw_with_expression_loop in tokenizer to only handle string that has '`' differently otherwise it should treat it as normal string

--- a/internal/token.go
+++ b/internal/token.go
@@ -1570,7 +1570,7 @@ raw_with_expression_loop:
 		}
 
 		// handle string
-		if c == '\'' || c == '"' || c == '`' {
+		if c == '`' {
 			z.readString(c)
 			z.tt = TextToken
 			z.data.End = z.raw.End

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -189,7 +189,7 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
-			"quotes within title",
+			"apostrophe within title",
 			`<title>Astro's</title>`,
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -189,6 +189,16 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"quotes within title",
+			`<title>Astro's</title>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"quotes within title",
+			`<title>My Astro "Website"</title>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
 			"textarea inside expression",
 			`
 						{bool && <textarea>It was a dark and stormy night...</textarea>}


### PR DESCRIPTION
## Changes

- Fixes #250
- updated string handler within raw_with_expression_loop in tokenizer, i believe that we need only to handle '`' rather than also handling '\\'' and '"'.

## Testing

two tests were added to check if it will tokenize titles with quotes properly. 

## Docs

bug fix only
