### PR TITLE
feat: `data-astro-raw` => `is:raw`

### DIFF
--- a/.changeset/yellow-kids-walk.md
+++ b/.changeset/yellow-kids-walk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Formalize support for magic `data-astro-raw` attribute with new, official `is:raw` directive

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -172,7 +172,7 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 		if i != 0 {
 			p.print(",")
 		}
-		if a.Key == "set:text" || a.Key == "set:html" {
+		if a.Key == "set:text" || a.Key == "set:html" || a.Key == "is:raw" {
 			continue
 		}
 		switch a.Type {
@@ -249,7 +249,7 @@ func (p *printer) printStyleOrScript(opts RenderOptions, n *astro.Node) {
 }
 
 func (p *printer) printAttribute(attr astro.Attribute) {
-	if attr.Key == "define:vars" || attr.Key == "set:text" || attr.Key == "set:html" {
+	if attr.Key == "define:vars" || attr.Key == "set:text" || attr.Key == "set:html" || attr.Key == "is:raw" {
 		return
 	}
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1467,6 +1467,20 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "is:raw",
+			source: "<article is:raw><% awesome %></article>",
+			want: want{
+				code: `<html><head></head><body><article><% awesome %></article></body></html>`,
+			},
+		},
+		{
+			name:   "Component is:raw",
+			source: "<Component is:raw>{<% awesome %>}</Component>",
+			want: want{
+				code: "${$$renderComponent($$result,'Component',Component,{},{\"default\": () => $$render`{<% awesome %>}`,})}",
+			},
+		},
+		{
 			name:   "set:html",
 			source: "<article set:html={content} />",
 			want: want{

--- a/internal/token.go
+++ b/internal/token.go
@@ -930,7 +930,7 @@ loop:
 	return false
 }
 
-func (z *Tokenizer) hasTag(s string) bool {
+func (z *Tokenizer) hasAttribute(s string) bool {
 	for i := len(z.attr) - 1; i >= 0; i-- {
 		x := z.attr[i]
 		key := z.buf[x[0].Start:x[0].End]
@@ -962,7 +962,10 @@ func (z *Tokenizer) readStartTag() TokenType {
 		raw = z.startTagIn("xmp")
 	}
 	if !raw {
-		raw = z.hasTag("data-astro-raw")
+		raw = z.hasAttribute("data-astro-raw")
+	}
+	if !raw {
+		raw = z.hasAttribute("is:raw")
 	}
 	if raw {
 		z.rawTag = string(z.buf[z.data.Start:z.data.End])

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -227,8 +227,23 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"is:raw allows children to be parsed as Text",
+			"<span is:raw>function foo() { }</span>",
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"is:raw treats all children as raw text",
+			"<Fragment is:raw><ul></ue></Fragment>",
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"is:raw treats all children as raw text",
+			"<Fragment is:raw><ul></ue></Fragment>",
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
 			"data-astro-raw allows other attributes",
-			"<span data-raw={true} data-astro-raw>function foo() { }</span>",
+			"<span data-raw={true} is:raw><%= Hi =%></span>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -242,7 +242,7 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
-			"data-astro-raw allows other attributes",
+			"is:raw allows other attributes",
 			"<span data-raw={true} is:raw><%= Hi =%></span>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},


### PR DESCRIPTION
## Changes

- Was investigating an issue with `data-astro-raw` that turned out to not be a problem with the compiler! Woohoo!
- This formalizes support for `data-astro-raw` attribute as the `is:raw` directive.
- `is:raw` attribute will not be printed in the output, it is just a compiler directive.

## Testing

Tests added

## Docs

TBD.
