### PR TITLE
Add `annotateSourceFile` option

### DIFF
--- a/.changeset/stale-steaks-brush.md
+++ b/.changeset/stale-steaks-brush.md
@@ -1,5 +1,23 @@
 ---
-'@astrojs/compiler': patch
+'@astrojs/compiler': minor
 ---
 
-Add `annotateSourceFile` option
+Add a new `annotateSourceFile` option. This options makes it so the compiler will annotate every element with their source file location. This is notably useful for dev tools to be able to provide features like a "Open in editor" button. This option is disabled by default.
+
+```ts
+<div>
+  <span>hello world</span>
+</div>
+```
+
+Results in:
+
+```ts
+<div data-astro-source-file="/Users/erika/Projects/..." data-astro-source-loc="1:1">
+  <span data-astro-source-file="/Users/erika/Projects/..." data-astro-source-loc="2:2">
+    hello world
+  </span>
+</div>
+```
+
+In Astro, this option is enabled only in development mode.

--- a/.changeset/stale-steaks-brush.md
+++ b/.changeset/stale-steaks-brush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add `annotateSourceFile` option

--- a/.changeset/stale-steaks-brush.md
+++ b/.changeset/stale-steaks-brush.md
@@ -4,7 +4,7 @@
 
 Add a new `annotateSourceFile` option. This options makes it so the compiler will annotate every element with their source file location. This is notably useful for dev tools to be able to provide features like a "Open in editor" button. This option is disabled by default.
 
-```ts
+```html
 <div>
   <span>hello world</span>
 </div>
@@ -12,11 +12,9 @@ Add a new `annotateSourceFile` option. This options makes it so the compiler wil
 
 Results in:
 
-```ts
+```html
 <div data-astro-source-file="/Users/erika/Projects/..." data-astro-source-loc="1:1">
-  <span data-astro-source-file="/Users/erika/Projects/..." data-astro-source-loc="2:2">
-    hello world
-  </span>
+  <span data-astro-source-file="/Users/erika/Projects/..." data-astro-source-loc="2:2">hello world</span>
 </div>
 ```
 

--- a/.changeset/stale-steaks-brush.md
+++ b/.changeset/stale-steaks-brush.md
@@ -2,7 +2,7 @@
 '@astrojs/compiler': minor
 ---
 
-Add a new `annotateSourceFile` option. This options makes it so the compiler will annotate every element with their source file location. This is notably useful for dev tools to be able to provide features like a "Open in editor" button. This option is disabled by default.
+Add a new `annotateSourceFile` option. This option makes it so the compiler will annotate every element with its source file location. This is notably useful for dev tools to be able to provide features like a "Open in editor" button. This option is disabled by default.
 
 ```html
 <div>

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -95,8 +95,8 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	if jsBool(options.Get("resultScopedSlot")) {
 		scopedSlot = true
 	}
-	transitionsAnimationURL := jsString(options.Get("transitionsAnimationURL"))
 
+	transitionsAnimationURL := jsString(options.Get("transitionsAnimationURL"))
 	if transitionsAnimationURL == "" {
 		transitionsAnimationURL = "astro/components/viewtransitions.css"
 	}

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -96,8 +96,14 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		scopedSlot = true
 	}
 	transitionsAnimationURL := jsString(options.Get("transitionsAnimationURL"))
+
 	if transitionsAnimationURL == "" {
 		transitionsAnimationURL = "astro/components/viewtransitions.css"
+	}
+
+	annotateSourceFile := false
+	if jsBool(options.Get("annotateSourceFile")) {
+		annotateSourceFile = true
 	}
 
 	var resolvePath any = options.Get("resolvePath")
@@ -132,6 +138,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		ResultScopedSlot:        scopedSlot,
 		ScopedStyleStrategy:     scopedStyleStrategy,
 		TransitionsAnimationURL: transitionsAnimationURL,
+		AnnotateSourceFile:      annotateSourceFile,
 	}
 }
 

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	astro "github.com/withastro/compiler/internal"
+	"golang.org/x/net/html/atom"
 )
 
 func ScopeElement(n *astro.Node, opts TransformOptions) {
@@ -27,6 +28,14 @@ func AddDefineVars(n *astro.Node, values []string) bool {
 	return false
 }
 
+func AnnotateElement(n *astro.Node, opts TransformOptions) {
+	if n.Type == astro.ElementNode && !n.Component && !n.Fragment {
+		if _, noScope := NeverScopedElements[n.Data]; !noScope {
+			annotateElement(n, opts)
+		}
+	}
+}
+
 var NeverScopedElements map[string]bool = map[string]bool{
 	"Fragment": true,
 	"base":     true,
@@ -46,6 +55,17 @@ var NeverScopedElements map[string]bool = map[string]bool{
 
 var NeverScopedSelectors map[string]bool = map[string]bool{
 	":root": true,
+}
+
+func annotateElement(n *astro.Node, opts TransformOptions) {
+	if n.DataAtom == atom.Html {
+		return
+	}
+	n.Attr = append(n.Attr, astro.Attribute{
+		Key:  "data-astro-source-file",
+		Type: astro.QuotedAttribute,
+		Val:  opts.Filename,
+	})
 }
 
 func injectDefineVars(n *astro.Node, values []string) {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -30,6 +30,7 @@ type TransformOptions struct {
 	TransitionsAnimationURL string
 	ResolvePath             func(string) string
 	PreprocessStyle         interface{}
+	AnnotateSourceFile      bool
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -58,6 +59,9 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		mergeClassList(doc, n, &opts)
 		if n.DataAtom == a.Head && !IsImplicitNode(n) {
 			doc.ContainsHead = true
+		}
+		if opts.AnnotateSourceFile {
+			AnnotateElement(n, opts)
 		}
 	})
 	if len(definedVars) > 0 && !didAddDefinedVars {

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -512,7 +511,7 @@ func TestAnnotation(t *testing.T) {
 			astro.PrintToSource(&b, doc)
 			got := strings.TrimSpace(b.String())
 			if tt.want != got {
-				t.Error(fmt.Sprintf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got))
+				t.Errorf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got)
 			}
 		})
 	}

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -56,6 +56,7 @@ export interface TransformOptions {
   transitionsAnimationURL?: string;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
+  annotateSourceFile?: boolean;
 }
 
 export type ConvertToTSXOptions = Pick<TransformOptions, 'filename' | 'normalizedFilename'>;


### PR DESCRIPTION
## Changes

- Allows Astro compiler to annotate elements with information about their source file and location
- Planned for improving DX in Astro core during dev

## Testing

- Tests added

## Docs

N/A