### PR TITLE
fix(#3823): scope html and body elements

### DIFF
--- a/.changeset/twenty-snakes-punch.md
+++ b/.changeset/twenty-snakes-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Ensure `html` and `body` elements are scoped

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -893,7 +893,7 @@ import Counter from '../components/Counter.jsx'`,
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
   
   ` + RENDER_HEAD_RESULT + `</head>
-  <body>
+  <body class="astro-HMNNHVCQ">
     <main class="astro-HMNNHVCQ">
       ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":($$metadata.getPath(Counter)),"client:component-export":($$metadata.getExport(Counter)),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
     </main>

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -15,10 +15,8 @@ func ScopeElement(n *astro.Node, opts TransformOptions) {
 }
 
 var NeverScopedElements map[string]bool = map[string]bool{
-	// "html" is a notable omission, see `NeverScopedSelectors`
 	"Fragment": true,
 	"base":     true,
-	"body":     true,
 	"font":     true,
 	"frame":    true,
 	"frameset": true,
@@ -33,8 +31,6 @@ var NeverScopedElements map[string]bool = map[string]bool{
 }
 
 var NeverScopedSelectors map[string]bool = map[string]bool{
-	// html is never scoped as a selector (from CSS) but is scoped as an element (from HTML)
-	"html":  true,
 	":root": true,
 }
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/3823
- For historical reasons, `body` was not scoped and `html` had inconsistent behavior.
- Now `html` and `body` are scoped like any element.

## Testing

Relevant tests updated

## Docs

Bug fix only