### PR TITLE
Properly handle RegExp literals in `js_scanner`

### DIFF
--- a/.changeset/wise-scissors-raise.md
+++ b/.changeset/wise-scissors-raise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of RegExp literals in frontmatter

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/norunners/vert v0.0.0-20210320050952-39b24b3cdf94
-	github.com/tdewolff/parse/v2 v2.5.22
+	github.com/tdewolff/parse/v2 v2.5.27
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/natemoo-re/vert v0.0.0-natemoo-re.8 h1:RCxCOL0e2bvB0wrmF/77X8/uewz/K7
 github.com/natemoo-re/vert v0.0.0-natemoo-re.8/go.mod h1:67MuD9cDWe6pmhyQrElFlSNMMzL0CMUdFURKxJSvxUM=
 github.com/tdewolff/parse/v2 v2.5.22 h1:KXMHTyx4VTL6Zu9a94SULQalDMvtP5FQq10mnSfaoGs=
 github.com/tdewolff/parse/v2 v2.5.22/go.mod h1:WzaJpRSbwq++EIQHYIRTpbYKNA3gn9it1Ik++q4zyho=
+github.com/tdewolff/parse/v2 v2.5.27 h1:PL3LzzXaOpmdrknnOlIeO2muIBHAwiKp6TxN1RbU5gI=
+github.com/tdewolff/parse/v2 v2.5.27/go.mod h1:WzaJpRSbwq++EIQHYIRTpbYKNA3gn9it1Ik++q4zyho=
 github.com/tdewolff/test v1.0.6 h1:76mzYJQ83Op284kMT+63iCNCI7NEERsIN8dLM+RiKr4=
 github.com/tdewolff/test v1.0.6/go.mod h1:6DAvZliBAAnD7rhVgwaM7DE5/d9NMOAJ09SqYqeK4QE=
 golang.org/x/net v0.0.0-20210716203947-853a461950ff h1:j2EK/QoxYNBsXI4R7fQkkRUk8y6wnOBI+6hgPdP/6Ds=

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -28,9 +28,6 @@ func FindRenderBody(source []byte) int {
 		}
 		openPairs := pairs['{'] > 0 || pairs['('] > 0 || pairs['['] > 0
 		if token == js.ErrorToken {
-			if l.Err() != io.EOF {
-				return -1
-			}
 			break
 		}
 

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -23,8 +23,10 @@ func FindRenderBody(source []byte) int {
 	// Let's lex the script until we find what we need!
 	for {
 		token, value := l.Next()
+		if token == js.DivToken || token == js.DivEqToken {
+			token, value = l.RegExp()
+		}
 		openPairs := pairs['{'] > 0 || pairs['('] > 0 || pairs['['] > 0
-
 		if token == js.ErrorToken {
 			if l.Err() != io.EOF {
 				return -1
@@ -46,6 +48,12 @@ func FindRenderBody(source []byte) int {
 			foundAssertion := false
 			for {
 				next, nextValue := l.Next()
+				if token == js.DivToken || token == js.DivEqToken {
+					next, nextValue = l.RegExp()
+				}
+				if next == js.ErrorToken {
+					break
+				}
 				i += len(nextValue)
 				if next == js.StringToken {
 					foundSpecifier = true
@@ -79,6 +87,12 @@ func FindRenderBody(source []byte) int {
 			i += len(value)
 			for {
 				next, nextValue := l.Next()
+				if next == js.DivToken || next == js.DivEqToken {
+					next, nextValue = l.RegExp()
+				}
+				if next == js.ErrorToken {
+					break
+				}
 				i += len(nextValue)
 				if js.IsIdentifier(next) {
 					foundIdentifier = true

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -140,6 +140,26 @@ export async function getStaticPaths() {
 }`,
 		},
 		{
+			name: "getStaticPaths with divider",
+			source: `export async function getStaticPaths() {
+  const pattern = a / b;
+}`,
+			want: `export async function getStaticPaths() {
+  const pattern = a / b;
+}`,
+		},
+		{
+			name: "getStaticPaths with divider and following content",
+			source: `export async function getStaticPaths() {
+  const value = 1 / 2;
+}
+const { a } = Astro.props;`,
+			want: `export async function getStaticPaths() {
+  const value = 1 / 2;
+}
+`,
+		},
+		{
 			name: "multiple imports",
 			source: `import { a } from "a";
 import { b } from "b";

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -131,6 +131,15 @@ export async function getStaticPaths() {
 }; `,
 		},
 		{
+			name: "getStaticPaths with RegExp escape",
+			source: `export async function getStaticPaths() {
+  const pattern = /\.md$/g.test('value');
+}`,
+			want: `export async function getStaticPaths() {
+  const pattern = /\.md$/g.test('value');
+}`,
+		},
+		{
 			name: "multiple imports",
 			source: `import { a } from "a";
 import { b } from "b";
@@ -149,7 +158,7 @@ import { c } from "c";
 		{
 			name: "RegExp is not a comment",
 			source: `import { a } from "a";
-/import { b } from "b";
+/import \{ b \} from "b";/;
 import { c } from "c";`,
 			want: `import { a } from "a";
 `,

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -526,6 +526,16 @@ const RegExp = /---< > > { }; import thing from "thing"; /
 			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, FrontmatterFenceToken, TextToken, StartExpressionToken, TextToken, EndExpressionToken},
 		},
 		{
+			"RegExp with Escape",
+			`---
+export async function getStaticPaths() {
+  const pattern = /\.md$/g;
+}
+---
+<div />`,
+			[]TokenType{FrontmatterFenceToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, FrontmatterFenceToken, SelfClosingTagToken},
+		},
+		{
 			"textarea",
 			`<textarea>{html}</textarea>`,
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken},


### PR DESCRIPTION
## Changes

- Fixes #323! For real this time.
- Turns out JS tokenization needs some context to properly tokenize RegExp literals (`/=/` or `/a/` or `/\./`)
- We weren't handling these properly, because we needed to call `l.RegExp()` to walk the tokenizer back and reconsume the following content as RegExp.

## Testing

- Added tests for reported issue, no longer hangs and works as expected
- Added test to ensure there wasn't a regression if `/` was not a RegExp literal but just division.

## Docs

Bug fix only
