### PR TITLE
Treat `{}` as raw text inside of `<math>`

### DIFF
--- a/.changeset/young-masks-cover.md
+++ b/.changeset/young-masks-cover.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve MathML support. `{}` inside of `<math>` is now treated as raw text rather than an expression construct.

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -85,6 +85,21 @@ func TestBasic(t *testing.T) {
 			[]TokenType{SelfClosingTagToken, StartTagToken, EndTagToken, SelfClosingTagToken},
 		},
 		{
+			"No expressions inside math",
+			`<math>{test}</math>`,
+			[]TokenType{StartTagToken, TextToken, TextToken, TextToken, EndTagToken},
+		},
+		{
+			"No expressions inside math (complex)",
+			`<math xmlns="http://www.w3.org/1998/Math/MathML"><annotation encoding="application/x-tex">\sqrt{2}</annotation></math>`,
+			[]TokenType{StartTagToken, StartTagToken, TextToken, TextToken, TextToken, TextToken, EndTagToken, EndTagToken},
+		},
+		{
+			"Expression attributes allowed inside math",
+			`<math set:html={test} />`,
+			[]TokenType{SelfClosingTagToken},
+		},
+		{
 			"SVG (self-closing)",
 			`<svg><path/></svg>`,
 			[]TokenType{StartTagToken, SelfClosingTagToken, EndTagToken},


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/277.
- Improves Astro's `MathML` support by treating `{}` characters as raw text. 
- Note that this introduces a new tokenization mode where _only expressions are disabled_. All children are still tokenized properly, but `{` is a `TextToken` rather than `StartExpressionToken`. This means that Astro compiler directives like `set:html` will continue to work inside of `<math>`.
- There are likely few users impacted by this change directly, but more users who use something like [KaTeX](https://katex.org/) (where `{}` represent significant characters) that will benefit from this indirectly.

## Testing

Tokenizer tests added!

## Docs

Bug fix. Should this be documented somewhere?