### PR TITLE
fix: strip newlines at the end of component files

### DIFF
--- a/.changeset/chilly-chairs-enjoy.md
+++ b/.changeset/chilly-chairs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Newlines at the end of Astro files are now stripped before the Astro file is processed.

--- a/.changeset/chilly-chairs-enjoy.md
+++ b/.changeset/chilly-chairs-enjoy.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': minor
 ---
 
-Newlines at the end of Astro files are now stripped before the Astro file is processed.
+Trailing space at the end of Astro files is now stripped from Component output.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -159,14 +159,9 @@ func preprocessStyle(i int, style *astro.Node, transformOptions transform.Transf
 	style.FirstChild.Data = str
 }
 
-func preprocessSource(source string) string {
-	// remove trailing newlines
-	return strings.TrimRight(source, "\n")
-}
-
 func Parse() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := preprocessSource(jsString(args[0]))
+		source := jsString(args[0])
 		parseOptions := makeParseOptions(js.Value(args[1]))
 
 		var doc *astro.Node
@@ -184,7 +179,7 @@ func Parse() interface{} {
 
 func ConvertToTSX() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := preprocessSource(jsString(args[0]))
+		source := jsString(args[0])
 		transformOptions := makeTransformOptions(js.Value(args[1]), "XXXXXX")
 
 		var doc *astro.Node
@@ -203,7 +198,7 @@ func ConvertToTSX() interface{} {
 
 func Transform() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := preprocessSource(jsString(args[0]))
+		source := jsString(args[0])
 		hash := astro.HashFromSource(source)
 		transformOptions := makeTransformOptions(js.Value(args[1]), hash)
 

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -159,9 +159,14 @@ func preprocessStyle(i int, style *astro.Node, transformOptions transform.Transf
 	style.FirstChild.Data = str
 }
 
+func preprocessSource(source string) string {
+	// remove trailing newlines
+	return strings.TrimRight(source, "\n")
+}
+
 func Parse() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := jsString(args[0])
+		source := preprocessSource(jsString(args[0]))
 		parseOptions := makeParseOptions(js.Value(args[1]))
 
 		var doc *astro.Node
@@ -179,7 +184,7 @@ func Parse() interface{} {
 
 func ConvertToTSX() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := jsString(args[0])
+		source := preprocessSource(jsString(args[0]))
 		transformOptions := makeTransformOptions(js.Value(args[1]), "XXXXXX")
 
 		var doc *astro.Node
@@ -198,7 +203,7 @@ func ConvertToTSX() interface{} {
 
 func Transform() interface{} {
 	return js.FuncOf(func(this js.Value, args []js.Value) interface{} {
-		source := jsString(args[0])
+		source := preprocessSource(jsString(args[0]))
 		hash := astro.HashFromSource(source)
 		transformOptions := makeTransformOptions(js.Value(args[1]), hash)
 

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -198,3 +198,46 @@ func TestFullTransform(t *testing.T) {
 		})
 	}
 }
+
+func TestTransformTrailingSpace(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "component with trailing space",
+			source: "<h1>Hello world</h1>\n\n\t ",
+			want:   `<h1>Hello world</h1>`,
+		},
+		{
+			name:   "component with no trailing space",
+			source: "<h1>Hello world</h1>",
+			want:   "<h1>Hello world</h1>",
+		},
+		{
+			name:   "component with leading and trailing space",
+			source: "<span/>\n\n\t <h1>Hello world</h1>\n\n\t ",
+			want:   "<span></span>\n\n\t <h1>Hello world</h1>",
+		},
+	}
+	var b strings.Builder
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b.Reset()
+			doc, err := astro.Parse(strings.NewReader(tt.source))
+			if err != nil {
+				t.Error(err)
+			}
+			ExtractStyles(doc)
+			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
+			doc.Styles = make([]*astro.Node, 0)
+			Transform(doc, TransformOptions{})
+			astro.PrintToSource(&b, doc)
+			got := b.String()
+			if tt.want != got {
+				t.Errorf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got)
+			}
+		})
+	}
+}

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -220,6 +220,11 @@ func TestTransformTrailingSpace(t *testing.T) {
 			source: "<span/>\n\n\t <h1>Hello world</h1>\n\n\t ",
 			want:   "<span></span>\n\n\t <h1>Hello world</h1>",
 		},
+		{
+			name:   "html with explicit space",
+			source: "<html><body>\n\n\n</body></html>",
+			want:   "<html><body>\n\n\n</body></html>",
+		},
 	}
 	var b strings.Builder
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

This makes it so that newlines at the end of files are not considered. This is because it can lead to confusing behaviour; defining an Astro component with a newline at the end (which can be implicitly placed by most editors) adds an implicit newline to the final output, resulting in strange spaces in the final HTML.

For example:

```astro
<!-- src/components/Link.astro -->
<a href={Astro.props.href}><slot /></a>
```

```astro
---
/* src/pages/index.astro */
import Link from '../components/Link.astro';
---
<p>this is a <Link href="example.com">test</Link>!</p>
```

results in a strange space between the link text and the exclamation mark:
![strange space example](https://cdn.discordapp.com/attachments/845430950191038464/978131877313540186/unknown.png)

This change simply makes it so that the three exposed JS functions all strip newlines from the end of the source text before attempting to use it.


## Testing

This was manually tested. Does this need automated testing?

## Docs

Bug fix only. (Does this need documentation?)