### PR TITLE
Do not escape `&` characters

### DIFF
--- a/.changeset/two-lobsters-report.md
+++ b/.changeset/two-lobsters-report.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Parse: fix escaping of `&` characters in AST output

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -41,8 +41,6 @@ func escapeForJSON(value string) string {
 	value = newlines.ReplaceAllString(value, `\n`)
 	doublequotes := regexp.MustCompile(`"`)
 	value = doublequotes.ReplaceAllString(value, `\"`)
-	amp := regexp.MustCompile(`&`)
-	value = amp.ReplaceAllString(value, `\&`)
 	r := regexp.MustCompile(`\r`)
 	value = r.ReplaceAllString(value, `\r`)
 	t := regexp.MustCompile(`\t`)

--- a/lib/compiler/test/parse/escaping.ts
+++ b/lib/compiler/test/parse/escaping.ts
@@ -1,0 +1,19 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { parse } from '@astrojs/compiler';
+
+const STYLE = `div { & span { color: red; }}`;
+const FIXTURE = `<style>${STYLE}</style>`;
+
+test('ampersand', async () => {
+  const result = await parse(FIXTURE);
+  assert.ok(result.ast, 'Expected an AST to be generated');
+  const [
+    {
+      children: [{ value: output }],
+    },
+  ] = result.ast.children;
+  assert.equal(output, STYLE, `Expected AST style to equal input`);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Fixes `parse` output by not escaping `&` characters
- Unblocks the Prettier plugin

## Testing

Test added

## Docs

Bug fix only
