### PR TITLE
fix: properly handle scoped class injection with spread attributes

### DIFF
--- a/.changeset/curvy-peas-buy.md
+++ b/.changeset/curvy-peas-buy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix long-standing bug where a `class` attribute inside of a spread prop will cause duplicate `class` attributes

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -423,11 +423,11 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					panic(`Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`)
 				}
 				if n.Parent.CustomElement {
-					p.printAttribute(a)
+					p.printAttribute(a, n)
 					p.addSourceMapping(n.Loc[0])
 				}
 			} else {
-				p.printAttribute(a)
+				p.printAttribute(a, n)
 				p.addSourceMapping(n.Loc[0])
 			}
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1301,6 +1301,37 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
+			name:   "class with spread",
+			source: `<div class="something" {...Astro.props} />`,
+			want: want{
+				code: `<div class="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+			},
+		},
+		{
+			name:   "class:list with spread",
+			source: `<div class:list="something" {...Astro.props} />`,
+			want: want{
+				code: `<div class:list="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+			},
+		},
+		{
+			name:   "spread without style or class",
+			source: `<div {...Astro.props} />`,
+			want: want{
+				code: `<div${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+			},
+		},
+		{
+			name:   "spread with style but no explicit class",
+			source: `<style>div { color: red; }</style><div {...Astro.props} />`,
+			want: want{
+				styles: []string{
+					"{props:{\"data-astro-id\":\"TN53UTDL\"},children:`div.astro-TN53UTDL{color:red}`}",
+				},
+				code: `<div${$$spreadAttributes(Astro.props,"Astro.props",{"class":"astro-XXXX"})}></div>`,
+			},
+		},
+		{
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 			want: want{

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -37,7 +37,13 @@ var NeverScopedSelectors map[string]bool = map[string]bool{
 }
 
 func injectScopedClass(n *astro.Node, opts TransformOptions) {
+	hasSpreadAttr := false
 	for i, attr := range n.Attr {
+		if !hasSpreadAttr && attr.Type == astro.SpreadAttribute {
+			// We only handle this special case on built-in elements
+			hasSpreadAttr = n.Component == false
+		}
+
 		// If we find an existing class attribute, append the scoped class
 		if attr.Key == "class" || (n.Component && attr.Key == "className") {
 			switch attr.Type {
@@ -66,6 +72,11 @@ func injectScopedClass(n *astro.Node, opts TransformOptions) {
 				return
 			}
 		}
+	}
+	// If there's a spread attribute, `class` might be there, so do not inject `class` here
+	// `class` will be injected by the `spreadAttributes` helper
+	if hasSpreadAttr {
+		return
 	}
 	// If we didn't find an existing class attribute, let's add one
 	n.Attr = append(n.Attr, astro.Attribute{


### PR DESCRIPTION
# Do not merge until core `spreadAttributes` is updated!

## Changes

- Long-standing bug that was tricky to fix.
- `<div {...Astro.props} />` would emit duplicate `class` attributes!
  - The compiler would scope this internally, so if `Astro.props` included `class` that would lead to duplicate `class` attributes and would throw in Vite.
- The solution is to update the compiler logic for injection, skipping `class` is a `...spread` attribute is found. This should be paired with an update to the `spreadAttributes` function to accept a third param of attributes that should alway be injected (`class`).

## Testing

Tests added

## Docs

Bug fix only!