### PR TITLE
Acknowledge self-closing formatting elements

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1205,9 +1205,19 @@ func inBodyIM(p *parser) bool {
 			}
 			p.reconstructActiveFormattingElements()
 			p.addFormattingElement()
+			if p.hasSelfClosingToken {
+				p.afe.pop()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
 		case a.B, a.Big, a.Code, a.Em, a.Font, a.I, a.S, a.Small, a.Strike, a.Strong, a.Tt, a.U:
 			p.reconstructActiveFormattingElements()
 			p.addFormattingElement()
+			if p.hasSelfClosingToken {
+				p.afe.pop()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
 		case a.Nobr:
 			p.reconstructActiveFormattingElements()
 			if p.elementInScope(defaultScope, a.Nobr) {
@@ -1215,6 +1225,11 @@ func inBodyIM(p *parser) bool {
 				p.reconstructActiveFormattingElements()
 			}
 			p.addFormattingElement()
+			if p.hasSelfClosingToken {
+				p.afe.pop()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
 		case a.Applet, a.Marquee, a.Object:
 			p.reconstructActiveFormattingElements()
 			p.addElement()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -886,6 +886,28 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 			},
 		},
 		{
+			name:   "Self-closing formatting elements",
+			source: `<div id="1"><div id="2"><div id="3"><i/><i/><i/></div></div></div>`,
+			want: want{
+				code: `<html><head></head><body><div id="1"><div id="2"><div id="3"><i></i><i></i><i></i></div></div></div></body></html>`,
+			},
+		},
+		{
+			name: "Self-closing formatting elements 2",
+			source: `<body>
+  <div id="1"><div id="2"><div id="3"><i id="a" /></div></div></div>
+  <div id="4"><div id="5"><div id="6"><i id="b" /></div></div></div>
+  <div id="7"><div id="8"><div id="9"><i id="c" /></div></div></div>
+</body>`,
+			want: want{
+				code: `<html><head></head><body>
+  <div id="1"><div id="2"><div id="3"><i id="a"></i></div></div></div>
+  <div id="4"><div id="5"><div id="6"><i id="b"></i></div></div></div>
+  <div id="7"><div id="8"><div id="9"><i id="c"></i></div></div></div>
+</body></html>`,
+			},
+		},
+		{
 			name: "Nested HTML in expressions, wrapped in parens",
 			source: `---
 const image = './penguin.png';


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/compiler/issues/272
- Self-closing tags were being removed from the open elements stack (`p.oe`) but continued to be added to the active formatting elements (`p.afe`) stack!
- This fixes the handling of self-closing formatting elements (`a`, `b`, `big`, `code`, `em`, `font`, `i`, `s`, `small`, `strike`, `strong`, `tt`, `u`, and `nobr`)

## Testing

Test case from issue added

## Docs

Bug fix only