### PR TITLE
Remove site default

### DIFF
--- a/.changeset/good-pears-chew.md
+++ b/.changeset/good-pears-chew.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Removes fallback for the site configuration

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -81,7 +81,7 @@ func makeTransformOptions(options js.Value, hash string) transform.TransformOpti
 
 	site := jsString(options.Get("site"))
 	if site == "" {
-		site = "https://astro.build"
+		site = ""
 	}
 
 	projectRoot := jsString(options.Get("projectRoot"))


### PR DESCRIPTION
## Changes

- This removes the default/fallback for `site`, because you have to provide that value now and we want `Astro.site` to be undefined if no value is provided.

## Testing

- Tested in withastro/astro proper.

## Docs

N/A