### PR TITLE
Improve `renderHead` behavior

### DIFF
--- a/.changeset/quick-lamps-stare.md
+++ b/.changeset/quick-lamps-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve head injection behavior

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -37,7 +37,6 @@ var ADD_ATTRIBUTE = "$$addAttribute"
 var SPREAD_ATTRIBUTES = "$$spreadAttributes"
 var DEFINE_STYLE_VARS = "$$defineStyleVars"
 var DEFINE_SCRIPT_VARS = "$$defineScriptVars"
-var RENDER_HEAD = "$$renderHead"
 var CREATE_METADATA = "$$createMetadata"
 var METADATA = "$$metadata"
 var RESULT = "$$result"
@@ -60,7 +59,6 @@ func (p *printer) printInternalImports(importSpecifier string) {
 	p.print("import {\n  ")
 	p.print(FRAGMENT + ",\n  ")
 	p.print("render as " + TEMPLATE_TAG + ",\n  ")
-	p.print("renderHead as " + RENDER_HEAD + ",\n  ")
 	p.print("createAstro as " + CREATE_ASTRO + ",\n  ")
 	p.print("createComponent as " + CREATE_COMPONENT + ",\n  ")
 	p.print("renderComponent as " + RENDER_COMPONENT + ",\n  ")
@@ -94,7 +92,7 @@ func (p *printer) printCSSImports(cssLen int) {
 
 func (p *printer) printRenderHead() {
 	p.addNilSourceMapping()
-	p.print(fmt.Sprintf("${%s(%s)}", RENDER_HEAD, RESULT))
+	p.print("<!--astro:head-->")
 }
 
 func (p *printer) printReturnOpen() {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -17,7 +17,6 @@ import (
 var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.Join([]string{
 	FRAGMENT,
 	"render as " + TEMPLATE_TAG,
-	"renderHead as " + RENDER_HEAD,
 	"createAstro as " + CREATE_ASTRO,
 	"createComponent as " + CREATE_COMPONENT,
 	"renderComponent as " + RENDER_COMPONENT,
@@ -43,7 +42,7 @@ var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE);\
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
 var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT);\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
-var RENDER_HEAD_RESULT = fmt.Sprintf("${%s(%s)}", RENDER_HEAD, RESULT)
+var RENDER_HEAD_RESULT = "<!--astro:head-->"
 
 // SPECIAL TEST FIXTURES
 var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[];:'\",.?")
@@ -98,7 +97,7 @@ func TestPrinter(t *testing.T) {
 			name:   "basic renderHead",
 			source: `<html><head><title>Ah</title></head></html>`,
 			want: want{
-				code: `<html><head><title>Ah</title>${$$renderHead($$result)}</head></html>`,
+				code: `<html><head><title>Ah</title>` + RENDER_HEAD_RESULT + `</head></html>`,
 			},
 		},
 		{
@@ -953,7 +952,7 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 			name:   "Self-closing title II",
 			source: `<html><head><title /></head><body></body></html>`,
 			want: want{
-				code: `<html><head><title></title>${$$renderHead($$result)}</head><body></body></html>`,
+				code: `<html><head><title></title>` + RENDER_HEAD_RESULT + `</head><body></body></html>`,
 			},
 		},
 		{
@@ -1755,7 +1754,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			transform.ExtractStyles(doc)
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
-				Scope:            "astro-XXXX",
+				Scope:            "XXXX",
 				Site:             "https://astro.build",
 				InternalURL:      "http://localhost:3000/",
 				ProjectRoot:      ".",

--- a/lib/compiler/test/render-head.test.mjs
+++ b/lib/compiler/test/render-head.test.mjs
@@ -15,9 +15,13 @@ async function run() {
     },
   });
 
-  if (!result.code.includes('$$renderHead(')) {
-    console.log(result.code);
-    throw new Error('Result did not include $$renderHead(');
+  if (!result.scope) {
+    throw new Error(`Result did not include a scope`);
+  }
+
+  console.log(result.code);
+  if (!result.code.includes(`<!--astro:head-->`)) {
+    throw new Error('Result did not include <!--astro:head--> placeholder');
   }
 }
 

--- a/lib/compiler/test/render-head.test.mjs
+++ b/lib/compiler/test/render-head.test.mjs
@@ -15,10 +15,6 @@ async function run() {
     },
   });
 
-  if (!result.scope) {
-    throw new Error(`Result did not include a scope`);
-  }
-
   console.log(result.code);
   if (!result.code.includes(`<!--astro:head-->`)) {
     throw new Error('Result did not include <!--astro:head--> placeholder');


### PR DESCRIPTION
## Changes

- Previously, we injected a `renderHead` util inline. This only worked sometimes because we `Promise.all()` the children and there was a race condition.
- Now, the compiler injects a `<!--astro:head-->` placeholder which can be swapped out at render time.

## Testing

Test added. Also tested manually in monorepo.

## Docs

N/A
