### PR TITLE
Fixes hoisted scripts passed a variable

### DIFF
--- a/.changeset/wise-elephants-kiss.md
+++ b/.changeset/wise-elephants-kiss.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes hoist script tracking when passed a variable

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -86,7 +86,9 @@ func (p *printer) printCSSImports(cssLen int) {
 		p.print(fmt.Sprintf("import \"%s?astro&type=style&index=%v&lang.css\";", p.opts.Filename, i))
 		i++
 	}
-	p.print("\n")
+	if cssLen > 0 {
+		p.print("\n")
+	}
 	p.hasCSSImports = true
 }
 
@@ -448,9 +450,16 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 			p.print(", ")
 		}
 
-		src := astro.GetAttribute(node, "src")
-		if src != nil {
-			p.print(fmt.Sprintf("{ type: 'remote', src: '%s' }", escapeSingleQuote(src.Val)))
+		srcAttr := astro.GetAttribute(node, "src")
+		if srcAttr != nil {
+			var src string
+			switch srcAttr.Type {
+			case astro.ExpressionAttribute:
+				src = srcAttr.Val
+			default:
+				src = fmt.Sprintf("'%s'", escapeSingleQuote(srcAttr.Val))
+			}
+			p.print(fmt.Sprintf("{ type: 'remote', src: %s }", src))
 		} else if node.FirstChild != nil {
 			p.print(fmt.Sprintf("{ type: 'inline', value: `%s` }", escapeInterpolation(escapeBackticks(node.FirstChild.Data))))
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1676,6 +1676,23 @@ const items = ["Dog", "Cat", "Platipus"];
 				},
 			},
 		},
+		{
+			name: "hoisted script taking a var",
+			source: `---
+
+import scriptUrl from '../scripts/script.js?url';
+---
+<script type="module" src={scriptUrl} hoist></script>`,
+			staticExtraction: true,
+			want: want{
+				code:        `<html><head></head><body></body></html>`,
+				frontmatter: []string{`import scriptUrl from '../scripts/script.js?url';`},
+				metadata: metadata{
+					modules: []string{`{ module: $$module1, specifier: '../scripts/script.js?url', assert: {} }`},
+					hoisted: []string{"{ type: 'remote', src: scriptUrl }"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- The static build uses the hoisted metadata to track which hoisted scripts are part of a page, in order to build them.
- This fixes it so that expressions are passed as the variable and not quoted.
- Part of https://github.com/withastro/astro/issues/2604

## Testing

Test added

## Docs

N/A
