### PR TITLE
Add tests for TSX sourcemaps

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -30,6 +30,7 @@
     "./types": "./types.d.ts"
   },
   "devDependencies": {
+    "@jridgewell/trace-mapping": "^0.3.14",
     "@types/node": "^16.4.12",
     "@types/sass": "^1.43.1",
     "typescript": "^4.4.3"

--- a/packages/compiler/test/tsx-sourcemaps/frontmatter.ts
+++ b/packages/compiler/test/tsx-sourcemaps/frontmatter.ts
@@ -1,0 +1,22 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { convertToTSX } from '@astrojs/compiler';
+import { generatedPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+
+test('frontmatter', async () => {
+  const input = `---
+dontExist
+---
+`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const traced = generatedPositionFor(tracer, { source: '<stdin>', line: 2, column: 0 });
+  assert.equal(traced, {
+    line: 1,
+    column: 0,
+  });
+});
+
+test.run();

--- a/packages/compiler/test/tsx-sourcemaps/template.ts
+++ b/packages/compiler/test/tsx-sourcemaps/template.ts
@@ -1,0 +1,85 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { convertToTSX } from '@astrojs/compiler';
+import { generatedPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+
+test('template expression basic', async () => {
+  const input = `<div>
+{dontExist}
+</div>
+`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const traced = generatedPositionFor(tracer, { source: '<stdin>', line: 2, column: 1 });
+  assert.equal(traced, {
+    line: 3,
+    column: 1,
+  });
+});
+
+test('template expression has dot', async () => {
+  const input = `<div>
+{console.log(hey)}
+</div>
+`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const traced = generatedPositionFor(tracer, { source: '<stdin>', line: 2, column: 13 });
+  assert.equal(traced, {
+    line: 3,
+    column: 13,
+  });
+});
+
+test('template expression with addition', async () => {
+  const input = `{"hello" + hey}`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const traced = generatedPositionFor(tracer, { source: '<stdin>', line: 1, column: 10 });
+  assert.equal(traced, {
+    line: 2,
+    column: 10,
+  });
+});
+
+test('html attribute', async () => {
+  const input = `<svg color="#000"></svg>`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const traced = generatedPositionFor(tracer, { source: '<stdin>', line: 1, column: 6 });
+  assert.equal(traced, {
+    line: 2,
+    column: 6,
+  });
+});
+
+test('complex template expression', async () => {
+  const input = `{[].map(item => {
+return <div>{items}</div>
+})}`;
+
+  const { map } = await convertToTSX(input);
+  const tracer = new TraceMap(map);
+
+  const item = generatedPositionFor(tracer, { source: '<stdin>', line: 1, column: 7 });
+  const items = generatedPositionFor(tracer, { source: '<stdin>', line: 2, column: 12 });
+
+  assert.equal(item, {
+    line: 2,
+    column: 7,
+  });
+  assert.equal(items, {
+    line: 3,
+    column: 24,
+  });
+});
+
+test.run();

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -60,6 +60,28 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('add trailling semicolon to frontmatter', async () => {
+  const input = `
+---
+const hello = ""
+---
+
+{hello}
+`;
+  const output = `
+const hello = "";
+<Fragment>
+{hello}
+</Fragment>
+
+export default function __AstroComponent_(_props: Record<string, any>): any {}
+`;
+  const { code } = await convertToTSX(input);
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test.run();
+
 test('moves attributes with dots in them to spread', async () => {
   const input = `<div x-on:keyup.shift.enter="alert('Astro')" name="value"></div>`;
   const output = `<Fragment>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,12 @@ importers:
 
   packages/compiler:
     specifiers:
+      '@jridgewell/trace-mapping': ^0.3.14
       '@types/node': ^16.4.12
       '@types/sass': ^1.43.1
       typescript: ^4.4.3
     devDependencies:
+      '@jridgewell/trace-mapping': 0.3.15
       '@types/node': 16.11.39
       '@types/sass': 1.43.1
       typescript: 4.7.3
@@ -281,6 +283,22 @@ packages:
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.15:
+    resolution: {integrity: sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
     dev: true
 
   /@manypkg/find-root/1.1.0:


### PR DESCRIPTION
## Changes

This adds some tests for the source maps generated when doing the TSX output. This also add a test for https://github.com/withastro/compiler/issues/461, though the "solution" in the test is an idealist one, I think

The expected offsets should be correct, however building failing tests is not super convenient 😅 A more extensive test suite for this is to run the tests from [the language server's compiler output PR](https://github.com/withastro/language-tools/pull/335), if the sourcemaps are correct, all tests should pass

## Testing

It's tests all the way down

## Docs

N/A
