### PR TITLE
fix: fix serialize spread attribute

### DIFF
--- a/.changeset/tame-eyes-provide.md
+++ b/.changeset/tame-eyes-provide.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix serialize spread attribute

--- a/packages/compiler/node/utils.ts
+++ b/packages/compiler/node/utils.ts
@@ -94,7 +94,7 @@ function serializeAttributes(node: TagLikeNode): string {
         break;
       }
       case 'spread': {
-        output += `{...${attr.value}}`;
+        output += `{...${attr.name}}`;
         break;
       }
     }

--- a/packages/compiler/test/parse/serialize.ts
+++ b/packages/compiler/test/parse/serialize.ts
@@ -16,7 +16,7 @@ let content = "Testing 123";
 
 <div>Hello {value}</div>
 
-<h1 name="value" set:html={content} empty {shorthand} expression={true} literal=\`tags\`>Hello {value}</h1>
+<h1 name="value" set:html={content} empty {shorthand} expression={true} literal=\`tags\` {...spread}>Hello {value}</h1>
 
 <Fragment set:html={content} />
 


### PR DESCRIPTION
## Changes

This PR fixes the wrong serialize when it has a spread attribute in `utils`'s `serialize` method.
This fix is related to https://github.com/withastro/prettier-plugin-astro/issues/193.

## Testing

I have added the spread attribute to the serialize test case template.

## Docs

bug fix only.
