### PR TITLE
Treat all documents as fragments which generate no implicit tags

### DIFF
--- a/.changeset/wicked-forks-do.md
+++ b/.changeset/wicked-forks-do.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Remove "as" option, treats all documents as fragments that generate no implicit tags

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -52,11 +52,6 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 		pathname = "<stdin>"
 	}
 
-	as := jsString(options.Get("as"))
-	if as == "" {
-		as = "document"
-	}
-
 	internalURL := jsString(options.Get("internalURL"))
 	if internalURL == "" {
 		internalURL = "astro/internal"
@@ -85,7 +80,6 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 	preprocessStyle := options.Get("preprocessStyle")
 
 	return transform.TransformOptions{
-		As:               as,
 		Scope:            hash,
 		Filename:         filename,
 		Pathname:         pathname,
@@ -149,30 +143,21 @@ func Transform() interface{} {
 			resolve := args[0]
 
 			var doc *astro.Node
-
-			if transformOptions.As == "document" {
-				docNode, err := astro.Parse(strings.NewReader(source))
-				doc = docNode
-				if err != nil {
-					fmt.Println(err)
-				}
-			} else if transformOptions.As == "fragment" {
-				nodes, err := astro.ParseFragment(strings.NewReader(source), &astro.Node{
-					Type:     astro.ElementNode,
-					Data:     atom.Template.String(),
-					DataAtom: atom.Template,
-				})
-				if err != nil {
-					fmt.Println(err)
-				}
-				doc = &astro.Node{
-					Type:                astro.DocumentNode,
-					HydrationDirectives: make(map[string]bool),
-				}
-				for i := 0; i < len(nodes); i++ {
-					n := nodes[i]
-					doc.AppendChild(n)
-				}
+			nodes, err := astro.ParseFragment(strings.NewReader(source), &astro.Node{
+				Type:     astro.ElementNode,
+				Data:     atom.Template.String(),
+				DataAtom: atom.Template,
+			})
+			if err != nil {
+				fmt.Println(err)
+			}
+			doc = &astro.Node{
+				Type:                astro.DocumentNode,
+				HydrationDirectives: make(map[string]bool),
+			}
+			for i := 0; i < len(nodes); i++ {
+				n := nodes[i]
+				doc.AppendChild(n)
 			}
 
 			// Hoist styles and scripts to the top-level

--- a/internal/print-to-source.go
+++ b/internal/print-to-source.go
@@ -14,42 +14,53 @@ func PrintToSource(buf *strings.Builder, node *Node) {
 	case TextNode:
 		buf.WriteString(node.Data)
 	case ElementNode:
-		buf.WriteString(fmt.Sprintf(`<%s`, node.Data))
-		for _, attr := range node.Attr {
-			if attr.Key == ImplicitNodeMarker {
-				continue
-			}
-			if attr.Namespace != "" {
-				buf.WriteString(attr.Namespace)
-				buf.WriteString(":")
-			}
-			buf.WriteString(" ")
-			switch attr.Type {
-			case QuotedAttribute:
-				buf.WriteString(attr.Key)
-				buf.WriteString("=")
-				buf.WriteString(`"` + attr.Val + `"`)
-			case EmptyAttribute:
-				buf.WriteString(attr.Key)
-			case ExpressionAttribute:
-				buf.WriteString(attr.Key)
-				buf.WriteString("=")
-				buf.WriteString(`{` + strings.TrimSpace(attr.Val) + `}`)
-			case SpreadAttribute:
-				buf.WriteString(`{...` + strings.TrimSpace(attr.Val) + `}`)
-			case ShorthandAttribute:
-				buf.WriteString(attr.Key)
-				buf.WriteString("=")
-				buf.WriteString(`{` + strings.TrimSpace(attr.Key) + `}`)
-			case TemplateLiteralAttribute:
-				buf.WriteString(attr.Key)
-				buf.WriteString("=`" + strings.TrimSpace(attr.Val) + "`")
+		isImplicit := false
+		for _, a := range node.Attr {
+			if a.Key == ImplicitNodeMarker {
+				isImplicit = true
+				break
 			}
 		}
-		buf.WriteString(`>`)
+		if !isImplicit {
+			buf.WriteString(fmt.Sprintf(`<%s`, node.Data))
+			for _, attr := range node.Attr {
+				if attr.Key == ImplicitNodeMarker {
+					continue
+				}
+				if attr.Namespace != "" {
+					buf.WriteString(attr.Namespace)
+					buf.WriteString(":")
+				}
+				buf.WriteString(" ")
+				switch attr.Type {
+				case QuotedAttribute:
+					buf.WriteString(attr.Key)
+					buf.WriteString("=")
+					buf.WriteString(`"` + attr.Val + `"`)
+				case EmptyAttribute:
+					buf.WriteString(attr.Key)
+				case ExpressionAttribute:
+					buf.WriteString(attr.Key)
+					buf.WriteString("=")
+					buf.WriteString(`{` + strings.TrimSpace(attr.Val) + `}`)
+				case SpreadAttribute:
+					buf.WriteString(`{...` + strings.TrimSpace(attr.Val) + `}`)
+				case ShorthandAttribute:
+					buf.WriteString(attr.Key)
+					buf.WriteString("=")
+					buf.WriteString(`{` + strings.TrimSpace(attr.Key) + `}`)
+				case TemplateLiteralAttribute:
+					buf.WriteString(attr.Key)
+					buf.WriteString("=`" + strings.TrimSpace(attr.Val) + "`")
+				}
+			}
+			buf.WriteString(`>`)
+		}
 		for c := node.FirstChild; c != nil; c = c.NextSibling {
 			PrintToSource(buf, c)
 		}
-		buf.WriteString(fmt.Sprintf(`</%s>`, node.Data))
+		if !isImplicit {
+			buf.WriteString(fmt.Sprintf(`</%s>`, node.Data))
+		}
 	}
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -77,7 +77,7 @@ func TestPrinter(t *testing.T) {
 			name:   "basic (no frontmatter)",
 			source: `<button>Click</button>`,
 			want: want{
-				code: `<html><head></head><body><button>Click</button></body></html>`,
+				code: `<button>Click</button>`,
 			},
 		},
 		{
@@ -88,7 +88,7 @@ const href = '/about';
 <a href={href}>About</a>`,
 			want: want{
 				frontmatter: []string{"", "const href = '/about';"},
-				code:        `<html><head></head><body><a${` + ADD_ATTRIBUTE + `(href, "href")}>About</a></body></html>`,
+				code:        `<a${` + ADD_ATTRIBUTE + `(href, "href")}>About</a>`,
 			},
 		},
 		{
@@ -103,7 +103,7 @@ export const getStaticPaths = async () => {
 				frontmatter: []string{`export const getStaticPaths = async () => {
 	return { paths: [] }
 }`, ""},
-				code: `<html><head></head><body><div></div></body></html>`,
+				code: `<div></div>`,
 			},
 		},
 		{
@@ -120,7 +120,7 @@ export const getStaticPaths = async () => {
 				getStaticPaths: `export const getStaticPaths = async () => {
 	return { paths: [] }
 }`,
-				code: `<html><head></head><body><div></div></body></html>`,
+				code: `<div></div>`,
 			},
 		},
 		{
@@ -139,7 +139,7 @@ const b = 0;`},
 				getStaticPaths: `export async function getStaticPaths() {
 	return { paths: [] }
 }`,
-				code: `<html><head></head><body><div></div></body></html>`,
+				code: `<div></div>`,
 			},
 		},
 		{
@@ -147,14 +147,13 @@ const b = 0;`},
 			source: `---
 import data from "test" assert { type: 'json' };
 ---
-<html><head></head><body></body></html>`,
+`,
 			want: want{
 				frontmatter: []string{
 					`import data from "test" assert { type: 'json' };`,
 				},
 				metadata: metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {type:'json'} }`}},
 				styles:   []string{},
-				code:     `<html><head></head><body></body></html>`,
 			},
 		},
 		{
@@ -181,7 +180,8 @@ import VueComponent from '../components/Vue.vue';
   </head>
   <body>
     ${` + RENDER_COMPONENT + `($$result,'VueComponent',VueComponent,{})}
-  </body></html>`,
+  </body></html>
+  `,
 			},
 		},
 		{
@@ -207,7 +207,8 @@ import * as ns from '../components';
   </head>
   <body>
     ${` + RENDER_COMPONENT + `($$result,'ns.Component',ns.Component,{})}
-  </body></html>`,
+  </body></html>
+  `,
 			},
 		},
 		{
@@ -228,7 +229,8 @@ import * as ns from '../components';
 	<noscript>
 		${` + RENDER_COMPONENT + `($$result,'Component',Component,{})}
 	</noscript>
-  </body></html>`,
+  </body></html>
+  `,
 			},
 		},
 		{
@@ -319,14 +321,14 @@ import * as components from '../components';
 			name:   "conditional render",
 			source: `<body>{false ? <div>#f</div> : <div>#t</div>}</body>`,
 			want: want{
-				code: "<html><head></head><body>${false ? $$render`<div>#f</div>` : $$render`<div>#t</div>`}</body></html>",
+				code: "<body>${false ? $$render`<div>#f</div>` : $$render`<div>#t</div>`}</body>",
 			},
 		},
 		{
 			name:   "simple ternary",
 			source: `<body>{link ? <a href="/">{link}</a> : <div>no link</div>}</body>`,
 			want: want{
-				code: fmt.Sprintf(`<html><head></head><body>${link ? $$render%s<a href="/">${link}</a>%s : $$render%s<div>no link</div>%s}</body></html>`, BACKTICK, BACKTICK, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`<body>${link ? $$render%s<a href="/">${link}</a>%s : $$render%s<div>no link</div>%s}</body>`, BACKTICK, BACKTICK, BACKTICK, BACKTICK),
 			},
 		},
 		{
@@ -341,25 +343,25 @@ const items = [0, 1, 2];
 </ul>`,
 			want: want{
 				frontmatter: []string{"", "const items = [0, 1, 2];"},
-				code: fmt.Sprintf(`<html><head></head><body><ul>
+				code: fmt.Sprintf(`<ul>
 	${items.map(item => {
 		return $$render%s<li>${item}</li>%s;
 	})}
-</ul></body></html>`, BACKTICK, BACKTICK),
+</ul>`, BACKTICK, BACKTICK),
 			},
 		},
 		{
 			name:   "map without component",
 			source: `<header><nav>{menu.map((item) => <a href={item.href}>{item.title}</a>)}</nav></header>`,
 			want: want{
-				code: fmt.Sprintf(`<html><head></head><body><header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav></header></body></html>`, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav></header>`, BACKTICK, BACKTICK),
 			},
 		},
 		{
 			name:   "map with component",
 			source: `<header><nav>{menu.map((item) => <a href={item.href}>{item.title}</a>)}</nav><Hello/></header>`,
 			want: want{
-				code: fmt.Sprintf(`<html><head></head><body><header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav>${$$renderComponent($$result,'Hello',Hello,{})}</header></body></html>`, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav>${$$renderComponent($$result,'Hello',Hello,{})}</header>`, BACKTICK, BACKTICK),
 			},
 		},
 		{
@@ -379,28 +381,28 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			want: want{
 				frontmatter: []string{"", "const groups = [[0, 1, 2], [3, 4, 5]];"},
 				styles:      []string{},
-				code: fmt.Sprintf(`<html><head></head><body><div>
+				code: fmt.Sprintf(`<div>
 	${groups.map(items => {
 		return %s<ul>${
 			items.map(item => {
 				return %s<li>${item}</li>%s;
 			})
 		}</ul>%s})}
-</div></body></html>`, "$$render"+BACKTICK, "$$render"+BACKTICK, BACKTICK, BACKTICK),
+</div>`, "$$render"+BACKTICK, "$$render"+BACKTICK, BACKTICK, BACKTICK),
 			},
 		},
 		{
 			name:   "backtick in HTML comment",
 			source: "<body><!-- `npm install astro` --></body>",
 			want: want{
-				code: "<html><head></head><body><!-- \\`npm install astro\\` --></body></html>",
+				code: "<body><!-- \\`npm install astro\\` --></body>",
 			},
 		},
 		{
 			name:   "nested expressions",
 			source: `<article>{(previous || next) && <aside>{previous && <div>Previous Article: <a rel="prev" href={new URL(previous.link, Astro.site).pathname}>{previous.text}</a></div>}{next && <div>Next Article: <a rel="next" href={new URL(next.link, Astro.site).pathname}>{next.text}</a></div>}</aside>}</article>`,
 			want: want{
-				code: `<html><head></head><body><article>${(previous || next) && $$render` + BACKTICK + `<aside>${previous && $$render` + BACKTICK + `<div>Previous Article: <a rel="prev"${$$addAttribute(new URL(previous.link, Astro.site).pathname, "href")}>${previous.text}</a></div>` + BACKTICK + `}${next && $$render` + BACKTICK + `<div>Next Article: <a rel="next"${$$addAttribute(new URL(next.link, Astro.site).pathname, "href")}>${next.text}</a></div>` + BACKTICK + `}</aside>` + BACKTICK + `}</article></body></html>`,
+				code: `<article>${(previous || next) && $$render` + BACKTICK + `<aside>${previous && $$render` + BACKTICK + `<div>Previous Article: <a rel="prev"${$$addAttribute(new URL(previous.link, Astro.site).pathname, "href")}>${previous.text}</a></div>` + BACKTICK + `}${next && $$render` + BACKTICK + `<div>Next Article: <a rel="next"${$$addAttribute(new URL(next.link, Astro.site).pathname, "href")}>${next.text}</a></div>` + BACKTICK + `}</aside>` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -419,7 +421,7 @@ const items = ['red', 'yellow', 'blue'];
 </div>`,
 			want: want{
 				frontmatter: []string{"", "const items = ['red', 'yellow', 'blue'];"},
-				code: `<html><head></head><body><div>
+				code: `<div>
   ${items.map((item) => (
     // foo < > < }
 $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
@@ -427,7 +429,7 @@ $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
   ${items.map((item) => (
     /* foo < > < } */$$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
   ))}
-</div></body></html>`,
+</div>`,
 			},
 		},
 		{
@@ -445,7 +447,7 @@ $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
 }
 </div>`,
 			want: want{
-				code: `<html><head></head><body><div>
+				code: `<div>
 ${
 	() => {
 		let generate = (input) => {
@@ -455,7 +457,7 @@ ${
 		};
 	}
 }
-</div></body></html>`,
+</div>`,
 			},
 		},
 		{
@@ -520,7 +522,8 @@ const name = "world";
   </head>
   <body>
     <div></div>
-  </body></html>`,
+  </body></html>
+  `,
 			},
 		},
 		{
@@ -540,10 +543,8 @@ const name = "world";
 		<p class="body">I’m a page</p>`,
 			want: want{
 				styles: []string{"{props:{\"data-astro-id\":\"DPOHFLYM\"},children:`.title.astro-DPOHFLYM{font-family:fantasy;font-size:28px;}.body.astro-DPOHFLYM{font-size:1em;}`}"},
-				code: `<html class="astro-DPOHFLYM"><head>
-
-		</head><body><h1 class="title astro-DPOHFLYM">Page Title</h1>
-		<p class="body astro-DPOHFLYM">I’m a page</p></body></html>`,
+				code: "\n\n\t\t" + `<h1 class="title astro-DPOHFLYM">Page Title</h1>
+		<p class="body astro-DPOHFLYM">I’m a page</p>`,
 			},
 		},
 		{
@@ -682,7 +683,8 @@ import Counter from '../components/Counter.jsx'`,
     <main class="astro-HMNNHVCQ">
       ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":($$metadata.getPath(Counter)),"client:component-export":($$metadata.getExport(Counter)),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
     </main>
-  </body></html>`,
+  </body></html>
+  `,
 			},
 		},
 		{
@@ -707,7 +709,7 @@ import Widget2 from '../components/Widget2.astro';`},
 				code: `<html lang="en">
   <head>
     <script type="module" src="/regular_script.js"></script>
-  </head><body></body></html>`,
+  </head></html>`,
 			},
 		},
 		{
@@ -720,7 +722,7 @@ import Widget2 from '../components/Widget2.astro';`},
 				styles:      []string{},
 				scripts:     []string{fmt.Sprintf(`{props:{"type":"module","hoist":true},children:%sconsole.log("Hello");%s}`, BACKTICK, BACKTICK)},
 				metadata:    metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
-				code:        `<html><head></head><body></body></html>`,
+				code:        ``,
 			},
 		},
 		{
@@ -733,7 +735,7 @@ import Widget2 from '../components/Widget2.astro';`},
 				styles:      []string{},
 				scripts:     []string{`{props:{"type":"module","hoist":true,"src":"url"}}`},
 				metadata:    metadata{hoisted: []string{`{ type: 'remote', src: 'url' }`}},
-				code:        "<html><head></head><body></body></html>",
+				code:        "",
 			},
 		},
 		{
@@ -746,37 +748,37 @@ import Widget2 from '../components/Widget2.astro';`},
 				styles:   []string{},
 				scripts:  []string{"{props:{\"type\":\"module\",\"hoist\":true},children:`console.log(\"Hello\");`}"},
 				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
-				code: `<html><head></head><body><main>
+				code: `<main>
 
-</main></body></html>`,
+</main>`,
 			},
 		},
 		{
 			name:   "script nohoist",
 			source: `<main><script type="module">console.log("Hello");</script>`,
 			want: want{
-				code: `<html><head></head><body><main><script type="module">console.log("Hello");</script></main></body></html>`,
+				code: `<main><script type="module">console.log("Hello");</script></main>`,
 			},
 		},
 		{
 			name:   "script define:vars",
 			source: `<main><script define:vars={{ value: 0 }} type="module">console.log(value);</script>`,
 			want: want{
-				code: fmt.Sprintf(`<html><head></head><body><main><script type="module">${%s({ value: 0 })}console.log(value);</script></main></body></html>`, DEFINE_SCRIPT_VARS),
+				code: fmt.Sprintf(`<main><script type="module">${%s({ value: 0 })}console.log(value);</script></main>`, DEFINE_SCRIPT_VARS),
 			},
 		},
 		{
 			name:   "text after title expression",
 			source: `<title>a {expr} b</title>`,
 			want: want{
-				code: `<html><head><title>a ${expr} b</title></head><body></body></html>`,
+				code: `<title>a ${expr} b</title>`,
 			},
 		},
 		{
 			name:   "text after title expressions",
 			source: `<title>a {expr} b {expr} c</title>`,
 			want: want{
-				code: `<html><head><title>a ${expr} b ${expr} c</title></head><body></body></html>`,
+				code: `<title>a ${expr} b ${expr} c</title>`,
 			},
 		},
 		{
@@ -799,14 +801,14 @@ import Widget2 from '../components/Widget2.astro';`},
 			name:   "condition expressions at the top-level",
 			source: `{cond && <span></span>}{cond && <strong></strong>}`,
 			want: want{
-				code: "<html><head></head><body>${cond && $$render`<span></span>`}${cond && $$render`<strong></strong>`}</body></html>",
+				code: "${cond && $$render`<span></span>`}${cond && $$render`<strong></strong>`}",
 			},
 		},
 		{
 			name:   "condition expressions at the top-level with head content",
 			source: `{cond && <meta charset=utf8>}{cond && <title>My title</title>}`,
 			want: want{
-				code: "<html><head>${cond && $$render`<meta charset=\"utf8\">`}${cond && $$render`<title>My title</title>`}</head><body></body></html>",
+				code: "${cond && $$render`<meta charset=\"utf8\">`}${cond && $$render`<title>My title</title>`}",
 			},
 		},
 		{
@@ -819,7 +821,7 @@ import 'test';
 				frontmatter: []string{`import 'test';`},
 				styles:      []string{},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
-				code:        `<html><head></head><body>${$$renderComponent($$result,'my-element','my-element',{})}</body></html>`,
+				code:        `${$$renderComponent($$result,'my-element','my-element',{})}`,
 			},
 		},
 		{
@@ -871,14 +873,14 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 			name:   "Self-closing script in head works",
 			source: `<html><head><script /></head><html>`,
 			want: want{
-				code: `<html><head><script></script></head><body></body></html>`,
+				code: `<html><head><script></script></head></html>`,
 			},
 		},
 		{
 			name:   "Self-closing components in head can have siblings",
 			source: `<html><head><BaseHead /><link href="test"></head><html>`,
 			want: want{
-				code: `<html><head>${$$renderComponent($$result,'BaseHead',BaseHead,{})}<link href="test"></head><body></body></html>`,
+				code: `<html><head>${$$renderComponent($$result,'BaseHead',BaseHead,{})}<link href="test"></head></html>`,
 			},
 		},
 		{
@@ -892,7 +894,7 @@ const canonicalURL = new URL('http://example.com');
 				frontmatter: []string{"", `const image = './penguin.png';
 const canonicalURL = new URL('http://example.com');`},
 				styles: []string{},
-				code:   "<html><head>${image && ($$render`<meta property=\"og:image\"${$$addAttribute(new URL(image, canonicalURL), \"content\")}>`)}</head><body></body></html>",
+				code:   "${image && ($$render`<meta property=\"og:image\"${$$addAttribute(new URL(image, canonicalURL), \"content\")}>`)}",
 			},
 		},
 		{
@@ -914,7 +916,7 @@ let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');
 }
 let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');`},
 				styles: []string{},
-				code:   "<html><head></head><body><div>testing</div></body></html>",
+				code:   "<div>testing</div>",
 			},
 		},
 		{
@@ -938,10 +940,10 @@ import ZComponent from '../components/ZComponent.jsx';`},
 						`{ module: $$module2, specifier: '../components/ZComponent.jsx', assert: {} }`,
 					},
 				},
-				code: `<html><head></head><body>
+				code: `<body>
   ${` + RENDER_COMPONENT + `($$result,'AComponent',AComponent,{})}
   ${` + RENDER_COMPONENT + `($$result,'ZComponent',ZComponent,{})}
-</body></html>`,
+</body>`,
 			},
 		},
 		{
@@ -953,16 +955,16 @@ import ZComponent from '../components/ZComponent.jsx';`},
   src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75"
   srcSet="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 800w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 1200w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1600&q=75 1600w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=2400&q=75 2400w"
   sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"
-></body></html>`,
+>`,
 			want: want{
-				code: `<html><head></head><body>` + longRandomString + `<img width="1600" height="1131" class="img" src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75" srcSet="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 800w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 1200w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1600&q=75 1600w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=2400&q=75 2400w" sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"></body></html>`,
+				code: `<html><body>` + longRandomString + `<img width="1600" height="1131" class="img" src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75" srcSet="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 800w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 1200w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1600&q=75 1600w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=2400&q=75 2400w" sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"></body></html>`,
 			},
 		},
 		{
 			name:   "SVG styles",
 			source: `<svg><style>path { fill: red; }</style></svg>`,
 			want: want{
-				code: `<html><head></head><body><svg><style>path { fill: red; }</style></svg></body></html>`,
+				code: `<svg><style>path { fill: red; }</style></svg>`,
 			},
 		},
 		{
@@ -973,7 +975,7 @@ const title = 'icon';
 <svg>{title ?? null}</svg>`,
 			want: want{
 				frontmatter: []string{"", "const title = 'icon';"},
-				code:        `<html><head></head><body><svg>${title ?? null}</svg></body></html>`,
+				code:        `<svg>${title ?? null}</svg>`,
 			},
 		},
 		{
@@ -984,7 +986,7 @@ const title = 'icon';
 <svg>{title ? <title>{title}</title> : null}</svg>`,
 			want: want{
 				frontmatter: []string{"", "const title = 'icon';"},
-				code:        `<html><head></head><body><svg>${title ? $$render` + BACKTICK + `<title>${title}</title>` + BACKTICK + ` : null}</svg></body></html>`,
+				code:        `<svg>${title ? $$render` + BACKTICK + `<title>${title}</title>` + BACKTICK + ` : null}</svg>`,
 			},
 		},
 		{
@@ -992,7 +994,7 @@ const title = 'icon';
 			source: `<script hoist></script>`,
 			want: want{
 				scripts: []string{`{props:{"hoist":true}}`},
-				code:    `<html><head></head><body></body></html>`,
+				code:    ``,
 			},
 		},
 		{
@@ -1000,7 +1002,7 @@ const title = 'icon';
 			source: `<style define:vars={{ color: "Gainsboro" }}></style>`,
 			want: want{
 				styles: []string{`{props:{"define:vars":({ color: "Gainsboro" }),"data-astro-id":"7HAAVZPE"}}`},
-				code:   `<html class="astro-7HAAVZPE"><head></head><body></body></html>`,
+				code:   ``,
 			},
 		},
 		{
@@ -1047,7 +1049,7 @@ const title = 'icon';
   gtag('config', 'G-TEL60V1WM9');
 </script> -->`,
 			want: want{
-				code: `<!-- Global Metadata --><html><head><meta charset="utf-8">
+				code: `<!-- Global Metadata --><meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -1086,7 +1088,7 @@ const title = 'icon';
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
   gtag('config', 'G-TEL60V1WM9');
-</script> --></head><body></body></html>`,
+</script> -->`,
 			},
 		},
 		{
@@ -1123,49 +1125,49 @@ import { Container, Col, Row } from 'react-bootstrap';
 					"{props:{\"data-astro-id\":\"EX5CHM4O\"},children:`div.astro-EX5CHM4O{color:green;}`}",
 					"{props:{\"global\":true},children:`div { color: red }`}",
 				},
-				code: "<html class=\"astro-EX5CHM4O\"><head>\n\n\n\n\n\n\n</head>\n<body><div class=\"astro-EX5CHM4O\"></div></body></html>",
+				code: "<head>\n\n\n\n\n\n\n</head>\n<div class=\"astro-EX5CHM4O\"></div>",
 			},
 		},
 		{
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 			want: want{
-				code: `<html><head></head><body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body></html>`,
+				code: `<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Fragment shorthand",
 			source: `<body><><div>Default</div><div>Named</div></></body>`,
 			want: want{
-				code: `<html><head></head><body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body></html>`,
+				code: `<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Fragment slotted",
 			source: `<body><Component><><div>Default</div><div>Named</div></></Component></body>`,
 			want: want{
-				code: `<html><head></head><body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body></html>`,
+				code: `<body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Fragment slotted with name",
 			source: `<body><Component><Fragment slot=named><div>Default</div><div>Named</div></Fragment></Component></body>`,
 			want: want{
-				code: `<html><head></head><body>${$$renderComponent($$result,'Component',Component,{},{"named": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{"slot":"named"},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body></html>`,
+				code: `<body>${$$renderComponent($$result,'Component',Component,{},{"named": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{"slot":"named"},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Preserve slots inside custom-element",
 			source: `<body><my-element><div slot=name>Name</div><div>Default</div></my-element></body>`,
 			want: want{
-				code: `<html><head></head><body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body></html>`,
+				code: `<body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Preserve namespaces",
 			source: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></svg>`,
 			want: want{
-				code: `<html><head></head><body><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></rect></svg></body></html>`,
+				code: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></rect></svg>`,
 			},
 		},
 		{
@@ -1231,7 +1233,8 @@ const { product } = Astro.props;
     </article>
   </div>
   ${$$renderComponent($$result,'Footer',Footer,{})}
-</body></html>`,
+</body></html>
+`,
 				frontmatter: []string{
 					`import Header from '../../components/Header.jsx'
 import Footer from '../../components/Footer.astro'
@@ -1264,6 +1267,13 @@ import ProductPageContent from '../../components/ProductPageContent.jsx';`,
 			},
 		},
 		{
+			name:   "doctype",
+			source: `<!DOCTYPE html><div/>`,
+			want: want{
+				code: `<!DOCTYPE html><div></div>`,
+			},
+		},
+		{
 			name: "select option expression",
 			source: `---
 const value = 'test';
@@ -1271,7 +1281,7 @@ const value = 'test';
 <select><option>{value}</option></select>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<html><head></head><body><select><option>${value}</option></select></body></html>`,
+				code:        `<select><option>${value}</option></select>`,
 			},
 		},
 		{
@@ -1282,7 +1292,7 @@ const value = 'test';
 <select>{value && <option>{value}</option>}</select>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<html><head></head><body><select>${value && $$render` + BACKTICK + `<option>${value}</option>` + BACKTICK + `}</select></body></html>`,
+				code:        `<select>${value && $$render` + BACKTICK + `<option>${value}</option>` + BACKTICK + `}</select>`,
 			},
 		},
 		{
@@ -1293,14 +1303,14 @@ const value = 'test';
 <textarea>{value}</textarea>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<html><head></head><body><textarea>${value}</textarea></body></html>`,
+				code:        `<textarea>${value}</textarea>`,
 			},
 		},
 		{
 			name:   "textarea inside expression",
 			source: `{bool && <textarea>{value}</textarea>} {!bool && <input>}`,
 			want: want{
-				code: `<html><head></head><body>${bool && $$render` + BACKTICK + `<textarea>${value}</textarea>` + BACKTICK + `} ${!bool && $$render` + BACKTICK + `<input>` + BACKTICK + `}</body></html>`,
+				code: `${bool && $$render` + BACKTICK + `<textarea>${value}</textarea>` + BACKTICK + `} ${!bool && $$render` + BACKTICK + `<input>` + BACKTICK + `}`,
 			},
 		},
 		{
@@ -1311,7 +1321,7 @@ const items = ["Dog", "Cat", "Platipus"];
 <table>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<html><head></head><body><table>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table></body></html>`,
+				code:        `<table>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
@@ -1322,7 +1332,7 @@ const items = ["Dog", "Cat", "Platipus"];
 <table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
+				code:        `<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
@@ -1333,56 +1343,56 @@ const items = ["Dog", "Cat", "Platipus"];
 <table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td><td>{item + 's'}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td><td>${item + 's'}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
+				code:        `<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td><td>${item + 's'}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
 			name:   "td expressions",
 			source: `<table><tr><td><h2>Row 1</h2></td><td>{title}</td></tr></table>`,
 			want: want{
-				code: `<html><head></head><body><table><tbody><tr><td><h2>Row 1</h2></td><td>${title}</td></tr></tbody></table></body></html>`,
+				code: `<table><tr><td><h2>Row 1</h2></td><td>${title}</td></tr></table>`,
 			},
 		},
 		{
 			name:   "th expressions",
 			source: `<table><thead><tr><th>{title}</th></tr></thead></table>`,
 			want: want{
-				code: `<html><head></head><body><table><thead><tr><th>${title}</th></tr></thead></table></body></html>`,
+				code: `<table><thead><tr><th>${title}</th></tr></thead></table>`,
 			},
 		},
 		{
 			name:   "anchor expressions",
 			source: `<a>{expr}</a>`,
 			want: want{
-				code: `<html><head></head><body><a>${expr}</a></body></html>`,
+				code: `<a>${expr}</a>`,
 			},
 		},
 		{
 			name:   "anchor inside expression",
 			source: `{true && <a>expr</a>}`,
 			want: want{
-				code: `<html><head></head><body>${true && $$render` + BACKTICK + `<a>expr</a>` + BACKTICK + `}</body></html>`,
+				code: `${true && $$render` + BACKTICK + `<a>expr</a>` + BACKTICK + `}`,
 			},
 		},
 		{
 			name:   "anchor content",
 			source: `<a><div><h3></h3><ul><li>{expr}</li></ul></div></a>`,
 			want: want{
-				code: `<html><head></head><body><a><div><h3></h3><ul><li>${expr}</li></ul></div></a></body></html>`,
+				code: `<a><div><h3></h3><ul><li>${expr}</li></ul></div></a>`,
 			},
 		},
 		{
 			name:   "small expression",
 			source: `<div><small>{a}</small>{data.map(a => <Component value={a} />)}</div>`,
 			want: want{
-				code: `<html><head></head><body><div><small>${a}</small>${data.map(a => $$render` + BACKTICK + `${$$renderComponent($$result,'Component',Component,{"value":(a)})}` + BACKTICK + `)}</div></body></html>`,
+				code: `<div><small>${a}</small>${data.map(a => $$render` + BACKTICK + `${$$renderComponent($$result,'Component',Component,{"value":(a)})}` + BACKTICK + `)}</div>`,
 			},
 		},
 		{
 			name:   "escaped entity",
 			source: `<img alt="A person saying &#x22;hello&#x22;">`,
 			want: want{
-				code: `<html><head></head><body><img alt="A person saying &quot;hello&quot;"></body></html>`,
+				code: `<img alt="A person saying &quot;hello&quot;">`,
 			},
 		},
 		{
@@ -1403,7 +1413,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "user-defined `implicit` is printed",
 			source: `<html implicit></html>`,
 			want: want{
-				code: `<html implicit><head></head><body></body></html>`,
+				code: `<html implicit></html>`,
 			},
 		},
 		{
@@ -1411,15 +1421,11 @@ const items = ["Dog", "Cat", "Platipus"];
 			source: `<style>/* comment */.container {
     padding: 2rem;
 	}
-</style>
-
-<div class="container">My Text</div>`,
+</style><div class="container">My Text</div>`,
 
 			want: want{
-				styles: []string{fmt.Sprintf(`{props:{"data-astro-id":"RN5ULUD7"},children:%s/* comment */.container.astro-RN5ULUD7{padding:2rem;}%s}`, BACKTICK, BACKTICK)},
-				code: `<html class="astro-RN5ULUD7"><head>
-
-</head><body><div class="container astro-RN5ULUD7">My Text</div></body></html>`,
+				styles: []string{fmt.Sprintf(`{props:{"data-astro-id":"SJ3WYE6H"},children:%s/* comment */.container.astro-SJ3WYE6H{padding:2rem;}%s}`, BACKTICK, BACKTICK)},
+				code:   `<div class="container astro-SJ3WYE6H">My Text</div>`,
 			},
 		},
 		{
@@ -1432,7 +1438,7 @@ const items = ["Dog", "Cat", "Platipus"];
   </table>
 </body>`,
 			want: want{
-				code: fmt.Sprintf(`<html><head></head><body>
+				code: fmt.Sprintf(`<html><body>
   <table>
   ${true ? ($$render%s<tr><td>Row 1</td></tr>%s) : null}
   ${true ? ($$render%s<tr><td>Row 2</td></tr>%s) : null}
@@ -1452,14 +1458,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "Empty expression",
 			source: "<body>({})</body>",
 			want: want{
-				code: `<html><head></head><body>(${(void 0)})</body></html>`,
+				code: `<body>(${(void 0)})</body>`,
 			},
 		},
 		{
 			name:   "Empty attribute expression",
 			source: "<body attr={}></body>",
 			want: want{
-				code: `<html><head></head><body${$$addAttribute((void 0), "attr")}></body></html>`,
+				code: `<body${$$addAttribute((void 0), "attr")}></body>`,
 			},
 		},
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -145,27 +145,3 @@ func walk(doc *astro.Node, cb func(*astro.Node)) {
 	}
 	f(doc)
 }
-
-func hasSiblings(n *astro.Node) bool {
-	if n.NextSibling == nil && n.PrevSibling == nil {
-		return false
-	}
-
-	var flag bool
-	if n.Parent != nil {
-		for c := n.Parent.FirstChild; c != nil; c = c.NextSibling {
-			if c == n {
-				continue
-			}
-			if c.Type == astro.TextNode && strings.TrimSpace(c.Data) == "" {
-				continue
-			}
-			if c.Type == astro.CommentNode {
-				continue
-			}
-			flag = true
-		}
-	}
-
-	return flag
-}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -10,7 +10,6 @@ import (
 )
 
 type TransformOptions struct {
-	As               string
 	Scope            string
 	Filename         string
 	Pathname         string
@@ -35,42 +34,6 @@ func Transform(doc *astro.Node, opts TransformOptions) *astro.Node {
 	// Important! Remove scripts from original location *after* walking the doc
 	for _, script := range doc.Scripts {
 		script.Parent.RemoveChild(script)
-	}
-
-	// Sometimes files have leading <script hoist> or <style>...
-	// Since we can't detect a "component-only" file until after `parse`, we need to handle
-	// them here. The component will be hoisted to the root of the document, `html` and `head` will be removed.
-	if opts.As != "fragment" {
-		var onlyComponent *astro.Node
-		var rootNode *astro.Node
-		walk(doc, func(n *astro.Node) {
-			if p := n.Parent; n.Component && p != nil && (p.DataAtom == a.Head || p.DataAtom == a.Body) {
-				if !hasSiblings(n) {
-					onlyComponent = n
-				}
-				return
-			}
-			if n.DataAtom == a.Html && (!IsImplictNode(n) || childCount(n) == 1) {
-				rootNode = n
-				return
-			}
-		})
-
-		if rootNode == nil {
-			rootNode = doc
-		}
-
-		if onlyComponent != nil {
-			p := onlyComponent.Parent
-			if IsImplictNode(p) {
-				onlyComponent.Parent.RemoveChild(onlyComponent)
-				rootNode.AppendChild(onlyComponent)
-				rootNode.RemoveChild(onlyComponent.PrevSibling)
-				if rootNode.FirstChild != nil && IsImplictNode(rootNode.FirstChild) {
-					rootNode.RemoveChild(rootNode.FirstChild)
-				}
-			}
-		}
 	}
 
 	// If we've emptied out all the nodes, this was a Fragment that only contained hoisted elements

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -142,12 +142,12 @@ func TestFullTransform(t *testing.T) {
 		{
 			name:   "respects explicitly authored elements 2",
 			source: `<head></head><Component />`,
-			want:   `<html><head></head><Component></Component></html>`,
+			want:   `<head></head><Component></Component>`,
 		},
 		{
 			name:   "respects explicitly authored elements 3",
 			source: `<body><Component /></body>`,
-			want:   `<html><head></head><body><Component></Component></body></html>`,
+			want:   `<body><Component></Component></body>`,
 		},
 		{
 			name:   "removes implicitly generated elements",
@@ -165,10 +165,10 @@ func TestFullTransform(t *testing.T) {
 <span />
 <Component />
 <span />`,
-			want: `<html><head><title>Title</title>
-</head><body><span></span>
+			want: `<title>Title</title>
+<span></span>
 <Component></Component>
-<span></span></body></html>`,
+<span></span>`,
 		},
 	}
 	var b strings.Builder

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -33,17 +33,6 @@ func IsImplictNodeMarker(attr astro.Attribute) bool {
 	return attr.Key == astro.ImplicitNodeMarker
 }
 
-func childCount(n *astro.Node) int {
-	var i int
-	for c := n.FirstChild; c != nil; c = c.NextSibling {
-		if IsImplictNode(c) {
-			continue
-		}
-		i++
-	}
-	return i
-}
-
 func GetQuotedAttr(n *astro.Node, key string) string {
 	for _, attr := range n.Attr {
 		if attr.Key == key {

--- a/lib/compiler/shared/types.ts
+++ b/lib/compiler/shared/types.ts
@@ -9,6 +9,9 @@ export interface TransformOptions {
   sourcefile?: string;
   pathname?: string;
   sourcemap?: boolean | 'inline' | 'external' | 'both';
+  /**
+   * @deprecated "as" has been removed and no longer has any effect!
+   */
   as?: 'document' | 'fragment';
   projectRoot?: string;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => Promise<PreprocessorResult>;

--- a/lib/compiler/test/body-fragment.test.mjs
+++ b/lib/compiler/test/body-fragment.test.mjs
@@ -13,7 +13,6 @@ import ThemeToggleButton from './ThemeToggleButton.tsx';
 <body><div>Hello!</div></body>`,
     {
       sourcemap: true,
-      as: 'fragment',
       site: undefined,
       sourcefile: 'MoreMenu.astro',
       sourcemap: 'both',

--- a/lib/compiler/test/extract.test.mjs
+++ b/lib/compiler/test/extract.test.mjs
@@ -11,7 +11,6 @@ async function run() {
 </style>`,
     {
       sourcemap: true,
-      as: 'fragment',
       site: undefined,
       sourcefile: 'MoreMenu.astro',
       sourcemap: 'both',

--- a/lib/compiler/test/script-fragment.test.mjs
+++ b/lib/compiler/test/script-fragment.test.mjs
@@ -5,7 +5,6 @@ import { transform } from '@astrojs/compiler';
 async function run() {
   const result = await transform(`<script src={Astro.resolve("../scripts/no_hoist_nonmodule.js")}></script>`, {
     sourcemap: true,
-    as: 'fragment',
     site: undefined,
     sourcefile: 'MoreMenu.astro',
     sourcemap: 'both',

--- a/lib/compiler/test/top-level-expression.test.mjs
+++ b/lib/compiler/test/top-level-expression.test.mjs
@@ -30,7 +30,6 @@ const internal = [];
 async function run() {
   const result = await transform(contents, {
     sourcemap: true,
-    as: 'fragment',
     site: undefined,
     sourcefile: 'MoreMenu.astro',
     sourcemap: 'both',

--- a/lib/compiler/test/visible.test.mjs
+++ b/lib/compiler/test/visible.test.mjs
@@ -19,7 +19,6 @@ async function run() {
     </div>`,
     {
       sourcemap: true,
-      as: 'fragment',
       site: undefined,
       sourcefile: 'MoreMenu.astro',
       sourcemap: 'both',


### PR DESCRIPTION
## Changes

- Partially implements https://github.com/withastro/rfcs/blob/main/active-rfcs/0007-finalize-head-body.md
- Removes `as: 'document'|'fragment'` special casing from the compiler
- Removes implicitly generated tags from the compiler output. What you author is what you get.

## Testing

Tests have been updated to reflect new behavior (no implicit `<html>`, `<head>`, or `<body>` tags)

## Docs

No docs yet
