### PR TITLE
Move `typescript` dependency to development dependencies

### DIFF
--- a/.changeset/rare-snakes-heal.md
+++ b/.changeset/rare-snakes-heal.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Move `typescript` dependency to development dependencies, as it is not needed in the package runtime.

--- a/lib/compiler/package.json
+++ b/lib/compiler/package.json
@@ -23,11 +23,9 @@
     },
     "./astro.wasm": "./astro.wasm"
   },
-  "dependencies": {
-    "typescript": "^4.3.5"
-  },
   "devDependencies": {
-    "@types/node": "^16.4.12"
+    "@types/node": "^16.4.12",
+    "typescript": "^4.4.3"
   },
   "volta": {
     "node": "16.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5340,7 +5340,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.3.5:
+typescript@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==


### PR DESCRIPTION
## Changes

Move TS to devDependencies, shouldn't be needed as a production dependency for the compiler.

## Testing

Tested by running `yarn build` in lib/compiler, not sure if more is needed.

## Docs

Internal dependency change only.
