### PR TITLE
Fix: keep explicit Component passing for `client:only`

### DIFF
--- a/.changeset/old-oranges-doubt.md
+++ b/.changeset/old-oranges-doubt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+For client:only components, keep passing Component to renderComponent for JS printer

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -330,7 +330,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 	isFragment := n.Fragment
 	isComponent := isFragment || n.Component || n.CustomElement
-	isClientOnly := isComponent && transform.HasAttr(n, "client:only")
 	isSlot := n.DataAtom == atom.Slot
 	isImplicit := false
 	for _, a := range n.Attr {

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -359,8 +359,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	switch true {
 	case isFragment:
 		p.print("Fragment")
-	case isClientOnly:
-		p.print("null")
 	case !isSlot && n.CustomElement:
 		p.print(fmt.Sprintf("'%s'", n.Data))
 	case !isSlot && !isImplicit:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -323,7 +323,7 @@ import Component from '../components';
     <title>Hello world</title>
   ` + RENDER_HEAD_RESULT + `</head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+    ${` + RENDER_COMPONENT + `($$result,'Component',Component,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
   </body></html>`,
 			},
 		},
@@ -352,7 +352,7 @@ import { Component } from '../components';
     <title>Hello world</title>
   ` + RENDER_HEAD_RESULT + `</head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"Component"})}
+    ${` + RENDER_COMPONENT + `($$result,'Component',Component,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"Component"})}
   </body></html>`,
 			},
 		},
@@ -381,7 +381,7 @@ import * as components from '../components';
     <title>Hello world</title>
   ` + RENDER_HEAD_RESULT + `</head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'components.A',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"A"})}
+    ${` + RENDER_COMPONENT + `($$result,'components.A',components.A,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"A"})}
   </body></html>`,
 			},
 		},
@@ -412,9 +412,9 @@ import Component from '../components';
     <title>Hello world</title>
   ` + RENDER_HEAD_RESULT + `</head>
   <body>
-    ${` + RENDER_COMPONENT + `($$result,'Component',null,{"test":"a","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
-	${` + RENDER_COMPONENT + `($$result,'Component',null,{"test":"b","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
-	${` + RENDER_COMPONENT + `($$result,'Component',null,{"test":"c","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+    ${` + RENDER_COMPONENT + `($$result,'Component',Component,{"test":"a","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+	${` + RENDER_COMPONENT + `($$result,'Component',Component,{"test":"b","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+	${` + RENDER_COMPONENT + `($$result,'Component',Component,{"test":"c","client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
   </body></html>`,
 			},
 		},


### PR DESCRIPTION
## Changes
- resolves issue logged in Astro core: https://github.com/withastro/astro/issues/2966
- for `client:only` components, keep passing the `Component` to the `renderComponent` function instead of stubbing as `null`. This preserves the Component import at the top of the file for static analysis by rollup. Verified this doesn't break any `client:only` behavior like accessing the global `window`

## Testing

Updated unit tests for `client:only` JS printer

## Docs

N/A
