### PR TITLE
fix(#391): inject astro scoped class when `class:list` is used

### DIFF
--- a/.changeset/hip-games-trade.md
+++ b/.changeset/hip-games-trade.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix Astro scoping when `class:list` is used

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -1,6 +1,8 @@
 package transform
 
 import (
+	"fmt"
+
 	astro "github.com/withastro/compiler/internal"
 )
 
@@ -62,6 +64,27 @@ func injectScopedClass(n *astro.Node, opts TransformOptions) {
 			case astro.ExpressionAttribute:
 				// as an expression
 				attr.Val = "(" + attr.Val + `) + " astro-` + opts.Scope + `"`
+				n.Attr[i] = attr
+				return
+			}
+		}
+
+		if attr.Key == "class:list" {
+			switch attr.Type {
+			case astro.EmptyAttribute:
+				// instead of an empty string
+				attr.Type = astro.QuotedAttribute
+				attr.Val = "astro-" + opts.Scope
+				n.Attr[i] = attr
+				return
+			case astro.QuotedAttribute, astro.TemplateLiteralAttribute:
+				// as a plain string
+				attr.Val = attr.Val + " astro-" + opts.Scope
+				n.Attr[i] = attr
+				return
+			case astro.ExpressionAttribute:
+				// as an expression
+				attr.Val = fmt.Sprintf(`[(%s), "astro-%s"]`, attr.Val, opts.Scope)
 				n.Attr[i] = attr
 				return
 			}

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -69,6 +69,21 @@ func TestScopeHTML(t *testing.T) {
 			source: "<Component {className} />",
 			want:   `<Component className={className + " astro-XXXXXX"}></Component>`,
 		},
+		{
+			name:   "element class:list",
+			source: "<div class:list={{ a: true }} />",
+			want:   `<div class:list={[({ a: true }), "astro-XXXXXX"]}></div>`,
+		},
+		{
+			name:   "element class:list string",
+			source: "<div class:list=\"weird but ok\" />",
+			want:   `<div class:list="weird but ok astro-XXXXXX"></div>`,
+		},
+		{
+			name:   "component class:list",
+			source: "<Component class:list={{ a: true }} />",
+			want:   `<Component class:list={[({ a: true }), "astro-XXXXXX"]}></Component>`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Changes

- Injected `astro-XXXXXX` when `class:list` is used instead of `class`
- Fixes #391 

## Testing

Tests updated

## Docs

Bug fix only
