### PR TITLE
Add the right import for non-CSS

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -93,7 +93,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	if n.Type == DocumentNode {
 		p.printInternalImports(p.opts.InternalURL)
 		if opts.opts.StaticExtraction {
-			p.printCSSImports(opts.cssLen)
+			p.printCSSImports(n)
 		}
 
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
@@ -116,7 +116,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			if c.Type == TextNode {
 				p.printInternalImports(p.opts.InternalURL)
 				if opts.opts.StaticExtraction {
-					p.printCSSImports(opts.cssLen)
+					p.printCSSImports(n)
 				}
 
 				// This scanner returns a position where we should slice the frontmatter.

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -61,10 +61,11 @@ type metadata struct {
 }
 
 type testcase struct {
-	name   string
-	source string
-	only   bool
-	want   want
+	name             string
+	source           string
+	staticExtraction bool
+	only             bool
+	want             want
 }
 
 func TestPrinter(t *testing.T) {
@@ -1463,6 +1464,17 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `<html><head></head><body${$$addAttribute((void 0), "attr")}></body></html>`,
 			},
 		},
+		{
+			name:             "Static build adds right import for scss",
+			source:           "<style lang=\"scss\">body{color:green;}</style>",
+			staticExtraction: true,
+			want: want{
+				code: `<html class="astro-H25ZX7J3"><head></head><body></body></html>`,
+				frontmatter: []string{
+					`import "?astro&type=style&index=0&lang.scss";`,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1492,7 +1504,7 @@ const items = ["Dog", "Cat", "Platipus"];
 				Site:             "https://astro.build",
 				InternalURL:      "http://localhost:3000/",
 				ProjectRoot:      ".",
-				StaticExtraction: false,
+				StaticExtraction: tt.staticExtraction,
 			})
 			output := string(result.Output)
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1465,6 +1465,17 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:             "Static build adds import for css",
+			source:           "<style>body{color:green;}</style>",
+			staticExtraction: true,
+			want: want{
+				code: `<html class="astro-BIUKII5Q"><head></head><body></body></html>`,
+				frontmatter: []string{
+					`import "?astro&type=style&index=0&lang.css";`,
+				},
+			},
+		},
+		{
 			name:             "Static build adds right import for scss",
 			source:           "<style lang=\"scss\">body{color:green;}</style>",
 			staticExtraction: true,


### PR DESCRIPTION
## Changes

- The static import adds imports like: `import "/src/pages/index.astro?astro&type=style&index=0&lang.css";`
- This PR makes it so that the `lang` attribute is used to add the right extension.

## Testing

Test added

## Docs

N/A, bug fix.