### PR TITLE
Handle nested expressions edge case

### DIFF
--- a/.changeset/eight-teachers-sniff.md
+++ b/.changeset/eight-teachers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Properly handle nested expressions that return multiple elements

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -620,6 +620,27 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			},
 		},
 		{
+			name:   "nested expressions II",
+			source: `<article>{(previous || next) && <aside>{previous && <div>Previous Article: <a rel="prev" href={new URL(previous.link, Astro.site).pathname}>{previous.text}</a></div>} {next && <div>Next Article: <a rel="next" href={new URL(next.link, Astro.site).pathname}>{next.text}</a></div>}</aside>}</article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${(previous || next) && $$render` + BACKTICK + `<aside>${previous && $$render` + BACKTICK + `<div>Previous Article: <a rel="prev"${$$addAttribute(new URL(previous.link, Astro.site).pathname, "href")}>${previous.text}</a></div>` + BACKTICK + `} ${next && $$render` + BACKTICK + `<div>Next Article: <a rel="next"${$$addAttribute(new URL(next.link, Astro.site).pathname, "href")}>${next.text}</a></div>` + BACKTICK + `}</aside>` + BACKTICK + `}</article>`,
+			},
+		},
+		{
+			name:   "nested expressions III",
+			source: `<div>{x.map((x) => x ? <div>{true ? <span>{x}</span> : null}</div> : <div>{false ? null : <span>{x}</span>}</div>)}</div>`,
+			want: want{
+				code: "${$$maybeRenderHead($$result)}<div>${x.map((x) => x ? $$render`<div>${true ? $$render`<span>${x}</span>` : null}</div>` : $$render`<div>${false ? null : $$render`<span>${x}</span>`}</div>`)}</div>",
+			},
+		},
+		{
+			name:   "nested expressions IV",
+			source: `<div>{() => { if (value > 0.25) { return <span>Default</span> } else if (value > 0.5) { return <span>Another</span> } else if (value > 0.75) { return <span>Other</span> } return <span>Yet Other</span> }}</div>`,
+			want: want{
+				code: "${$$maybeRenderHead($$result)}<div>${() => { if (value > 0.25) { return $$render`<span>Default</span>`} else if (value > 0.5) { return $$render`<span>Another</span>`} else if (value > 0.75) { return $$render`<span>Other</span>`} return $$render`<span>Yet Other</span>`}}</div>",
+			},
+		},
+		{
 			name: "expressions with JS comments",
 			source: `---
 const items = ['red', 'yellow', 'blue'];

--- a/internal/token.go
+++ b/internal/token.go
@@ -1333,13 +1333,17 @@ func (z *Tokenizer) isAtExpressionBoundary() bool {
 }
 
 func (z *Tokenizer) trackPreviousTokens() {
-	if z.tt == StartExpressionToken {
+	// Reset stack on expression boundaries
+	if z.tt == StartExpressionToken || z.tt == EndExpressionToken {
 		z.prevTokens = make([]Token, 0)
 	}
 	if z.tt == StartTagToken {
 		z.prevTokens = append(z.prevTokens, z.Token())
 	} else if z.tt == EndTagToken {
 		if len(z.prevTokens) > 0 {
+			// This is a very simple stack that pops matching closing elements off the stack,
+			// which is good enough for our purposes.
+			// We only use this to track when `{` should be `StartExpressionToken` or `TextToken`
 			for i := 1; i < len(z.prevTokens)+1; i++ {
 				tok := z.prevTokens[len(z.prevTokens)-i]
 				if tok.Data == string(z.buf[z.data.Start:z.data.End]) {

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -199,6 +199,20 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"expression with multiple elements",
+			`<div>{() => {
+				if (value > 0.25) {
+					return <span>Default</span>
+				} else if (value > 0.5) {
+					return <span>Another</span>
+				} else if (value > 0.75) {
+					return <span>Other</span>
+				}
+				return <span>Yet Other</span>
+			}}</div>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
+		},
+		{
 			"attribute expression with quoted braces",
 			`<div value={"{"} />`,
 			[]TokenType{SelfClosingTagToken},


### PR DESCRIPTION
## Changes

- Discovered a bug in the course of fixing https://github.com/withastro/compiler/pull/447
- Fixes edge case with multiple nested expressions
- The tokenizer has some rough heuristics around when braces start an expression vs when they act as raw text
- Previously, `StartTagToken` and `EndTagToken` would reset these heuristics
- This PR implements a simple stack for `StartTagToken` and `EndTagToken` that determines if we're inside elements (`{` === `StartExpressionToken`) or outside of them (`{` === `TextToken`)

## Testing

Multiple test cases added

## Docs

Bug fix only
