### PR TITLE
Include component metadata in the transformResult

### DIFF
--- a/.changeset/bright-panthers-hang.md
+++ b/.changeset/bright-panthers-hang.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Adds component metadata to the TransformResult

--- a/internal/node.go
+++ b/internal/node.go
@@ -62,6 +62,12 @@ const ImplicitNodeMarker = "\x00implicit"
 // template, td, th, and caption elements".
 var scopeMarker = Node{Type: scopeMarkerNode}
 
+type HydratedComponentMetadata struct {
+	ExportName   string
+	Specifier    string
+	ResolvedPath string
+}
+
 // A Node consists of a NodeType and some Data (tag name for element nodes,
 // content for text) and are part of a tree of Nodes. Element nodes may also
 // have a Namespace and contain a slice of Attributes. Data is unescaped, so
@@ -80,10 +86,12 @@ type Node struct {
 	Parent, FirstChild, LastChild, PrevSibling, NextSibling *Node
 
 	// These are only accessible from the document root Node
-	Styles, Scripts      []*Node
-	HydratedComponents   []*Node
-	ClientOnlyComponents []*Node
-	HydrationDirectives  map[string]bool
+	Styles, Scripts          []*Node
+	HydratedComponentNodes   []*Node
+	HydratedComponents       []*HydratedComponentMetadata
+	ClientOnlyComponentNodes []*Node
+	ClientOnlyComponents     []*HydratedComponentMetadata
+	HydrationDirectives      map[string]bool
 
 	Type      NodeType
 	DataAtom  atom.Atom

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -375,15 +375,15 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 	var specs []string
 	var asrts []string
 	var conlyspecs []string
-	unfoundconly := make([]*astro.Node, len(doc.ClientOnlyComponents))
-	copy(unfoundconly, doc.ClientOnlyComponents)
+	unfoundconly := make([]*astro.Node, len(doc.ClientOnlyComponentNodes))
+	copy(unfoundconly, doc.ClientOnlyComponentNodes)
 
 	modCount := 1
 	loc, statement := js_scanner.NextImportStatement(source, 0)
 	for loc != -1 {
 		isClientOnlyImport := false
 	component_loop:
-		for _, n := range doc.ClientOnlyComponents {
+		for _, n := range doc.ClientOnlyComponentNodes {
 			for _, imported := range statement.Imports {
 				if imported.ExportName == "*" {
 					prefix := fmt.Sprintf("%s.", imported.LocalName)
@@ -498,7 +498,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 
 	// Hydrated Components
 	p.print(", hydratedComponents: [")
-	for i, node := range doc.HydratedComponents {
+	for i, node := range doc.HydratedComponentNodes {
 		if i > 0 {
 			p.print(", ")
 		}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -324,7 +324,7 @@ func eachImportStatement(doc *astro.Node, cb func(stmt js_scanner.ImportStatemen
 		source := []byte(doc.FirstChild.FirstChild.Data)
 		loc, statement := js_scanner.NextImportStatement(source, 0)
 		for loc != -1 {
-			if cb(statement) == false {
+			if !cb(statement) {
 				break
 			}
 			loc, statement = js_scanner.NextImportStatement(source, loc)

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -2,10 +2,12 @@ package transform
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"unicode"
 
 	astro "github.com/withastro/compiler/internal"
+	"github.com/withastro/compiler/internal/js_scanner"
 	"github.com/withastro/compiler/internal/loc"
 	"golang.org/x/net/html/atom"
 	a "golang.org/x/net/html/atom"
@@ -27,7 +29,7 @@ func Transform(doc *astro.Node, opts TransformOptions) *astro.Node {
 	shouldScope := len(doc.Styles) > 0 && ScopeStyle(doc.Styles, opts)
 	walk(doc, func(n *astro.Node) {
 		ExtractScript(doc, n, &opts)
-		AddComponentProps(doc, n)
+		AddComponentProps(doc, n, &opts)
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
@@ -200,7 +202,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 	}
 }
 
-func AddComponentProps(doc *astro.Node, n *astro.Node) {
+func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 	if n.Type == astro.ElementNode && (n.Component || n.CustomElement) {
 		for _, attr := range n.Attr {
 			id := n.Data
@@ -222,11 +224,21 @@ func AddComponentProps(doc *astro.Node, n *astro.Node) {
 				n.Attr = append(n.Attr, hydrationAttr)
 
 				if attr.Key == "client:only" {
-					doc.ClientOnlyComponents = append([]*astro.Node{n}, doc.ClientOnlyComponents...)
+					doc.ClientOnlyComponentNodes = append([]*astro.Node{n}, doc.ClientOnlyComponentNodes...)
+
+					match := matchNodeToImportStatement(doc, n)
+					if match != nil {
+						doc.ClientOnlyComponents = append(doc.ClientOnlyComponents, &astro.HydratedComponentMetadata{
+							ExportName:   match.ExportName,
+							Specifier:    match.Specifier,
+							ResolvedPath: resolveIdForMatch(match, opts),
+						})
+					}
+
 					break
 				}
 				// prepend node to maintain authored order
-				doc.HydratedComponents = append([]*astro.Node{n}, doc.HydratedComponents...)
+				doc.HydratedComponentNodes = append([]*astro.Node{n}, doc.HydratedComponentNodes...)
 				pathAttr := astro.Attribute{
 					Key:  "client:component-path",
 					Val:  fmt.Sprintf("$$metadata.getPath(%s)", id),
@@ -240,8 +252,82 @@ func AddComponentProps(doc *astro.Node, n *astro.Node) {
 					Type: astro.ExpressionAttribute,
 				}
 				n.Attr = append(n.Attr, exportAttr)
+
+				match := matchNodeToImportStatement(doc, n)
+				if match != nil {
+					doc.HydratedComponents = append(doc.HydratedComponents, &astro.HydratedComponentMetadata{
+						ExportName:   match.ExportName,
+						Specifier:    match.Specifier,
+						ResolvedPath: resolveIdForMatch(match, opts),
+					})
+				}
+
 				break
 			}
+		}
+	}
+}
+
+type ImportMatch struct {
+	ExportName string
+	Specifier  string
+}
+
+func matchNodeToImportStatement(doc *astro.Node, n *astro.Node) *ImportMatch {
+	var match *ImportMatch
+
+	eachImportStatement(doc, func(stmt js_scanner.ImportStatement) bool {
+		for _, imported := range stmt.Imports {
+			if imported.ExportName == "*" {
+				prefix := fmt.Sprintf("%s.", imported.LocalName)
+
+				if strings.HasPrefix(n.Data, prefix) {
+					exportParts := strings.Split(n.Data[len(prefix):], ".")
+					exportName := exportParts[0]
+
+					match = &ImportMatch{
+						ExportName: exportName,
+						Specifier:  stmt.Specifier,
+					}
+
+					return false
+				}
+			} else if imported.LocalName == n.Data {
+				match = &ImportMatch{
+					ExportName: imported.ExportName,
+					Specifier:  stmt.Specifier,
+				}
+				return false
+			}
+		}
+
+		return true
+	})
+
+	return match
+}
+
+func resolveIdForMatch(match *ImportMatch, opts *TransformOptions) string {
+	if strings.HasPrefix(match.Specifier, ".") && len(opts.Pathname) > 0 {
+		u, err := url.Parse(opts.Pathname)
+		if err == nil {
+			ref, _ := url.Parse(match.Specifier)
+			ou := u.ResolveReference(ref)
+			return ou.String()
+		}
+	}
+	return ""
+}
+
+func eachImportStatement(doc *astro.Node, cb func(stmt js_scanner.ImportStatement) bool) {
+	if doc.FirstChild.Type == astro.FrontmatterNode {
+		source := []byte(doc.FirstChild.FirstChild.Data)
+		loc, statement := js_scanner.NextImportStatement(source, 0)
+		for loc != -1 {
+			if cb(statement) == false {
+				break
+			}
+			loc, statement = js_scanner.NextImportStatement(source, loc)
 		}
 	}
 }

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -37,9 +37,17 @@ export type HoistedScript = { type: string } & (
     }
 );
 
+export interface HydratedComponent {
+  exportName: string;
+  specifier: string;
+  resolvedPath: string;
+}
+
 export interface TransformResult {
   css: string[];
   scripts: HoistedScript[];
+  hydratedComponents: HydratedComponent[];
+  clientOnlyComponents: HydratedComponent[];
   code: string;
   map: string;
 }

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -1,0 +1,86 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform, TransformResult } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+import One from '../components/one.jsx';
+import * as Two from '../components/two.jsx';
+import { Three } from '../components/three.tsx';
+
+import Four from '../components/four.jsx';
+import * as Five from '../components/five.jsx';
+import { Six } from '../components/six.jsx';
+---
+
+<One client:load />
+<Two.someName client:load />
+<Three client:load />
+
+<!-- client only tests -->
+<Four client:only />
+<Five.someName client:only />
+<Six client:only />
+`;
+
+let result: TransformResult;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro',
+    experimentalStaticExtraction: true,
+  });
+});
+
+test('Hydrated component', () => {
+  let components = result.hydratedComponents;
+  assert.equal(components.length, 3);
+});
+
+test('Hydrated components: default export', () => {
+  let components = result.hydratedComponents;
+  assert.equal(components[0].exportName, 'default');
+  assert.equal(components[0].specifier, '../components/one.jsx');
+  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/one.jsx');
+});
+
+test('Hydrated components: star export', () => {
+  let components = result.hydratedComponents;
+  assert.equal(components[1].exportName, 'someName');
+  assert.equal(components[1].specifier, '../components/two.jsx');
+  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/two.jsx');
+});
+
+test('Hydrated components: named export', () => {
+  let components = result.hydratedComponents;
+  assert.equal(components[2].exportName, 'Three');
+  assert.equal(components[2].specifier, '../components/three.tsx');
+  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/three.tsx');
+});
+
+test('ClientOnly component', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components.length, 3);
+});
+
+test('ClientOnly components: default export', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components[0].exportName, 'default');
+  assert.equal(components[0].specifier, '../components/four.jsx');
+  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four.jsx');
+});
+
+test('ClientOnly components: star export', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components[1].exportName, 'someName');
+  assert.equal(components[1].specifier, '../components/five.jsx');
+  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five.jsx');
+});
+
+test('ClientOnly components: named export', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components[2].exportName, 'Six');
+  assert.equal(components[2].specifier, '../components/six.jsx');
+  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/six.jsx');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Includes component metadata as part of the transform result: `hydratedComponents` and `clientOnlyComponents`. This includes the specifier, resolvedPath, and exportName.
- This information will be used by the build to know what client JS needs to be built, without running the code in dev SSR mode as we do today.

## Testing

- Tests added

## Docs

N/A