### PR TITLE
[WIP] Allow external scoping

### DIFF
--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -79,6 +79,11 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 		projectRoot = "."
 	}
 
+	externalScoping := false
+	if jsBool(options.Get("externalScoping")) {
+		externalScoping = true
+	}
+
 	staticExtraction := false
 	if jsBool(options.Get("experimentalStaticExtraction")) {
 		staticExtraction = true
@@ -96,6 +101,7 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 		Site:             site,
 		ProjectRoot:      projectRoot,
 		PreprocessStyle:  preprocessStyle,
+		ExternalScoping:  externalScoping,
 		StaticExtraction: staticExtraction,
 	}
 }
@@ -129,7 +135,7 @@ func preprocessStyle(i int, style *astro.Node, transformOptions transform.Transf
 		return
 	}
 	attrs := wasm_utils.GetAttrs(style)
-	data, _ := wasm_utils.Await(transformOptions.PreprocessStyle.(js.Value).Invoke(style.FirstChild.Data, attrs))
+	data, _ := wasm_utils.Await(transformOptions.PreprocessStyle.(js.Value).Invoke(style.FirstChild.Data, attrs, transformOptions))
 	// note: Rollup (and by extension our Astro Vite plugin) allows for "undefined" and "null" responses if a transform wishes to skip this occurrence
 	if data[0].Equal(js.Undefined()) || data[0].Equal(js.Null()) {
 		return

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -20,11 +20,12 @@ type TransformOptions struct {
 	Site             string
 	ProjectRoot      string
 	PreprocessStyle  interface{}
+	ExternalScoping  bool
 	StaticExtraction bool
 }
 
 func Transform(doc *astro.Node, opts TransformOptions) *astro.Node {
-	shouldScope := len(doc.Styles) > 0 && ScopeStyle(doc.Styles, opts)
+	shouldScope := opts.ExternalScoping || len(doc.Styles) > 0 && ScopeStyle(doc.Styles, opts)
 	walk(doc, func(n *astro.Node) {
 		ExtractScript(doc, n)
 		AddComponentProps(doc, n)


### PR DESCRIPTION
## Changes

- Provides short path to fixing CSS parsing issues.
- Provides short path to supporting container queries.
- This allows external style scoping with an `externalScoping` flag.
- Passes `transformOptions` to `preprocessStyle`, which should allow PostCSS to apply the styling.

## Testing

help needed

## Docs

help needed