### PR TITLE
Do not switch to `inBodyIM` when encountering slots in the `head`

### DIFF
--- a/.changeset/khaki-bulldogs-reflect.md
+++ b/.changeset/khaki-bulldogs-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix issue with named slots in <head> element

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -776,7 +776,6 @@ func inHeadIM(p *parser) bool {
 		case a.Slot:
 			p.addElement()
 			p.setOriginalIM()
-			p.im = inBodyIM
 			if p.hasSelfClosingToken {
 				p.addLoc()
 				p.oe.pop()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -107,6 +107,13 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "head slot II",
+			source: `<html><head><slot /></head><body class="a"></body></html>`,
+			want: want{
+				code: `<html><head>${$$renderSlot($$result,$$slots["default"])}` + RENDER_HEAD_RESULT + `</head><body class="a"></body></html>`,
+			},
+		},
+		{
 			name: "basic (frontmatter)",
 			source: `---
 const href = '/about';


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/2951, fixes https://github.com/withastro/astro/issues/2904
- We had a bug in the logic that handled inserting a `slot` inside of the `head` element.
- This PR fixes the bug by not switching the parser to `inBodyIM`, but keeping the parser in `inHeadIM` after encountering a `slot` element.

## Testing

Test added

## Docs

Bug fix only
