### PR TITLE
fix(#340): reset insertion mode on invalid tags when inSelectIM

### DIFF
--- a/.changeset/popular-toys-cough.md
+++ b/.changeset/popular-toys-cough.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix #340, fixing behavior of content after an expression inside of <select>

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2156,6 +2156,8 @@ func inSelectIM(p *parser) bool {
 			p.tokenizer.NextIsNotRawText()
 			// Ignore the token.
 			return true
+		default:
+			return inBodyIM(p)
 		}
 	case EndTagToken:
 		switch p.tok.DataAtom {
@@ -2195,7 +2197,7 @@ func inSelectIM(p *parser) bool {
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()
-		return true
+		return inBodyIM(p)
 	case DoctypeToken:
 		// Ignore the token.
 		return true

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1435,6 +1435,13 @@ const value = 'test';
 			},
 		},
 		{
+			name:   "select map expression",
+			source: `<select>{[1, 2, 3].map(num => <option>{num}</option>)}</select><div>Hello world!</div>`,
+			want: want{
+				code: `<select>${[1, 2, 3].map(num => $$render` + BACKTICK + `<option>${num}</option>` + BACKTICK + `)}</select><div>Hello world!</div>`,
+			},
+		},
+		{
 			name: "textarea",
 			source: `---
 const value = 'test';

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -337,6 +337,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
 		},
 		{
+			"select with expression",
+			`<select>{[1, 2, 3].map(num => <option>{num}</option>)}</select>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, EndTagToken},
+		},
+		{
 			"Markdown codeblock",
 			fmt.Sprintf(`<Markdown>
 		%s%s%s


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/compiler/issues/340
- Markup after `inSelectIM` would be ignored. Now we switch back to `inBodyIM` when we encounter any unhandled element.

## Testing

Tests updated

## Docs

Bug fix only