### PR TITLE
Preserve `slot` attribute outside of component, support `<slot is:inline />`

### DIFF
--- a/.changeset/happy-vans-fetch.md
+++ b/.changeset/happy-vans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Support `<slot is:inline />` and preserve slot attribute when not inside component

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -354,9 +354,11 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	isSlot := n.DataAtom == atom.Slot
 	isImplicit := false
 	for _, a := range n.Attr {
+		if isSlot && a.Key == "is:inline" {
+			isSlot = false
+		}
 		if transform.IsImplictNodeMarker(a) {
 			isImplicit = true
-			break
 		}
 	}
 
@@ -438,13 +440,13 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				continue
 			}
 			if a.Key == "slot" {
-				if !(n.Parent.Component || n.Parent.CustomElement) {
-					panic(`Element with a slot='...' attribute must be a child of a component or a descendant of a custom element`)
+				if n.Parent.Component {
+					continue
 				}
-				if n.Parent.CustomElement {
-					p.printAttribute(a, n)
-					p.addSourceMapping(n.Loc[0])
-				}
+				// Note: if we encounter "slot" NOT inside a component, that's fine
+				// These should be perserved in the output
+				p.printAttribute(a, n)
+				p.addSourceMapping(n.Loc[0])
 			} else {
 				p.printAttribute(a, n)
 				p.addSourceMapping(n.Loc[0])

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -130,6 +130,20 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "preserve is:inline slot",
+			source: `<slot is:inline />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<slot></slot>`,
+			},
+		},
+		{
+			name:   "preserve is:inline slot II",
+			source: `<slot name="test" is:inline />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<slot name="test"></slot>`,
+			},
+		},
+		{
 			name:   "text only",
 			source: "Hello!",
 			want: want{
@@ -140,14 +154,14 @@ func TestPrinter(t *testing.T) {
 			name:   "attribute with template literal",
 			source: "<a :href=\"`/home`\">Home</a>",
 			want: want{
-				code: "<a :href=\"\\`/home\\`\">Home</a>",
+				code: "${$$maybeRenderHead($$result)}<a :href=\"\\`/home\\`\">Home</a>",
 			},
 		},
 		{
 			name:   "attribute with template literal interpolation",
 			source: "<a :href=\"`/${url}`\">Home</a>",
 			want: want{
-				code: "<a :href=\"\\`/\\${url}\\`\">Home</a>",
+				code: "${$$maybeRenderHead($$result)}<a :href=\"\\`/\\${url}\\`\">Home</a>",
 			},
 		},
 		{


### PR DESCRIPTION
## Changes

- Previously, we would throw if the `slot` attribute was used outside of a component or `custom-element`.
- Given projects like OpenUI's upcoming [`select`](https://open-ui.org/components/select), standard elements may soon support slots. We need to support this.
- This PR preserves `slot` attributes **unless** the immediate parent is a component. This matches existing behavior **and** unblocks standard uses for the `slot` attribute.
- This PR adds `is:inline` support for the `slot` element. Instead of replacing this with slotted contents, we will literally print `<slot />`. This unblocks standard use cases for the `slot` element.

## Testing

Printer tests added.

## Docs

TODO