### PR TITLE
Add support for comment block only expressions and comment blocks in attributes and props

### DIFF
--- a/.changeset/rude-bulldogs-listen.md
+++ b/.changeset/rude-bulldogs-listen.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Add support for commenting out attributes or props with `//` or `/* */`
+Add support for block comment only expressions and block comments in element attributes/props

--- a/.changeset/rude-bulldogs-listen.md
+++ b/.changeset/rude-bulldogs-listen.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Add support for block comment only expressions and block comments in element attributes/props
+Add support for block comment only expressions, block comment only shorthand attributes and block comments in shorthand attributes

--- a/.changeset/rude-bulldogs-listen.md
+++ b/.changeset/rude-bulldogs-listen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add support for commenting out attributes or props with `//` or `/* */`

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -291,7 +291,7 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 			p.print(strings.TrimSpace(attr.Val))
 		}
 		p.addSourceMapping(attr.KeyLoc)
-		p.print(`, "` + removeComments(attr.Key) + `")}`)
+		p.print(`, "` + strings.TrimSpace(attr.Key) + `")}`)
 	case astro.SpreadAttribute:
 		p.print(fmt.Sprintf("${%s(", SPREAD_ATTRIBUTES))
 		p.addSourceMapping(loc.Loc{Start: attr.KeyLoc.Start - 3})

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1829,8 +1829,8 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "comment blocks are removed",
-			source: `<h1>{/* a comment */}Hello</h1>`,
+			name:   "comment only expressions are removed",
+			source: `{/* a comment 1 */}<h1>{/* a comment 2*/}Hello</h1>`,
 			want: want{
 				code: `<h1>Hello</h1>`,
 			},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1807,6 +1807,34 @@ const items = ["Dog", "Cat", "Platipus"];
 				},
 			},
 		},
+		{
+			name:   "comments removed from attribute list",
+			source: `<div><h1 {/* comment 1 */} value="1" {/* comment 2 */}>Hello</h1><Component {/* comment 1 */} value="1" {/* comment 2 */} /></div>`,
+			want: want{
+				code: `<div><h1 value="1">Hello</h1>${$$renderComponent($$result,'Component',Component,{"value":"1",})}</div>`,
+			},
+		},
+		{
+			name:   "includes comments for shorthand attribute",
+			source: `<div><h1 {/* comment 1 */ id /* comment 2 */}>Hello</h1><Component {/* comment 1 */ id /* comment 2 */}/></div>`,
+			want: want{
+				code: `<div><h1${$$addAttribute(/* comment 1 */ id /* comment 2 */, "id")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"id":(/* comment 1 */ id /* comment 2 */)})}</div>`,
+			},
+		},
+		{
+			name:   "includes comments for expression attribute",
+			source: `<div><h1 attr={/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */}>Hello</h1><Component attr={/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */}/></div>`,
+			want: want{
+				code: `<div><h1${$$addAttribute(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */, "attr")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"attr":(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */)})}</div>`,
+			},
+		},
+		{
+			name:   "comment blocks are removed",
+			source: `<h1>{/* a comment */}Hello</h1>`,
+			want: want{
+				code: `<h1>Hello</h1>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -53,3 +53,29 @@ func escapeSingleQuote(str string) string {
 func encodeDoubleQuote(str string) string {
 	return strings.Replace(str, `"`, "&quot;", -1)
 }
+
+// Remove comment blocks from string (e.g. "/* a comment */aProp" => "aProp")
+func removeComments(input string) string {
+	var (
+		sb        = strings.Builder{}
+		inComment = false
+	)
+	for cur := 0; cur < len(input); cur++ {
+		peekIs := func(assert byte) bool { return cur+1 < len(input) && input[cur+1] == assert }
+		if input[cur] == '/' && !inComment && peekIs('*') {
+			inComment = true
+			cur++
+		} else if input[cur] == '*' && inComment && peekIs('/') {
+			inComment = false
+			cur++
+		} else if !inComment {
+			sb.WriteByte(input[cur])
+		}
+	}
+
+	if inComment {
+		panic("unterminated comment")
+	}
+
+	return strings.TrimSpace(sb.String())
+}

--- a/internal/token.go
+++ b/internal/token.go
@@ -821,6 +821,58 @@ find_next:
 	}
 }
 
+// skips past any chars until first char is encountered from given splice
+func (z *Tokenizer) skipUntilChar(chars []byte) {
+find_next:
+	for {
+		c := z.readByte()
+		// fail on error
+		if z.err != nil {
+			z.data.End = z.raw.End - 1
+			return
+		}
+		// handle escape char \
+		if c == '\\' {
+			z.raw.End++
+			c = z.buf[z.data.Start : z.data.Start+1][0]
+			// if this is a match but it’s escaped, skip and move to the next char
+			for _, v := range chars {
+				if c == v {
+					z.raw.End++
+					continue find_next
+				}
+			}
+		}
+		// match found!
+		for _, v := range chars {
+			if c == v {
+				return
+			}
+		}
+	}
+}
+
+// skip past an attribute that is commented out with // or /*
+func (z *Tokenizer) skipCommentedAttribute() {
+	c := z.readByte()
+	switch c {
+	case '/':
+		z.skipUntilChar([]byte{'\r', '\n'})
+	case '*':
+		for {
+			z.skipUntilChar([]byte{'*'})
+			c = z.readByte()
+			if c == '/' {
+				return
+			}
+			if z.err == io.EOF {
+				panic("unterminated comment")
+			}
+			z.raw.End--
+		}
+	}
+}
+
 // read RegExp expressions and comments (starting from '/' byte)
 func (z *Tokenizer) readCommentOrRegExp(boundaryChars []byte) {
 	c := z.readByte() // find next character after '/' to know how to handle it
@@ -837,6 +889,9 @@ func (z *Tokenizer) readCommentOrRegExp(boundaryChars []byte) {
 			if c == '/' {
 				z.data.End = z.raw.End
 				return
+			}
+			if z.err == io.EOF {
+				panic("unterminated comment")
 			}
 		}
 	// RegExp
@@ -1082,6 +1137,9 @@ func (z *Tokenizer) readTag(saveAttr bool) {
 	}
 	for {
 		c := z.readByte()
+		if z.err != nil || c == '/' {
+			z.skipCommentedAttribute()
+		}
 		if z.err != nil || c == '>' {
 			break
 		}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -377,6 +377,21 @@ To fix this, please change
 to use the longhand Fragment syntax:
   <Fragment slot="named">`,
 		},
+		{
+			"unterminated comment block",
+			"/*",
+			"unterminated comment",
+		},
+		{
+			"unterminated comment block in expression",
+			"<div>{/*}</div>",
+			"unterminated comment",
+		},
+		{
+			"unterminated comment block in attribute list",
+			`<div a="1" /* b="2" />`,
+			"unterminated comment",
+		},
 	}
 	runPanicTest(t, Panics)
 }
@@ -807,6 +822,25 @@ func TestAttributes(t *testing.T) {
 		{
 			"iframe allows attributes",
 			"<iframe src=\"https://google.com\"></iframe>",
+			[]AttributeType{QuotedAttribute},
+		},
+		{
+			"attribute commented out with line comment",
+			`<div
+				// value="a"
+				anotherValue="b"
+				/>`,
+			[]AttributeType{QuotedAttribute},
+		},
+		{
+			"attribute commented out with block comment",
+			`<div /* value="a" */ anotherValue="b" />`,
+			[]AttributeType{QuotedAttribute},
+		},
+		{
+			"attributes commented out with multiline block comment",
+			`<div /* value="a"
+				value="b" */ anotherValue="b" />`,
 			[]AttributeType{QuotedAttribute},
 		},
 	}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -379,7 +379,7 @@ to use the longhand Fragment syntax:
 		},
 		{
 			"unterminated comment block",
-			"/*",
+			"{/*",
 			"unterminated comment",
 		},
 		{
@@ -389,7 +389,7 @@ to use the longhand Fragment syntax:
 		},
 		{
 			"unterminated comment block in attribute list",
-			`<div a="1" /* b="2" />`,
+			`<div a="1" {/* b="2" />`,
 			"unterminated comment",
 		},
 	}
@@ -825,23 +825,14 @@ func TestAttributes(t *testing.T) {
 			[]AttributeType{QuotedAttribute},
 		},
 		{
-			"attribute commented out with line comment",
-			`<div
-				// value="a"
-				anotherValue="b"
-				/>`,
-			[]AttributeType{QuotedAttribute},
+			"shorthand attribute with comment",
+			"<div {/* a comment */ value} />",
+			[]AttributeType{ShorthandAttribute},
 		},
 		{
-			"attribute commented out with block comment",
-			`<div /* value="a" */ anotherValue="b" />`,
-			[]AttributeType{QuotedAttribute},
-		},
-		{
-			"attributes commented out with multiline block comment",
-			`<div /* value="a"
-				value="b" */ anotherValue="b" />`,
-			[]AttributeType{QuotedAttribute},
+			"expression with comment",
+			"<div a={/* a comment */ value} />",
+			[]AttributeType{ExpressionAttribute},
 		},
 	}
 


### PR DESCRIPTION
## Changes
- Adds support for expressions that only contain a comment block
  - `{/* a comment */}`
- Adds support for comments in Shorthand
  - `<h1 {/* comment in shorthand */ id}>Hello</h1>`
- Adds support for Shorthand attributes that only contain a comment
  - `<h1 {/* id={prop commentd out} */} class={class}>Hello</h1>`  
- Adds panic when a comment block is unterminated (missing `*/`)

See tests https://github.com/withastro/compiler/pull/364/files#diff-d0dbf4b902747f2cdc45290c88eb59b04d03bebcb2bd8872a0b49284a9dac9d1R1810

## Testing
Tests added for
- Comment only expressions
- Comments in attributes/props
- Panic when a comment block is unterminated

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
I don't think we need to add this to docs explicitly

## TODO
- [x] Add support for comments in attributes/props
- [x] Add support for comment blocks