### PR TITLE
Add renderHead injection points

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -32,6 +32,7 @@ var TEMPLATE_TAG = "$$render"
 var CREATE_ASTRO = "$$createAstro"
 var CREATE_COMPONENT = "$$createComponent"
 var RENDER_COMPONENT = "$$renderComponent"
+var RENDER_HEAD = "$$renderHead"
 var UNESCAPE_HTML = "$$unescapeHTML"
 var RENDER_SLOT = "$$renderSlot"
 var ADD_ATTRIBUTE = "$$addAttribute"
@@ -68,6 +69,7 @@ func (p *printer) printInternalImports(importSpecifier string) {
 	p.print("createAstro as " + CREATE_ASTRO + ",\n  ")
 	p.print("createComponent as " + CREATE_COMPONENT + ",\n  ")
 	p.print("renderComponent as " + RENDER_COMPONENT + ",\n  ")
+	p.print("renderHead as " + RENDER_HEAD + ",\n  ")
 	p.print("unescapeHTML as " + UNESCAPE_HTML + ",\n  ")
 	p.print("renderSlot as " + RENDER_SLOT + ",\n  ")
 	p.print("addAttribute as " + ADD_ATTRIBUTE + ",\n  ")
@@ -97,7 +99,7 @@ func (p *printer) printCSSImports(cssLen int) {
 
 func (p *printer) printRenderHead() {
 	p.addNilSourceMapping()
-	p.print("<!--astro:head-->")
+	p.print(fmt.Sprintf("%s(%s)", RENDER_HEAD, RESULT))
 }
 
 func (p *printer) printReturnOpen() {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -33,6 +33,7 @@ var CREATE_ASTRO = "$$createAstro"
 var CREATE_COMPONENT = "$$createComponent"
 var RENDER_COMPONENT = "$$renderComponent"
 var RENDER_HEAD = "$$renderHead"
+var MAYBE_RENDER_HEAD = "$$maybeRenderHead"
 var UNESCAPE_HTML = "$$unescapeHTML"
 var RENDER_SLOT = "$$renderSlot"
 var ADD_ATTRIBUTE = "$$addAttribute"
@@ -70,6 +71,7 @@ func (p *printer) printInternalImports(importSpecifier string) {
 	p.print("createComponent as " + CREATE_COMPONENT + ",\n  ")
 	p.print("renderComponent as " + RENDER_COMPONENT + ",\n  ")
 	p.print("renderHead as " + RENDER_HEAD + ",\n  ")
+	p.print("maybeRenderHead as " + MAYBE_RENDER_HEAD + ",\n  ")
 	p.print("unescapeHTML as " + UNESCAPE_HTML + ",\n  ")
 	p.print("renderSlot as " + RENDER_SLOT + ",\n  ")
 	p.print("addAttribute as " + ADD_ATTRIBUTE + ",\n  ")
@@ -99,7 +101,12 @@ func (p *printer) printCSSImports(cssLen int) {
 
 func (p *printer) printRenderHead() {
 	p.addNilSourceMapping()
-	p.print(fmt.Sprintf("%s(%s)", RENDER_HEAD, RESULT))
+	p.print(fmt.Sprintf("${%s(%s)}", RENDER_HEAD, RESULT))
+}
+
+func (p *printer) printMaybeRenderHead() {
+	p.addNilSourceMapping()
+	p.print(fmt.Sprintf("${%s(%s)}", MAYBE_RENDER_HEAD, RESULT))
 }
 
 func (p *printer) printReturnOpen() {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -20,6 +20,7 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"createAstro as " + CREATE_ASTRO,
 	"createComponent as " + CREATE_COMPONENT,
 	"renderComponent as " + RENDER_COMPONENT,
+	"renderHead as " + RENDER_HEAD,
 	"unescapeHTML as " + UNESCAPE_HTML,
 	"renderSlot as " + RENDER_SLOT,
 	"addAttribute as " + ADD_ATTRIBUTE,
@@ -41,7 +42,7 @@ var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE);\
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
 var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT);\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
-var RENDER_HEAD_RESULT = "<!--astro:head-->"
+var RENDER_HEAD_RESULT = "$$renderHead($$result)"
 
 // SPECIAL TEST FIXTURES
 var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[];:'\",.?")

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -21,6 +21,7 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"createComponent as " + CREATE_COMPONENT,
 	"renderComponent as " + RENDER_COMPONENT,
 	"renderHead as " + RENDER_HEAD,
+	"maybeRenderHead as " + MAYBE_RENDER_HEAD,
 	"unescapeHTML as " + UNESCAPE_HTML,
 	"renderSlot as " + RENDER_SLOT,
 	"addAttribute as " + ADD_ATTRIBUTE,
@@ -42,7 +43,7 @@ var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE);\
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
 var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT);\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
-var RENDER_HEAD_RESULT = "$$renderHead($$result)"
+var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
 
 // SPECIAL TEST FIXTURES
 var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[];:'\",.?")
@@ -90,7 +91,7 @@ func TestPrinter(t *testing.T) {
 			name:   "basic (no frontmatter)",
 			source: `<button>Click</button>`,
 			want: want{
-				code: `<button>Click</button>`,
+				code: `${$$maybeRenderHead($$result)}<button>Click</button>`,
 			},
 		},
 		{
@@ -143,7 +144,7 @@ const href = '/about';
 <a href={href}>About</a>`,
 			want: want{
 				frontmatter: []string{"", "const href = '/about';"},
-				code:        `<a${` + ADD_ATTRIBUTE + `(href, "href")}>About</a>`,
+				code:        `${$$maybeRenderHead($$result)}<a${` + ADD_ATTRIBUTE + `(href, "href")}>About</a>`,
 			},
 		},
 		{
@@ -158,7 +159,7 @@ export const getStaticPaths = async () => {
 				frontmatter: []string{`export const getStaticPaths = async () => {
 	return { paths: [] }
 }`, ""},
-				code: `<div></div>`,
+				code: `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{
@@ -175,7 +176,7 @@ export const getStaticPaths = async () => {
 				getStaticPaths: `export const getStaticPaths = async () => {
 	return { paths: [] }
 }`,
-				code: `<div></div>`,
+				code: `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{
@@ -194,7 +195,7 @@ const b = 0;`},
 				getStaticPaths: `export async function getStaticPaths() {
 	return { paths: [] }
 }`,
-				code: `<div></div>`,
+				code: `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{
@@ -205,7 +206,7 @@ mod.export();
 <div />`,
 			want: want{
 				frontmatter: []string{``, `mod.export();`},
-				code:        `<div></div>`,
+				code:        `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{
@@ -226,7 +227,7 @@ import data from "test" assert { type: 'json' };
 			name:   "no expressions in math",
 			source: `<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\colon X \to \mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
 			want: want{
-				code: `<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\\colon X \\to \\mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
+				code: `${$$maybeRenderHead($$result)}<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\\colon X \\to \\mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
 			},
 		},
 		{
@@ -246,21 +247,21 @@ import data from "test" assert { type: 'json' };
 			name:   "solidus in template literal expression",
 			source: "<div value={`${attr ? `a/b` : \"c\"} awesome`} />",
 			want: want{
-				code: "<div${$$addAttribute(`${attr ? `a/b` : \"c\"} awesome`, \"value\")}></div>",
+				code: "${$$maybeRenderHead($$result)}<div${$$addAttribute(`${attr ? `a/b` : \"c\"} awesome`, \"value\")}></div>",
 			},
 		},
 		{
 			name:   "nested template literal expression",
 			source: "<div value={`${attr ? `a/b ${`c`}` : \"d\"} awesome`} />",
 			want: want{
-				code: "<div${$$addAttribute(`${attr ? `a/b ${`c`}` : \"d\"} awesome`, \"value\")}></div>",
+				code: "${$$maybeRenderHead($$result)}<div${$$addAttribute(`${attr ? `a/b ${`c`}` : \"d\"} awesome`, \"value\")}></div>",
 			},
 		},
 		{
 			name:   "complex nested template literal expression",
 			source: "<div value={`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} ahhhh`} />",
 			want: want{
-				code: "<div${$$addAttribute(`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} ahhhh`, \"value\")}></div>",
+				code: "${$$maybeRenderHead($$result)}<div${$$addAttribute(`${attr ? `a/b ${`c ${`d ${cool}`}`}` : \"d\"} ahhhh`, \"value\")}></div>",
 			},
 		},
 		{
@@ -464,35 +465,35 @@ import Component from '../components';
 			name:   "iframe",
 			source: `<iframe src="something" />`,
 			want: want{
-				code: "<iframe src=\"something\"></iframe>",
+				code: "${$$maybeRenderHead($$result)}<iframe src=\"something\"></iframe>",
 			},
 		},
 		{
 			name:   "conditional render",
 			source: `<body>{false ? <div>#f</div> : <div>#t</div>}</body>`,
 			want: want{
-				code: "<body>${false ? $$render`<div>#f</div>` : $$render`<div>#t</div>`}</body>",
+				code: "${$$maybeRenderHead($$result)}<body>${false ? $$render`<div>#f</div>` : $$render`<div>#t</div>`}</body>",
 			},
 		},
 		{
 			name:   "conditional noscript",
 			source: `{mode === "production" && <noscript>Hello</noscript>}`,
 			want: want{
-				code: "${mode === \"production\" && $$render`<noscript>Hello</noscript>`}",
+				code: "${mode === \"production\" && $$render`${$$maybeRenderHead($$result)}<noscript>Hello</noscript>`}",
 			},
 		},
 		{
 			name:   "conditional iframe",
 			source: `{bool && <iframe src="something">content</iframe>}`,
 			want: want{
-				code: "${bool && $$render`<iframe src=\"something\">content</iframe>`}",
+				code: "${bool && $$render`${$$maybeRenderHead($$result)}<iframe src=\"something\">content</iframe>`}",
 			},
 		},
 		{
 			name:   "simple ternary",
 			source: `<body>{link ? <a href="/">{link}</a> : <div>no link</div>}</body>`,
 			want: want{
-				code: fmt.Sprintf(`<body>${link ? $$render%s<a href="/">${link}</a>%s : $$render%s<div>no link</div>%s}</body>`, BACKTICK, BACKTICK, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<body>${link ? $$render%s<a href="/">${link}</a>%s : $$render%s<div>no link</div>%s}</body>`, BACKTICK, BACKTICK, BACKTICK, BACKTICK),
 			},
 		},
 		{
@@ -507,7 +508,7 @@ const items = [0, 1, 2];
 </ul>`,
 			want: want{
 				frontmatter: []string{"", "const items = [0, 1, 2];"},
-				code: fmt.Sprintf(`<ul>
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<ul>
 	${items.map(item => {
 		return $$render%s<li>${item}</li>%s;
 	})}
@@ -518,14 +519,14 @@ const items = [0, 1, 2];
 			name:   "map without component",
 			source: `<header><nav>{menu.map((item) => <a href={item.href}>{item.title}</a>)}</nav></header>`,
 			want: want{
-				code: fmt.Sprintf(`<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav></header>`, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav></header>`, BACKTICK, BACKTICK),
 			},
 		},
 		{
 			name:   "map with component",
 			source: `<header><nav>{menu.map((item) => <a href={item.href}>{item.title}</a>)}</nav><Hello/></header>`,
 			want: want{
-				code: fmt.Sprintf(`<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav>${$$renderComponent($$result,'Hello',Hello,{})}</header>`, BACKTICK, BACKTICK),
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<header><nav>${menu.map((item) => $$render%s<a${$$addAttribute(item.href, "href")}>${item.title}</a>%s)}</nav>${$$renderComponent($$result,'Hello',Hello,{})}</header>`, BACKTICK, BACKTICK),
 			},
 		},
 		{
@@ -545,7 +546,7 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			want: want{
 				frontmatter: []string{"", "const groups = [[0, 1, 2], [3, 4, 5]];"},
 				styles:      []string{},
-				code: fmt.Sprintf(`<div>
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<div>
 	${groups.map(items => {
 		return %s<ul>${
 			items.map(item => {
@@ -559,14 +560,14 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			name:   "backtick in HTML comment",
 			source: "<body><!-- `npm install astro` --></body>",
 			want: want{
-				code: "<body><!-- \\`npm install astro\\` --></body>",
+				code: "${$$maybeRenderHead($$result)}<body><!-- \\`npm install astro\\` --></body>",
 			},
 		},
 		{
 			name:   "nested expressions",
 			source: `<article>{(previous || next) && <aside>{previous && <div>Previous Article: <a rel="prev" href={new URL(previous.link, Astro.site).pathname}>{previous.text}</a></div>}{next && <div>Next Article: <a rel="next" href={new URL(next.link, Astro.site).pathname}>{next.text}</a></div>}</aside>}</article>`,
 			want: want{
-				code: `<article>${(previous || next) && $$render` + BACKTICK + `<aside>${previous && $$render` + BACKTICK + `<div>Previous Article: <a rel="prev"${$$addAttribute(new URL(previous.link, Astro.site).pathname, "href")}>${previous.text}</a></div>` + BACKTICK + `}${next && $$render` + BACKTICK + `<div>Next Article: <a rel="next"${$$addAttribute(new URL(next.link, Astro.site).pathname, "href")}>${next.text}</a></div>` + BACKTICK + `}</aside>` + BACKTICK + `}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${(previous || next) && $$render` + BACKTICK + `<aside>${previous && $$render` + BACKTICK + `<div>Previous Article: <a rel="prev"${$$addAttribute(new URL(previous.link, Astro.site).pathname, "href")}>${previous.text}</a></div>` + BACKTICK + `}${next && $$render` + BACKTICK + `<div>Next Article: <a rel="next"${$$addAttribute(new URL(next.link, Astro.site).pathname, "href")}>${next.text}</a></div>` + BACKTICK + `}</aside>` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -585,7 +586,7 @@ const items = ['red', 'yellow', 'blue'];
 </div>`,
 			want: want{
 				frontmatter: []string{"", "const items = ['red', 'yellow', 'blue'];"},
-				code: `<div>
+				code: `${$$maybeRenderHead($$result)}<div>
   ${items.map((item) => (
     // foo < > < }
 $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
@@ -611,7 +612,7 @@ $$render` + "`" + `<div${$$addAttribute(color, "id")}>color</div>` + "`" + `
 }
 </div>`,
 			want: want{
-				code: `<div>
+				code: `${$$maybeRenderHead($$result)}<div>
 ${
 	() => {
 		let generate = (input) => {
@@ -636,7 +637,7 @@ import Component from "test";
 			want: want{
 				frontmatter: []string{`import Component from "test";`},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
-				code:        `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + "`" + `<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
+				code:        `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + "`" + `${$$maybeRenderHead($$result)}<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
 			},
 		},
 		{
@@ -652,7 +653,7 @@ import Component from 'test';
 			want: want{
 				frontmatter: []string{`import Component from 'test';`},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
-				code:        `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + "`" + `<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
+				code:        `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + "`" + `${$$maybeRenderHead($$result)}<div>Default</div>` + "`" + `,"named": () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
 			},
 		},
 		{
@@ -662,7 +663,7 @@ import Component from 'test';
 	{items.map(item => <div>{item}</div>)}
 </Component>`,
 			want: want{
-				code: `${$$renderComponent($$result,'Component',Component,{"data":(data)},{"default": () => $$render` + BACKTICK + `${items.map(item => $$render` + BACKTICK + `<div>${item}</div>` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Component',Component,{"data":(data)},{"default": () => $$render` + BACKTICK + `${items.map(item => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<div>${item}</div>` + BACKTICK + `)}` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -707,7 +708,7 @@ const name = "world";
 		<p class="body">I’m a page</p>`,
 			want: want{
 				styles: []string{"{props:{\"data-astro-id\":\"DPOHFLYM\"},children:`.title.astro-DPOHFLYM{font-family:fantasy;font-size:28px}.body.astro-DPOHFLYM{font-size:1em}`}"},
-				code: "\n\n\t\t" + `<h1 class="title astro-DPOHFLYM">Page Title</h1>
+				code: "\n\n\t\t" + `${$$maybeRenderHead($$result)}<h1 class="title astro-DPOHFLYM">Page Title</h1>
 		<p class="body astro-DPOHFLYM">I’m a page</p>`,
 			},
 		},
@@ -912,7 +913,7 @@ import Widget2 from '../components/Widget2.astro';`},
 				styles:   []string{},
 				scripts:  []string{"{props:{\"type\":\"module\",\"hoist\":true},children:`console.log(\"Hello\");`}"},
 				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
-				code: `<main>
+				code: `${$$maybeRenderHead($$result)}<main>
 
 </main>`,
 			},
@@ -921,14 +922,14 @@ import Widget2 from '../components/Widget2.astro';`},
 			name:   "script inline",
 			source: `<main><script is:inline type="module">console.log("Hello");</script>`,
 			want: want{
-				code: `<main><script type="module">console.log("Hello");</script></main>`,
+				code: `${$$maybeRenderHead($$result)}<main><script type="module">console.log("Hello");</script></main>`,
 			},
 		},
 		{
 			name:   "script define:vars",
 			source: `<main><script define:vars={{ value: 0 }} type="module">console.log(value);</script>`,
 			want: want{
-				code: fmt.Sprintf(`<main><script type="module">${%s({ value: 0 })}console.log(value);</script></main>`, DEFINE_SCRIPT_VARS),
+				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<main><script type="module">${%s({ value: 0 })}console.log(value);</script></main>`, DEFINE_SCRIPT_VARS),
 			},
 		},
 		{
@@ -958,14 +959,14 @@ import Widget2 from '../components/Widget2.astro';`},
 				frontmatter: []string{`import Component from 'test';`, `const name = 'named';`},
 				styles:      []string{},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
-				code:        `${$$renderComponent($$result,'Component',Component,{},{[name]: () => $$render` + "`" + `<div>Named</div>` + "`" + `,})}`,
+				code:        `${$$renderComponent($$result,'Component',Component,{},{[name]: () => $$render` + "`" + `${$$maybeRenderHead($$result)}<div>Named</div>` + "`" + `,})}`,
 			},
 		},
 		{
 			name:   "condition expressions at the top-level",
 			source: `{cond && <span></span>}{cond && <strong></strong>}`,
 			want: want{
-				code: "${cond && $$render`<span></span>`}${cond && $$render`<strong></strong>`}",
+				code: "${cond && $$render`${$$maybeRenderHead($$result)}<span></span>`}${cond && $$render`<strong></strong>`}",
 			},
 		},
 		{
@@ -1065,7 +1066,7 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
 			name:   "Self-closing formatting elements",
 			source: `<div id="1"><div id="2"><div id="3"><i/><i/><i/></div></div></div>`,
 			want: want{
-				code: `<div id="1"><div id="2"><div id="3"><i></i><i></i><i></i></div></div></div>`,
+				code: `${$$maybeRenderHead($$result)}<div id="1"><div id="2"><div id="3"><i></i><i></i><i></i></div></div></div>`,
 			},
 		},
 		{
@@ -1076,7 +1077,7 @@ ${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"clie
   <div id="7"><div id="8"><div id="9"><i id="c" /></div></div></div>
 </body>`,
 			want: want{
-				code: `<body>
+				code: `${$$maybeRenderHead($$result)}<body>
   <div id="1"><div id="2"><div id="3"><i id="a"></i></div></div></div>
   <div id="4"><div id="5"><div id="6"><i id="b"></i></div></div></div>
   <div id="7"><div id="8"><div id="9"><i id="c"></i></div></div></div>
@@ -1116,7 +1117,7 @@ let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');
 }
 let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');`},
 				styles: []string{},
-				code:   "<div>testing</div>",
+				code:   "${$$maybeRenderHead($$result)}<div>testing</div>",
 			},
 		},
 		{
@@ -1140,7 +1141,7 @@ import ZComponent from '../components/ZComponent.jsx';`},
 						`{ module: $$module2, specifier: '../components/ZComponent.jsx', assert: {} }`,
 					},
 				},
-				code: `<body>
+				code: `${$$maybeRenderHead($$result)}<body>
   ${` + RENDER_COMPONENT + `($$result,'AComponent',AComponent,{})}
   ${` + RENDER_COMPONENT + `($$result,'ZComponent',ZComponent,{})}
 </body>`,
@@ -1157,14 +1158,14 @@ import ZComponent from '../components/ZComponent.jsx';`},
   sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"
 >`,
 			want: want{
-				code: `<html><body>` + longRandomString + `<img width="1600" height="1131" class="img" src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75" srcSet="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 800w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 1200w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1600&q=75 1600w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=2400&q=75 2400w" sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"></body></html>`,
+				code: `<html>${$$maybeRenderHead($$result)}<body>` + longRandomString + `<img width="1600" height="1131" class="img" src="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75" srcSet="https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 800w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1200&q=75 1200w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=1600&q=75 1600w,https://images.unsplash.com/photo-1469854523086-cc02fe5d8800?w=2400&q=75 2400w" sizes="(max-width: 800px) 800px, (max-width: 1200px) 1200px, (max-width: 1600px) 1600px, (max-width: 2400px) 2400px, 1200px"></body></html>`,
 			},
 		},
 		{
 			name:   "SVG styles",
 			source: `<svg><style>path { fill: red; }</style></svg>`,
 			want: want{
-				code: `<svg><style>path { fill: red; }</style></svg>`,
+				code: `${$$maybeRenderHead($$result)}<svg><style>path { fill: red; }</style></svg>`,
 			},
 		},
 		{
@@ -1175,7 +1176,7 @@ const title = 'icon';
 <svg>{title ?? null}</svg>`,
 			want: want{
 				frontmatter: []string{"", "const title = 'icon';"},
-				code:        `<svg>${title ?? null}</svg>`,
+				code:        `${$$maybeRenderHead($$result)}<svg>${title ?? null}</svg>`,
 			},
 		},
 		{
@@ -1186,7 +1187,7 @@ const title = 'icon';
 <svg>{title ? <title>{title}</title> : null}</svg>`,
 			want: want{
 				frontmatter: []string{"", "const title = 'icon';"},
-				code:        `<svg>${title ? $$render` + BACKTICK + `<title>${title}</title>` + BACKTICK + ` : null}</svg>`,
+				code:        `${$$maybeRenderHead($$result)}<svg>${title ? $$render` + BACKTICK + `<title>${title}</title>` + BACKTICK + ` : null}</svg>`,
 			},
 		},
 		{
@@ -1308,7 +1309,7 @@ import { Container, Col, Row } from 'react-bootstrap';
 			want: want{
 				frontmatter: []string{`import { Container, Col, Row } from 'react-bootstrap';`},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'react-bootstrap', assert: {} }`}},
-				code:        "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{},{\"default\": () => $$render`<h1>Hi!</h1>`,})}`,})}`,})}",
+				code:        "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{},{\"default\": () => $$render`${$$maybeRenderHead($$result)}<h1>Hi!</h1>`,})}`,})}`,})}",
 			},
 		},
 		{
@@ -1332,21 +1333,21 @@ import { Container, Col, Row } from 'react-bootstrap';
 			name:   "class with spread",
 			source: `<div class="something" {...Astro.props} />`,
 			want: want{
-				code: `<div class="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div class="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
 			},
 		},
 		{
 			name:   "class:list with spread",
 			source: `<div class:list="something" {...Astro.props} />`,
 			want: want{
-				code: `<div class:list="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div class:list="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
 			},
 		},
 		{
 			name:   "spread without style or class",
 			source: `<div {...Astro.props} />`,
 			want: want{
-				code: `<div${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
 			},
 		},
 		{
@@ -1356,21 +1357,21 @@ import { Container, Col, Row } from 'react-bootstrap';
 				styles: []string{
 					"{props:{\"data-astro-id\":\"TN53UTDL\"},children:`div.astro-TN53UTDL{color:red}`}",
 				},
-				code: `<div${$$spreadAttributes(Astro.props,"Astro.props",{"class":"astro-XXXX"})}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,"Astro.props",{"class":"astro-XXXX"})}></div>`,
 			},
 		},
 		{
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 			want: want{
-				code: `<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Fragment shorthand",
 			source: `<body><><div>Default</div><div>Named</div></></body>`,
 			want: want{
-				code: `<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
@@ -1391,28 +1392,28 @@ import { Container, Col, Row } from 'react-bootstrap';
 			name:   "Fragment slotted",
 			source: `<body><Component><><div>Default</div><div>Named</div></></Component></body>`,
 			want: want{
-				code: `<body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Fragment slotted with name",
 			source: `<body><Component><Fragment slot=named><div>Default</div><div>Named</div></Fragment></Component></body>`,
 			want: want{
-				code: `<body>${$$renderComponent($$result,'Component',Component,{},{"named": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{"slot":"named"},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>${$$renderComponent($$result,'Component',Component,{},{"named": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{"slot":"named"},{"default": () => $$render` + BACKTICK + `<div>Default</div><div>Named</div>` + BACKTICK + `,})}` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Preserve slots inside custom-element",
 			source: `<body><my-element><div slot=name>Name</div><div>Default</div></my-element></body>`,
 			want: want{
-				code: `<body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>${$$renderComponent($$result,'my-element','my-element',{},{"default": () => $$render` + BACKTICK + `<div slot="name">Name</div><div>Default</div>` + BACKTICK + `,})}</body>`,
 			},
 		},
 		{
 			name:   "Preserve namespaces",
 			source: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></svg>`,
 			want: want{
-				code: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></rect></svg>`,
+				code: `${$$maybeRenderHead($$result)}<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></rect></svg>`,
 			},
 		},
 		{
@@ -1515,7 +1516,7 @@ import ProductPageContent from '../../components/ProductPageContent.jsx';`,
 			name:   "doctype",
 			source: `<!DOCTYPE html><div/>`,
 			want: want{
-				code: `<!DOCTYPE html><div></div>`,
+				code: `<!DOCTYPE html>${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{
@@ -1526,7 +1527,7 @@ const value = 'test';
 <select><option>{value}</option></select>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<select><option>${value}</option></select>`,
+				code:        `${$$maybeRenderHead($$result)}<select><option>${value}</option></select>`,
 			},
 		},
 		{
@@ -1537,14 +1538,14 @@ const value = 'test';
 <select>{value && <option>{value}</option>}</select>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<select>${value && $$render` + BACKTICK + `<option>${value}</option>` + BACKTICK + `}</select>`,
+				code:        `${$$maybeRenderHead($$result)}<select>${value && $$render` + BACKTICK + `<option>${value}</option>` + BACKTICK + `}</select>`,
 			},
 		},
 		{
 			name:   "select map expression",
 			source: `<select>{[1, 2, 3].map(num => <option>{num}</option>)}</select><div>Hello world!</div>`,
 			want: want{
-				code: `<select>${[1, 2, 3].map(num => $$render` + BACKTICK + `<option>${num}</option>` + BACKTICK + `)}</select><div>Hello world!</div>`,
+				code: `${$$maybeRenderHead($$result)}<select>${[1, 2, 3].map(num => $$render` + BACKTICK + `<option>${num}</option>` + BACKTICK + `)}</select><div>Hello world!</div>`,
 			},
 		},
 		{
@@ -1555,14 +1556,14 @@ const value = 'test';
 <textarea>{value}</textarea>`,
 			want: want{
 				frontmatter: []string{"", "const value = 'test';"},
-				code:        `<textarea>${value}</textarea>`,
+				code:        `${$$maybeRenderHead($$result)}<textarea>${value}</textarea>`,
 			},
 		},
 		{
 			name:   "textarea inside expression",
 			source: `{bool && <textarea>{value}</textarea>} {!bool && <input>}`,
 			want: want{
-				code: `${bool && $$render` + BACKTICK + `<textarea>${value}</textarea>` + BACKTICK + `} ${!bool && $$render` + BACKTICK + `<input>` + BACKTICK + `}`,
+				code: `${bool && $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<textarea>${value}</textarea>` + BACKTICK + `} ${!bool && $$render` + BACKTICK + `<input>` + BACKTICK + `}`,
 			},
 		},
 		{
@@ -1573,14 +1574,14 @@ const items = ["Dog", "Cat", "Platipus"];
 <table>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<table>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
+				code:        `${$$maybeRenderHead($$result)}<table>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
 			name:   "table caption expression",
 			source: `<table><caption>{title}</caption><tr><td>Hello</td></tr></table>`,
 			want: want{
-				code: `<table><caption>${title}</caption><tr><td>Hello</td></tr></table>`,
+				code: `${$$maybeRenderHead($$result)}<table><caption>${title}</caption><tr><td>Hello</td></tr></table>`,
 			},
 		},
 		{
@@ -1591,7 +1592,7 @@ const items = ["Dog", "Cat", "Platipus"];
 <table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
+				code:        `${$$maybeRenderHead($$result)}<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
@@ -1602,105 +1603,105 @@ const items = ["Dog", "Cat", "Platipus"];
 <table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td><td>{item + 's'}</td></tr>))}</table>`,
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
-				code:        `<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td><td>${item + 's'}</td></tr>` + BACKTICK + `))}</table>`,
+				code:        `${$$maybeRenderHead($$result)}<table><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td><td>${item + 's'}</td></tr>` + BACKTICK + `))}</table>`,
 			},
 		},
 		{
 			name:   "tbody expressions 3",
 			source: `<table><tbody>{rows.map(row => (<tr><td><strong>{row}</strong></td></tr>))}</tbody></table>`,
 			want: want{
-				code: `<table><tbody>${rows.map(row => ($$render` + BACKTICK + `<tr><td><strong>${row}</strong></td></tr>` + BACKTICK + `))}</tbody></table>`,
+				code: `${$$maybeRenderHead($$result)}<table><tbody>${rows.map(row => ($$render` + BACKTICK + `<tr><td><strong>${row}</strong></td></tr>` + BACKTICK + `))}</tbody></table>`,
 			},
 		},
 		{
 			name:   "td expressions",
 			source: `<table><tr><td><h2>Row 1</h2></td><td>{title}</td></tr></table>`,
 			want: want{
-				code: `<table><tr><td><h2>Row 1</h2></td><td>${title}</td></tr></table>`,
+				code: `${$$maybeRenderHead($$result)}<table><tr><td><h2>Row 1</h2></td><td>${title}</td></tr></table>`,
 			},
 		},
 		{
 			name:   "th expressions",
 			source: `<table><thead><tr><th>{title}</th></tr></thead></table>`,
 			want: want{
-				code: `<table><thead><tr><th>${title}</th></tr></thead></table>`,
+				code: `${$$maybeRenderHead($$result)}<table><thead><tr><th>${title}</th></tr></thead></table>`,
 			},
 		},
 		{
 			name:   "tr only",
 			source: `<tr><td>col 1</td><td>col 2</td><td>{foo}</td></tr>`,
 			want: want{
-				code: `<tr><td>col 1</td><td>col 2</td><td>${foo}</td></tr>`,
+				code: `${$$maybeRenderHead($$result)}<tr><td>col 1</td><td>col 2</td><td>${foo}</td></tr>`,
 			},
 		},
 		{
 			name:   "caption only",
 			source: `<caption>Hello world!</caption>`,
 			want: want{
-				code: `<caption>Hello world!</caption>`,
+				code: `${$$maybeRenderHead($$result)}<caption>Hello world!</caption>`,
 			},
 		},
 		{
 			name:   "anchor expressions",
 			source: `<a>{expr}</a>`,
 			want: want{
-				code: `<a>${expr}</a>`,
+				code: `${$$maybeRenderHead($$result)}<a>${expr}</a>`,
 			},
 		},
 		{
 			name:   "anchor inside expression",
 			source: `{true && <a>expr</a>}`,
 			want: want{
-				code: `${true && $$render` + BACKTICK + `<a>expr</a>` + BACKTICK + `}`,
+				code: `${true && $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<a>expr</a>` + BACKTICK + `}`,
 			},
 		},
 		{
 			name:   "anchor content",
 			source: `<a><div><h3></h3><ul><li>{expr}</li></ul></div></a>`,
 			want: want{
-				code: `<a><div><h3></h3><ul><li>${expr}</li></ul></div></a>`,
+				code: `${$$maybeRenderHead($$result)}<a><div><h3></h3><ul><li>${expr}</li></ul></div></a>`,
 			},
 		},
 		{
 			name:   "small expression",
 			source: `<div><small>{a}</small>{data.map(a => <Component value={a} />)}</div>`,
 			want: want{
-				code: `<div><small>${a}</small>${data.map(a => $$render` + BACKTICK + `${$$renderComponent($$result,'Component',Component,{"value":(a)})}` + BACKTICK + `)}</div>`,
+				code: `${$$maybeRenderHead($$result)}<div><small>${a}</small>${data.map(a => $$render` + BACKTICK + `${$$renderComponent($$result,'Component',Component,{"value":(a)})}` + BACKTICK + `)}</div>`,
 			},
 		},
 		{
 			name:   "division inside expression",
 			source: `<div>{16 / 4}</div>`,
 			want: want{
-				code: `<div>${16 / 4}</div>`,
+				code: `${$$maybeRenderHead($$result)}<div>${16 / 4}</div>`,
 			},
 		},
 		{
 			name:   "escaped entity",
 			source: `<img alt="A person saying &#x22;hello&#x22;">`,
 			want: want{
-				code: `<img alt="A person saying &quot;hello&quot;">`,
+				code: `${$$maybeRenderHead($$result)}<img alt="A person saying &quot;hello&quot;">`,
 			},
 		},
 		{
 			name:   "textarea in form",
 			source: `<html><Component><form><textarea></textarea></form></Component></html>`,
 			want: want{
-				code: `<html>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `,})}</html>`,
+				code: `<html>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<form><textarea></textarea></form>` + BACKTICK + `,})}</html>`,
 			},
 		},
 		{
 			name:   "select in form",
 			source: `<form><select>{options.map((option) => (<option value={option.id}>{option.title}</option>))}</select><div><label>Title 3</label><input type="text" /></div><button type="submit">Submit</button></form>`,
 			want: want{
-				code: `<form><select>${options.map((option) => ($$render` + BACKTICK + `<option${$$addAttribute(option.id, "value")}>${option.title}</option>` + BACKTICK + `))}</select><div><label>Title 3</label><input type="text"></div><button type="submit">Submit</button></form>`,
+				code: `${$$maybeRenderHead($$result)}<form><select>${options.map((option) => ($$render` + BACKTICK + `<option${$$addAttribute(option.id, "value")}>${option.title}</option>` + BACKTICK + `))}</select><div><label>Title 3</label><input type="text"></div><button type="submit">Submit</button></form>`,
 			},
 		},
 		{
 			name:   "slot inside of Base",
 			source: `<Base title="Home"><div>Hello</div></Base>`,
 			want: want{
-				code: `${$$renderComponent($$result,'Base',Base,{"title":"Home"},{"default": () => $$render` + BACKTICK + `<div>Hello</div>` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Base',Base,{"title":"Home"},{"default": () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<div>Hello</div>` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -1719,7 +1720,7 @@ const items = ["Dog", "Cat", "Platipus"];
 
 			want: want{
 				styles: []string{fmt.Sprintf(`{props:{"data-astro-id":"SJ3WYE6H"},children:%s.container.astro-SJ3WYE6H{padding:2rem}%s}`, BACKTICK, BACKTICK)},
-				code:   `<div class="container astro-SJ3WYE6H">My Text</div>`,
+				code:   `${$$maybeRenderHead($$result)}<div class="container astro-SJ3WYE6H">My Text</div>`,
 			},
 		},
 		{
@@ -1732,7 +1733,7 @@ const items = ["Dog", "Cat", "Platipus"];
   </table>
 </body>`,
 			want: want{
-				code: fmt.Sprintf(`<html><body>
+				code: fmt.Sprintf(`<html>${$$maybeRenderHead($$result)}<body>
   <table>
   ${true ? ($$render%s<tr><td>Row 1</td></tr>%s) : null}
   ${true ? ($$render%s<tr><td>Row 2</td></tr>%s) : null}
@@ -1752,21 +1753,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "Empty expression",
 			source: "<body>({})</body>",
 			want: want{
-				code: `<body>(${(void 0)})</body>`,
+				code: `${$$maybeRenderHead($$result)}<body>(${(void 0)})</body>`,
 			},
 		},
 		{
 			name:   "Empty attribute expression",
 			source: "<body attr={}></body>",
 			want: want{
-				code: `<body${$$addAttribute((void 0), "attr")}></body>`,
+				code: `${$$maybeRenderHead($$result)}<body${$$addAttribute((void 0), "attr")}></body>`,
 			},
 		},
 		{
 			name:   "is:raw",
 			source: "<article is:raw><% awesome %></article>",
 			want: want{
-				code: `<article><% awesome %></article>`,
+				code: `${$$maybeRenderHead($$result)}<article><% awesome %></article>`,
 			},
 		},
 		{
@@ -1780,14 +1781,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html",
 			source: "<article set:html={content} />",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
 			name:   "set:text",
 			source: "<article set:text={content} />",
 			want: want{
-				code: `<article>${content}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${content}</article>`,
 			},
 		},
 		{
@@ -1822,21 +1823,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on self-closing tag",
 			source: "<article set:html={content} />",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
 			name:   "set:html with other attributes",
 			source: "<article set:html={content} cool=\"true\" />",
 			want: want{
-				code: `<article cool="true">${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
 			name:   "set:html on empty tag",
 			source: "<article set:html={content}></article>",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
@@ -1844,21 +1845,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html and set:text",
 			source: "<article set:html={content} set:text={content} />",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with children",
 			source: "<article set:html={content}>!!!</article>",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with empty whitespace",
 			source: "<article set:html={content}>   </article>",
 			want: want{
-				code: `<article>${$$unescapeHTML(content)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
 		{
@@ -1880,7 +1881,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			source:           "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			staticExtraction: true,
 			want: want{
-				code: `<h1 class="astro-VFS5OEMV">testing</h1>`,
+				code: `${$$maybeRenderHead($$result)}<h1 class="astro-VFS5OEMV">testing</h1>`,
 				styles: []string{
 					"{props:{\"define:vars\":({color:'green'}),\"data-astro-id\":\"VFS5OEMV\"},children:`h1.astro-VFS5OEMV{color:var(--color)}`}",
 				},
@@ -1905,28 +1906,28 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "comments removed from attribute list",
 			source: `<div><h1 {/* comment 1 */} value="1" {/* comment 2 */}>Hello</h1><Component {/* comment 1 */} value="1" {/* comment 2 */} /></div>`,
 			want: want{
-				code: `<div><h1 value="1">Hello</h1>${$$renderComponent($$result,'Component',Component,{"value":"1",})}</div>`,
+				code: `${$$maybeRenderHead($$result)}<div><h1 value="1">Hello</h1>${$$renderComponent($$result,'Component',Component,{"value":"1",})}</div>`,
 			},
 		},
 		{
 			name:   "includes comments for shorthand attribute",
 			source: `<div><h1 {/* comment 1 */ id /* comment 2 */}>Hello</h1><Component {/* comment 1 */ id /* comment 2 */}/></div>`,
 			want: want{
-				code: `<div><h1${$$addAttribute(/* comment 1 */ id /* comment 2 */, "id")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"id":(/* comment 1 */ id /* comment 2 */)})}</div>`,
+				code: `${$$maybeRenderHead($$result)}<div><h1${$$addAttribute(/* comment 1 */ id /* comment 2 */, "id")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"id":(/* comment 1 */ id /* comment 2 */)})}</div>`,
 			},
 		},
 		{
 			name:   "includes comments for expression attribute",
 			source: `<div><h1 attr={/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */}>Hello</h1><Component attr={/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */}/></div>`,
 			want: want{
-				code: `<div><h1${$$addAttribute(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */, "attr")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"attr":(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */)})}</div>`,
+				code: `${$$maybeRenderHead($$result)}<div><h1${$$addAttribute(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */, "attr")}>Hello</h1>${$$renderComponent($$result,'Component',Component,{"attr":(/* comment 1 */ isTrue ? 1 : 2 /* comment 2 */)})}</div>`,
 			},
 		},
 		{
 			name:   "comment only expressions are removed",
 			source: `{/* a comment 1 */}<h1>{/* a comment 2*/}Hello</h1>`,
 			want: want{
-				code: `<h1>Hello</h1>`,
+				code: `${$$maybeRenderHead($$result)}<h1>Hello</h1>`,
 			},
 		},
 	}


### PR DESCRIPTION
## Changes

- This removes the previous `render:head` comment with a call to `renderHead($$result)`. This is placed at the end of the head.
- This *also* adds `maybeRenderHead($$result)` insertion points. These are placed before the *first* non-head element of a component; a div, a textarea, a body tag, whatever.
  - The `$$result` object is used as a key in a WeakMap, so that this `maybeRenderHead` is only going to result in head injection if there wasn't already an injected head somewhere else, for ex in a parent page component.
  - All of this logic only exists to accommodate not having to use a `<head>` element in an Astro app.
  
There is 1 scenario where this might not inject in the right place:

```astro
---
import SomeComponent from '../components/SomeComponent.jsx';
---
<SomeComponent>
  <div>here</div>
<SomeComponent>
```

Here `SomeComponent` is a non-Astro component that contains its own `<head>`. Since we don't know about non-Astro components we can't inject into its head. Instead we'll inject right before the `<div>`. This seems like a pretty corner-case and worth the tradeoff.

## Testing

- All tests are updated and verified.
- More tests added for the no-head condition in the main Astro repo.

## Docs

N/A, this is a perf related issue for streaming.