### PR TITLE
Fix nested template literal expressions in attributes

### DIFF
--- a/.changeset/perfect-chefs-invite.md
+++ b/.changeset/perfect-chefs-invite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of nested template literals inside of expressions

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -162,6 +162,27 @@ import data from "test" assert { type: 'json' };
 			},
 		},
 		{
+			name:   "solidus in template literal expression",
+			source: "<div value={`${attr ? `a/b` : \"c\"} awesome`} />",
+			want: want{
+				code: "<html><head></head><body><div${$$addAttribute(`${attr ? `a/b` : \"c\"} awesome`, \"value\")}></div></body></html>",
+			},
+		},
+		{
+			name:   "nested template literal expression",
+			source: "<div value={`${attr ? `a/b ${`c`}` : \"d\"} awesome`} />",
+			want: want{
+				code: "<html><head></head><body><div${$$addAttribute(`${attr ? `a/b ${`c`}` : \"d\"} awesome`, \"value\")}></div></body></html>",
+			},
+		},
+		{
+			name:   "complex nested template literal expression",
+			source: "<div value={`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} ahhhh`} />",
+			want: want{
+				code: "<html><head></head><body><div${$$addAttribute(`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} ahhhh`, \"value\")}></div></body></html>",
+			},
+		},
+		{
 			name: "component",
 			source: `---
 import VueComponent from '../components/Vue.vue';

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -169,6 +169,16 @@ func TestBasic(t *testing.T) {
 			[]TokenType{SelfClosingTagToken},
 		},
 		{
+			"attribute expression with solidus inside template literal",
+			"<div value={attr ? `a/b` : \"c\"} />",
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
+			"complex attribute expression",
+			"<div value={`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} awesome`} />",
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
 			"attribute expression with solidus no spaces",
 			`<div value={(100/2)} />`,
 			[]TokenType{SelfClosingTagToken},
@@ -306,11 +316,6 @@ To fix this, please change
   < slot="named">
 to use the longhand Fragment syntax:
   <Fragment slot="named">`,
-		},
-		{
-			"block comment in attribute",
-			`<div {// uhh} />`,
-			`Block comments (//) are not allowed inside of expressions`,
 		},
 	}
 	runPanicTest(t, Panics)
@@ -717,6 +722,16 @@ func TestAttributes(t *testing.T) {
 		{
 			"expression with quoted braces",
 			`<div value={ "{" } />`,
+			[]AttributeType{ExpressionAttribute},
+		},
+		{
+			"attribute expression with solidus inside template literal",
+			"<div value={attr ? `a/b` : \"c\"} />",
+			[]AttributeType{ExpressionAttribute},
+		},
+		{
+			"attribute expression with solidus inside template literal with trailing text",
+			"<div value={`${attr ? `a/b` : \"c\"} awesome`} />",
 			[]AttributeType{ExpressionAttribute},
 		},
 	}


### PR DESCRIPTION
## Changes

- Closes #251.
- Nested template literals weren't being handled properly inside of Attribute expressions. Specifically, we had no logic to track them, so the `/` character would trigger an unexpected code flow.
- This PR updates the attribute tokenizer to be aware of template literals and properly tokenize nested template literals.

## Testing

Tokenizer and printer tests added

## Docs

Bug fix only