### PR TITLE
Prevent including module metadata imports for side-effectual CSS

### DIFF
--- a/.changeset/shiny-dots-care.md
+++ b/.changeset/shiny-dots-care.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Prevent side-effectual CSS imports from becoming module metadata

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -44,7 +44,7 @@ var RESULT = "$$result"
 var SLOTS = "$$slots"
 var FRAGMENT = "Fragment"
 var BACKTICK = "`"
-var styleModuleSpecExp = regexp.MustCompile("(\\.css|\\.sass|\\.scss)$")
+var styleModuleSpecExp = regexp.MustCompile(`(\.css|\.sass|\.scss)$`)
 
 func (p *printer) print(text string) {
 	p.output = append(p.output, text...)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -44,7 +44,7 @@ var RESULT = "$$result"
 var SLOTS = "$$slots"
 var FRAGMENT = "Fragment"
 var BACKTICK = "`"
-var styleModuleSpecExp = regexp.MustCompile(`(\.css|\.sass|\.scss)$`)
+var styleModuleSpecExp = regexp.MustCompile(`(\.css|\.pcss|\.postcss|\.sass|\.scss|\.styl|\.stylus|\.less)$`)
 
 func (p *printer) print(text string) {
 	p.output = append(p.output, text...)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -222,6 +222,19 @@ import data from "test" assert { type: 'json' };
 			},
 		},
 		{
+			name: "css imports are not included in module metadata",
+			source: `---
+			import './styles.css';
+			---
+			`,
+			want: want{
+				frontmatter: []string{
+					`import './styles.css';`,
+				},
+				styles: []string{},
+			},
+		},
+		{
 			name:   "solidus in template literal expression",
 			source: "<div value={`${attr ? `a/b` : \"c\"} awesome`} />",
 			want: want{


### PR DESCRIPTION
## Changes

- The compiler adds import statements for each user import in order to figure out which one maps to a component.
- CSS side-effectual imports should *not* be included in this metadata. Doing so prevents CSS try shaking this code away.
- This is part of switching to Vite's internal CSS plugin and fixing https://github.com/withastro/astro/issues/2146

## Testing

- Test added

## Docs

N/A, bug fix.