### PR TITLE
Handle self-closing raw elements

### DIFF
--- a/.changeset/moody-horses-greet.md
+++ b/.changeset/moody-horses-greet.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/compiler': patch
+---
+
+Reset tokenizer state when a raw element that is self-closing is encountered. 
+
+This fixes the handling of self-closing elements like `<title />` and `<script />` when used with `set:html`.

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -921,6 +921,20 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 			},
 		},
 		{
+			name:   "Self-closing title",
+			source: `<title />`,
+			want: want{
+				code: `<html><head><title></title></head><body></body></html>`,
+			},
+		},
+		{
+			name:   "Self-closing title II",
+			source: `<html><head><title /></head><body></body></html>`,
+			want: want{
+				code: `<html><head><title></title></head><body></body></html>`,
+			},
+		},
+		{
 			name:   "Self-closing components in head can have siblings",
 			source: `<html><head><BaseHead /><link href="test"></head><html>`,
 			want: want{

--- a/internal/token.go
+++ b/internal/token.go
@@ -991,10 +991,18 @@ func (z *Tokenizer) readStartTag() TokenType {
 	// HTML void tags list: https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#syntax-elements
 	// Note: self-closing tags in SVG and MathML work differently; handled below
 	if z.startTagIn("area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr") {
+		// Reset tokenizer state for self-closing elements
+		z.rawTag = ""
+		z.noExpressionTag = ""
+		z.openBraceIsExpressionStart = true
 		return SelfClosingTagToken
 	}
 	// Look for a self-closing token that’s not in the list above (e.g. "<svg><path/></svg>")
 	if z.err == nil && z.buf[z.raw.End-2] == '/' {
+		// Reset tokenizer state for self-closing elements
+		z.rawTag = ""
+		z.noExpressionTag = ""
+		z.openBraceIsExpressionStart = true
 		return SelfClosingTagToken
 	}
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -60,6 +60,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{SelfClosingTagToken},
 		},
 		{
+			"self-closing title",
+			`<title set:html={} /><div></div>`,
+			[]TokenType{SelfClosingTagToken, StartTagToken, EndTagToken},
+		},
+		{
 			"self-closing tag (no slash)",
 			`<img width="480" height="320">`,
 			[]TokenType{SelfClosingTagToken},


### PR DESCRIPTION
## Changes

- Fixes our handling of elements like `<title />` and `<script />`.
- These cases were very unlikely before, but with the introduction of `set:text` and `set:html` they are much more likely.
- This was a change needed in the tokenizer because `<title />` would read everything following as raw text since it never encountered a closing `</title>` tag.

## Testing

Tests added

## Docs

Bug fix only