### PR TITLE
Warn on client: usage with scripts

### DIFF
--- a/.changeset/stale-birds-clean.md
+++ b/.changeset/stale-birds-clean.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Warning on client: usage on scripts

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -198,6 +198,12 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 			if shouldAdd {
 				doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
 			}
+		} else {
+			for _, attr := range n.Attr {
+				if strings.HasPrefix(attr.Key, "client:") {
+					fmt.Printf("%s: <script> does not need the %s directive and is always added as a module script.\n", opts.Filename, attr.Key)
+				}
+			}
 		}
 	}
 }

--- a/packages/compiler/test/client-directive/warn.ts
+++ b/packages/compiler/test/client-directive/warn.ts
@@ -1,0 +1,18 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<script client:load></script>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, { experimentalStaticExtraction: true });
+});
+
+test('logs a warning for using a client directive', () => {
+  assert.ok(result.code);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Adds a warning when using a `client:` directive on a script.

## Testing

- Added a test, but unable to specifically capture the warning in a test. Tried overriding console.log/warn/error, I think Go might be pushing to `stdout` directly. However you can see that the warning does occur when running the test.

## Docs

N/A