### PR TITLE
fix(#380): fix json escape

### DIFF
--- a/.changeset/six-squids-wink.md
+++ b/.changeset/six-squids-wink.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix json escape

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -37,6 +37,8 @@ type ASTNode struct {
 }
 
 func escapeForJSON(value string) string {
+	backslash := regexp.MustCompile(`\\`)
+	value = backslash.ReplaceAllString(value, `\\`)
 	newlines := regexp.MustCompile(`\n`)
 	value = newlines.ReplaceAllString(value, `\n`)
 	doublequotes := regexp.MustCompile(`"`)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2070,6 +2070,16 @@ const a = "hey"
 <div>{a}</div>`,
 			want: []ASTNode{{Type: "frontmatter", Value: "\nconst a = \"hey\"\n"}, {Type: "element", Name: "div", Children: []ASTNode{{Type: "expression", Children: []ASTNode{{Type: "text", Value: "a"}}}}}},
 		},
+		{
+			name: "JSON escape",
+			source: `---
+const a = "\n"
+const b = "\""
+const c = '\''
+---
+{a + b + c}`,
+			want: []ASTNode{{Type: "frontmatter", Value: "\nconst a = \"\\n\"\nconst b = \"\\\"\"\nconst c = '\\''\n"}, {Type: "expression", Children: []ASTNode{{Type: "text", Value: "a + b + c"}}}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

Fixes #380

This PR fixes `escapeForJSON` to escape the backslash (`/`).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I added a test case for a template with backslashes to `internal/printer/printer_test.go TestPrintToJSON` and verified that `go test -v ./internal/...` command passed.


## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

bug fix only.