### PR TITLE
Fix unmatched closing brace in template literal

### DIFF
--- a/.changeset/proud-cheetahs-sort.md
+++ b/.changeset/proud-cheetahs-sort.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of unmatched close brace in template literals

--- a/internal/token.go
+++ b/internal/token.go
@@ -1309,9 +1309,12 @@ func (z *Tokenizer) readTagAttrExpression() {
 				z.attrTemplateLiteralStack = append(z.attrTemplateLiteralStack, 0)
 			}
 		case '}':
-			z.attrExpressionStack--
-			if z.attrExpressionStack == 0 && z.allTagAttrExpressionsClosed() {
-				return
+			inTemplateLiteral := len(z.attrTemplateLiteralStack) >= z.attrExpressionStack && z.attrTemplateLiteralStack[z.attrExpressionStack-1] > 0
+			if !inTemplateLiteral {
+				z.attrExpressionStack--
+				if z.attrExpressionStack == 0 && z.allTagAttrExpressionsClosed() {
+					return
+				}
 			}
 		}
 	}

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -376,8 +376,18 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, EndTagToken, StartTagToken, TextToken, EndTagToken},
 		},
 		{
-			"single brace",
+			"single open brace",
 			"<main id={`{`}></main>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
+		{
+			"single close brace",
+			"<main id={`}`}></main>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
+		{
+			"extra close brace",
+			"<main id={`${}}`}></main>",
 			[]TokenType{StartTagToken, EndTagToken},
 		},
 		{


### PR DESCRIPTION
## Changes

- Fixes #424 
- Properly handle unmatched `}` inside template literals

## Testing

Tests added

## Docs

Bug fix only