### PR TITLE
Provide a good error when unable to find matching client:only import …

### DIFF
--- a/.changeset/happy-beers-perform.md
+++ b/.changeset/happy-beers-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Provides a better error message when we can't match client:only usage to an import statement

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -335,7 +335,13 @@ func (p *printer) printTopLevelAstro(opts transform.TransformOptions) {
 	p.println(fmt.Sprintf("const $$Astro = %s(%s, '%s', '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, patharg, p.opts.Site, p.opts.ProjectRoot))
 }
 
-func remove(slice []*astro.Node, s int) []*astro.Node {
+func remove(slice []*astro.Node, node *astro.Node) []*astro.Node {
+	var s int
+	for i, n := range slice {
+		if n == node {
+			s = i
+		}
+	}
 	return append(slice[:s], slice[s+1:]...)
 }
 
@@ -351,7 +357,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 	for loc != -1 {
 		isClientOnlyImport := false
 	component_loop:
-		for cindex, n := range doc.ClientOnlyComponents {
+		for _, n := range doc.ClientOnlyComponents {
 			for _, imported := range statement.Imports {
 				if imported.ExportName == "*" {
 					prefix := fmt.Sprintf("%s.", imported.LocalName)
@@ -374,7 +380,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 							Type: astro.QuotedAttribute,
 						}
 						n.Attr = append(n.Attr, exportAttr)
-						remove(unfoundconly, cindex)
+						unfoundconly = remove(unfoundconly, n)
 
 						isClientOnlyImport = true
 						continue component_loop
@@ -388,7 +394,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 					}
 					n.Attr = append(n.Attr, pathAttr)
 					conlyspecs = append(conlyspecs, statement.Specifier)
-					remove(unfoundconly, cindex)
+					unfoundconly = remove(unfoundconly, n)
 
 					exportAttr := astro.Attribute{
 						Key:  "client:component-export",

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -19,6 +19,7 @@ _Note: Public APIs are likely to change before 1.0! Use at your own discretion._
 The Astro compiler can convert `.astro` syntax to a TypeScript Module whose default export generates HTML.
 
 **Some notes**...
+
 - TypeScript is valid `.astro` syntax! The output code may need an additional post-processing step to generate valid JavaScript.
 - `.astro` files rely on a server implementation exposed as `astro/internal` in the Node ecosystem. Other runtimes currently need to bring their own rendering implementation and reference it via `internalURL`. This is a pain point we're looking into fixing.
 
@@ -38,6 +39,7 @@ const result = await transform(source, {
 The Astro compiler can emit an AST using the `parse` method.
 
 **Some notes**...
+
 - Position data is currently incomplete and in some cases incorrect. We're working on it!
 - A `TextNode` can represent both HTML `text` and JavaScript/TypeScript source code.
 - The `@astrojs/compiler/utils` entrypoint exposes a `walk` function that can be used to traverse the AST. It also exposes the `is` helper which can be used as guards to derive the proper types for each `node`.
@@ -55,7 +57,7 @@ walk(result.ast, (node) => {
   if (is.tag(node)) {
     console.log(node.name);
   }
-})
+});
 ```
 
 ## Contributing

--- a/packages/compiler/node/index.ts
+++ b/packages/compiler/node/index.ts
@@ -54,7 +54,16 @@ const startRunningService = async (): Promise<Service> => {
   go.run(wasm.instance);
   const _service: any = (globalThis as any)['@astrojs/compiler'];
   return {
-    transform: (input, options) => new Promise((resolve) => resolve(_service.transform(input, options || {}))),
+    transform: (input, options) =>
+      new Promise((resolve) => {
+        try {
+          resolve(_service.transform(input, options || {}));
+        } catch (err) {
+          // Recreate the service next time on panic
+          longLivedService = void 0;
+          throw err;
+        }
+      }),
     parse: (input, options) => new Promise((resolve) => resolve(_service.parse(input, options || {}))).then((result: any) => ({ ...result, ast: JSON.parse(result.ast) })),
   };
 };

--- a/packages/compiler/test/basic/client-only-unfound.ts
+++ b/packages/compiler/test/basic/client-only-unfound.ts
@@ -21,14 +21,14 @@ test.before(async () => {
     await transform(FIXTURE, {
       pathname: '/src/components/Cool.astro',
     });
-  } catch(err) {
+  } catch (err) {
     error = err;
   }
 });
 
 test('got an error because client:only component not found import', () => {
-  console.log('error', error);
-})
+  assert.ok(error, 'paniced');
+});
 
 /*
 test('exports named component', () => {
@@ -37,5 +37,3 @@ test('exports named component', () => {
 */
 
 test.run();
-
-

--- a/packages/compiler/test/basic/client-only-unfound.ts
+++ b/packages/compiler/test/basic/client-only-unfound.ts
@@ -1,0 +1,41 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `---
+import * as components from '../components';
+const { MyComponent } = components;
+---
+<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+    <MyComponent client:only />
+  </body>
+</html>`;
+
+let error: Error;
+test.before(async () => {
+  try {
+    await transform(FIXTURE, {
+      pathname: '/src/components/Cool.astro',
+    });
+  } catch(err) {
+    error = err;
+  }
+});
+
+test('got an error because client:only component not found import', () => {
+  console.log('error', error);
+})
+
+/*
+test('exports named component', () => {
+  assert.match(result.code, 'export default $$Cool', 'Expected output to contain named export');
+});
+*/
+
+test.run();
+
+

--- a/packages/compiler/test/parse/orphan-slot.ts
+++ b/packages/compiler/test/parse/orphan-slot.ts
@@ -22,7 +22,6 @@ test.before(async () => {
 
 test('orphan slot', () => {
   assert.ok(result.code, 'able to parse');
-  console.log(result.code);
 });
 
 test.run();

--- a/packages/compiler/test/parse/serialize.ts
+++ b/packages/compiler/test/parse/serialize.ts
@@ -31,6 +31,7 @@ test.before(async () => {
   try {
     result = serialize(ast);
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.log(e);
   }
 });

--- a/packages/compiler/types.d.ts
+++ b/packages/compiler/types.d.ts
@@ -1,1 +1,1 @@
-export * from './shared/ast'
+export * from './shared/ast';


### PR DESCRIPTION
## Changes

- Checks to see if any client:only components did not have a matching import statement.
- If there are any, panic that the compiler cannot complete successful, providing a good error message for the scenario.

## Testing

- Test added when trying to use a frontmatter variable with client:only.

## Docs

N/A, bug fix.