### PR TITLE
fix(#343): orphan table elements in body

### DIFF
--- a/.changeset/slow-dragons-deliver.md
+++ b/.changeset/slow-dragons-deliver.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix #343, edge case with <tr> inside component

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1365,8 +1365,6 @@ func inBodyIM(p *parser) bool {
 				p.im = inHeadIM
 				return true
 			}
-		case a.Caption, a.Col, a.Colgroup, a.Frame, a.Tbody, a.Td, a.Tfoot, a.Th, a.Thead, a.Tr:
-			// Ignore the token.
 		default:
 			p.reconstructActiveFormattingElements()
 			p.addElement()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1500,6 +1500,20 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "tr only",
+			source: `<tr><td>col 1</td><td>col 2</td><td>{foo}</td></tr>`,
+			want: want{
+				code: `<tr><td>col 1</td><td>col 2</td><td>${foo}</td></tr>`,
+			},
+		},
+		{
+			name:   "caption only",
+			source: `<caption>Hello world!</caption>`,
+			want: want{
+				code: `<caption>Hello world!</caption>`,
+			},
+		},
+		{
 			name:   "anchor expressions",
 			source: `<a>{expr}</a>`,
 			want: want{


### PR DESCRIPTION
## Changes

- Previously, `<tr>` (and a few others) at the top level would not be printed.
- Now they will. Removed code that ignored these elements.
- Closes #343, #351

## Testing

Test added

## Docs

Bug fix only
