### PR TITLE
Warn when using an expression on hoist `src` attr

### DIFF
--- a/.changeset/unlucky-swans-destroy.md
+++ b/.changeset/unlucky-swans-destroy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Adds a warning when using an expression with a hoisted script

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -154,7 +154,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 					if attr.Type == astro.ExpressionAttribute {
 						if opts.StaticExtraction {
 							shouldAdd = false
-							fmt.Printf("%s: <script hoist> uses the expression {%s} on the src attribute and will be ignore. Use a static string on the src attribute instead.\n", opts.Filename, attr.Val)
+							fmt.Printf("%s: <script hoist> uses the expression {%s} on the src attribute and will be ignored. Use a string literal on the src attribute instead.\n", opts.Filename, attr.Val)
 						}
 						break
 					}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -25,7 +25,7 @@ type TransformOptions struct {
 func Transform(doc *astro.Node, opts TransformOptions) *astro.Node {
 	shouldScope := len(doc.Styles) > 0 && ScopeStyle(doc.Styles, opts)
 	walk(doc, func(n *astro.Node) {
-		ExtractScript(doc, n)
+		ExtractScript(doc, n, &opts)
 		AddComponentProps(doc, n)
 		if shouldScope {
 			ScopeElement(n, opts)
@@ -140,7 +140,7 @@ func NormalizeSetDirectives(doc *astro.Node) {
 // 	}
 // }
 
-func ExtractScript(doc *astro.Node, n *astro.Node) {
+func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Script {
 		if HasSetDirective(n) {
 			return
@@ -148,8 +148,23 @@ func ExtractScript(doc *astro.Node, n *astro.Node) {
 		// if <script hoist>, hoist to the document root
 		// If also using define:vars, that overrides the hoist tag.
 		if hasTruthyAttr(n, "hoist") && !HasAttr(n, "define:vars") {
+			shouldAdd := true
+			for _, attr := range n.Attr {
+				if attr.Key == "src" {
+					if attr.Type == astro.ExpressionAttribute {
+						if opts.StaticExtraction {
+							shouldAdd = false
+							fmt.Printf("%s: <script hoist> uses the expression {%s} on the src attribute and will be ignore. Use a static string on the src attribute instead.\n", opts.Filename, attr.Val)
+						}
+						break
+					}
+				}
+			}
+
 			// prepend node to maintain authored order
-			doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
+			if shouldAdd {
+				doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
+			}
 		}
 	}
 }

--- a/lib/compiler/test/hoist-expression.test.mjs
+++ b/lib/compiler/test/hoist-expression.test.mjs
@@ -1,0 +1,20 @@
+/* eslint-disable no-console */
+import { transform } from '@astrojs/compiler';
+
+async function run() {
+  const result = await transform(
+    `---
+const url = 'foo';
+---
+<script type="module" hoist src={url}></script>`,
+    {
+      sourcefile: 'src/pages/index.astro',
+      sourcemap: true,
+      experimentalStaticExtraction: true
+    }
+  );
+
+  console.assert(result);
+}
+
+await run();

--- a/lib/compiler/test/hoist-expression.test.mjs
+++ b/lib/compiler/test/hoist-expression.test.mjs
@@ -10,7 +10,7 @@ const url = 'foo';
     {
       sourcefile: 'src/pages/index.astro',
       sourcemap: true,
-      experimentalStaticExtraction: true
+      experimentalStaticExtraction: true,
     }
   );
 


### PR DESCRIPTION
## Changes

- Adds a warning when doing `<script hoist src={expr}></script>`.
- That's because we need to statically resolve these, explained here: https://github.com/withastro/astro/issues/2648

## Testing

mjs test added

## Docs

N/A