### PR TITLE
Update AST to include `fragment`

### DIFF
--- a/.changeset/afraid-elephants-live.md
+++ b/.changeset/afraid-elephants-live.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add `fragment` node types to AST definitions, expose Fragment helper to utils

--- a/lib/compiler/browser/utils.ts
+++ b/lib/compiler/browser/utils.ts
@@ -5,6 +5,7 @@ import {
   ElementNode,
   CustomElementNode,
   ComponentNode,
+  FragmentNode,
   LiteralNode,
   ExpressionNode,
   TextNode,
@@ -29,7 +30,7 @@ export const is = {
     return typeof (node as any).value === 'string';
   },
   tag(node: Node): node is ElementNode | CustomElementNode | ComponentNode {
-    return node.type === 'element' || node.type === 'custom-element' || node.type === 'component';
+    return node.type === 'element' || node.type === 'custom-element' || node.type === 'component' || node.type === 'fragment';
   },
   whitespace(node: Node): node is TextNode {
     return node.type === 'text' && node.value.trim().length === 0;
@@ -38,6 +39,7 @@ export const is = {
   element: guard<ElementNode>('element'),
   customElement: guard<CustomElementNode>('custom-element'),
   component: guard<ComponentNode>('component'),
+  fragment: guard<FragmentNode>('fragment'),
   expression: guard<ExpressionNode>('expression'),
   text: guard<TextNode>('text'),
   doctype: guard<DoctypeNode>('doctype'),

--- a/lib/compiler/node/utils.ts
+++ b/lib/compiler/node/utils.ts
@@ -5,6 +5,7 @@ import {
   ElementNode,
   CustomElementNode,
   ComponentNode,
+  FragmentNode,
   LiteralNode,
   ExpressionNode,
   TextNode,
@@ -29,7 +30,7 @@ export const is = {
     return typeof (node as any).value === 'string';
   },
   tag(node: Node): node is ElementNode | CustomElementNode | ComponentNode {
-    return node.type === 'element' || node.type === 'custom-element' || node.type === 'component';
+    return node.type === 'element' || node.type === 'custom-element' || node.type === 'component' || node.type === 'fragment';
   },
   whitespace(node: Node): node is TextNode {
     return node.type === 'text' && node.value.trim().length === 0;
@@ -38,6 +39,7 @@ export const is = {
   element: guard<ElementNode>('element'),
   customElement: guard<CustomElementNode>('custom-element'),
   component: guard<ComponentNode>('component'),
+  fragment: guard<FragmentNode>('fragment'),
   expression: guard<ExpressionNode>('expression'),
   text: guard<TextNode>('text'),
   doctype: guard<DoctypeNode>('doctype'),

--- a/lib/compiler/shared/ast.ts
+++ b/lib/compiler/shared/ast.ts
@@ -1,5 +1,5 @@
-export type ParentNode = RootNode | ElementNode | ComponentNode | CustomElementNode | ExpressionNode;
-export type Node = RootNode | ElementNode | ComponentNode | CustomElementNode | ExpressionNode | TextNode | FrontmatterNode | DoctypeNode | CommentNode;
+export type ParentNode = RootNode | ElementNode | ComponentNode | CustomElementNode | FragmentNode | ExpressionNode;
+export type Node = RootNode | ElementNode | ComponentNode | CustomElementNode | FragmentNode | ExpressionNode | TextNode | FrontmatterNode | DoctypeNode | CommentNode;
 
 export interface Position {
   start: Point;
@@ -19,7 +19,7 @@ export interface BaseNode {
 }
 
 export interface ParentLikeNode extends BaseNode {
-  type: 'element' | 'component' | 'custom-element' | 'expression' | 'root';
+  type: 'element' | 'component' | 'custom-element' | 'fragment' | 'expression' | 'root';
   children: Node[];
 }
 
@@ -49,6 +49,13 @@ export interface TextNode extends LiteralNode {
 
 export interface ElementNode extends ParentLikeNode {
   type: 'element';
+  name: string;
+  attributes: AttributeNode[];
+  directives: DirectiveNode[];
+}
+
+export interface FragmentNode extends ParentLikeNode {
+  type: 'fragment';
   name: string;
   attributes: AttributeNode[];
   directives: DirectiveNode[];


### PR DESCRIPTION
## Changes

- Updates the `parse` AST utils to include `fragment` guard
- Adds `FragmentNode` interface definition

## Testing

N/A, type change only

## Docs

N/A
