### PR TITLE
fix: escape template literals in HTML attribute value strings

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -285,7 +285,7 @@ func (p *printer) printAttribute(attr astro.Attribute, n *astro.Node) {
 		p.print(attr.Key)
 		p.print("=")
 		p.addSourceMapping(attr.ValLoc)
-		p.print(`"` + encodeDoubleQuote(attr.Val) + `"`)
+		p.print(`"` + encodeDoubleQuote(escapeInterpolation(escapeBackticks(attr.Val))) + `"`)
 	case astro.EmptyAttribute:
 		p.addSourceMapping(attr.KeyLoc)
 		p.print(attr.Key)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -135,6 +135,20 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "attribute with template literal",
+			source: "<a :href=\"`/home`\">Home</a>",
+			want: want{
+				code: "<a :href=\"\\`/home\\`\">Home</a>",
+			},
+		},
+		{
+			name:   "attribute with template literal interpolation",
+			source: "<a :href=\"`/${url}`\">Home</a>",
+			want: want{
+				code: "<a :href=\"\\`/\\${url}\\`\">Home</a>",
+			},
+		},
+		{
 			name: "basic (frontmatter)",
 			source: `---
 const href = '/about';

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -95,6 +95,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{SelfClosingTagToken, StartTagToken, EndTagToken, SelfClosingTagToken},
 		},
 		{
+			"attribute with quoted template literal",
+			"<a :href=\"`/home`\">Home</a>",
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
 			"No expressions inside math",
 			`<math>{test}</math>`,
 			[]TokenType{StartTagToken, TextToken, TextToken, TextToken, EndTagToken},
@@ -777,6 +782,16 @@ func TestAttributes(t *testing.T) {
 		{
 			"expression with apostrophe",
 			`<div a="fred's" />`,
+			[]AttributeType{QuotedAttribute},
+		},
+		{
+			"expression with template literal",
+			"<div a=\"`value`\" />",
+			[]AttributeType{QuotedAttribute},
+		},
+		{
+			"expression with template literal interpolation",
+			"<div a=\"`${value}`\" />",
 			[]AttributeType{QuotedAttribute},
 		},
 		{


### PR DESCRIPTION
Closes #437 

## Changes

Backticks in plain HTML attributes needs to escaped in the render output

## Testing

- Added token and printer tests to verify the backticks are being escaped in attribute values
- Tested manually by doing the escaping in Astro core in between `transform()` and `compile()`

## Docs

bug fix only
