### PR TITLE
Fix conditional special elements

### DIFF
--- a/.changeset/nine-cheetahs-act.md
+++ b/.changeset/nine-cheetahs-act.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix conditional rendering for special elements like `iframe` and `noscript`

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2763,7 +2763,7 @@ func (p *parser) parseCurrentToken() {
 		if p.inForeignContent() {
 			consumed = parseForeignContent(p)
 		} else {
-			if p.im == nil && p.context != nil {
+			if p.im == nil {
 				p.im = inBodyIM
 			}
 			consumed = p.im(p)

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -440,9 +440,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.print(escapeText(c.Data))
 			} else {
 				render1(p, c, RenderOptions{
-					isRoot: false,
-					depth:  depth + 1,
-					opts:   opts.opts,
+					isRoot:       false,
+					isExpression: opts.isExpression,
+					depth:        depth + 1,
+					opts:         opts.opts,
 				})
 			}
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -341,10 +341,31 @@ import * as components from '../components';
 			},
 		},
 		{
+			name:   "iframe",
+			source: `<iframe src="something" />`,
+			want: want{
+				code: "<html><head></head><body><iframe src=\"something\"></iframe></body></html>",
+			},
+		},
+		{
 			name:   "conditional render",
 			source: `<body>{false ? <div>#f</div> : <div>#t</div>}</body>`,
 			want: want{
 				code: "<html><head></head><body>${false ? $$render`<div>#f</div>` : $$render`<div>#t</div>`}</body></html>",
+			},
+		},
+		{
+			name:   "conditional noscript",
+			source: `{mode === "production" && <noscript>Hello</noscript>}`,
+			want: want{
+				code: "<html><head>${mode === \"production\" && $$render`<noscript>Hello</noscript>`}</head><body></body></html>",
+			},
+		},
+		{
+			name:   "conditional iframe",
+			source: `{bool && <iframe src="something">content</iframe>}`,
+			want: want{
+				code: "<html><head></head><body>${bool && $$render`<iframe src=\"something\">content</iframe>`}</body></html>",
 			},
 		},
 		{

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -257,6 +257,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"iframe allows attributes",
+			"<iframe src=\"https://google.com\"></iframe>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
+		{
 			"data-astro-raw allows children to be parsed as Text",
 			"<span data-astro-raw>function foo() { }</span>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
@@ -773,6 +778,11 @@ func TestAttributes(t *testing.T) {
 			"attribute expression with solidus inside template literal with trailing text",
 			"<div value={`${attr ? `a/b` : \"c\"} awesome`} />",
 			[]AttributeType{ExpressionAttribute},
+		},
+		{
+			"iframe allows attributes",
+			"<iframe src=\"https://google.com\"></iframe>",
+			[]AttributeType{QuotedAttribute},
 		},
 	}
 


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/284
- Fixes conditional rendering of special elements like `iframe` and `noscript`.
- These were setting the parser `context`, which then meant `p.im()` would throw.

## Testing

Tests added

## Docs

Bug fix only