### PR TITLE
Revert "Fixes hoisted scripts passed a variable (#295)"

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -86,9 +86,7 @@ func (p *printer) printCSSImports(cssLen int) {
 		p.print(fmt.Sprintf("import \"%s?astro&type=style&index=%v&lang.css\";", p.opts.Filename, i))
 		i++
 	}
-	if cssLen > 0 {
-		p.print("\n")
-	}
+	p.print("\n")
 	p.hasCSSImports = true
 }
 
@@ -450,16 +448,9 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 			p.print(", ")
 		}
 
-		srcAttr := astro.GetAttribute(node, "src")
-		if srcAttr != nil {
-			var src string
-			switch srcAttr.Type {
-			case astro.ExpressionAttribute:
-				src = srcAttr.Val
-			default:
-				src = fmt.Sprintf("'%s'", escapeSingleQuote(srcAttr.Val))
-			}
-			p.print(fmt.Sprintf("{ type: 'remote', src: %s }", src))
+		src := astro.GetAttribute(node, "src")
+		if src != nil {
+			p.print(fmt.Sprintf("{ type: 'remote', src: '%s' }", escapeSingleQuote(src.Val)))
 		} else if node.FirstChild != nil {
 			p.print(fmt.Sprintf("{ type: 'inline', value: `%s` }", escapeInterpolation(escapeBackticks(node.FirstChild.Data))))
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1676,23 +1676,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				},
 			},
 		},
-		{
-			name: "hoisted script taking a var",
-			source: `---
-
-import scriptUrl from '../scripts/script.js?url';
----
-<script type="module" src={scriptUrl} hoist></script>`,
-			staticExtraction: true,
-			want: want{
-				code:        `<html><head></head><body></body></html>`,
-				frontmatter: []string{`import scriptUrl from '../scripts/script.js?url';`},
-				metadata: metadata{
-					modules: []string{`{ module: $$module1, specifier: '../scripts/script.js?url', assert: {} }`},
-					hoisted: []string{"{ type: 'remote', src: scriptUrl }"},
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This reverts commit 403968241da36dcae94b3941bb7d33d2fce083ec.

## Changes

- This change has adverse affects when passing `Astro.resolve()` into a hoisted script that we do not want to break, yet.

## Testing

Just a revert.

## Docs

Just a revert.