### PR TITLE
Fix `<select>` elements with expression children

### DIFF
--- a/.changeset/nice-bulldogs-unite.md
+++ b/.changeset/nice-bulldogs-unite.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with `select` elements and expression children

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2205,7 +2205,7 @@ func inSelectIM(p *parser) bool {
 	case StartExpressionToken:
 		p.addExpression()
 		p.afe = append(p.afe, &scopeMarker)
-		p.setOriginalIM()
+		p.originalIM = inBodyIM
 		p.im = inExpressionIM
 		return true
 	case EndExpressionToken:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1624,6 +1624,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "select in form",
+			source: `<form><select>{options.map((option) => (<option value={option.id}>{option.title}</option>))}</select><div><label>Title 3</label><input type="text" /></div><button type="submit">Submit</button></form>`,
+			want: want{
+				code: `<form><select>${options.map((option) => ($$render` + BACKTICK + `<option${$$addAttribute(option.id, "value")}>${option.title}</option>` + BACKTICK + `))}</select><div><label>Title 3</label><input type="text"></div><button type="submit">Submit</button></form>`,
+			},
+		},
+		{
 			name:   "slot inside of Base",
 			source: `<Base title="Home"><div>Hello</div></Base>`,
 			want: want{

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -347,6 +347,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"select with expression",
+			`<select>{[1, 2, 3].map(num => <option>{num}</option>)}</select><div>Hello</div>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, EndTagToken, StartTagToken, TextToken, EndTagToken},
+		},
+		{
 			"Markdown codeblock",
 			fmt.Sprintf(`<Markdown>
 		%s%s%s


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/compiler/issues/366
- There was an edge case where we'd return to `inSelectIM` from `inExpressionIM` but then we never left `inSelectIM`.
- This PR changes it so that we go `inSelectIM => inExpressionIM => inBodyIM`.

## Testing

Test added, our current coverage didn't catch this.

## Docs

Bug fix only