### PR TITLE
Remove limitation that imports must be at the top

### DIFF
--- a/.changeset/twenty-spoons-perform.md
+++ b/.changeset/twenty-spoons-perform.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': minor
 ---
 
-Removes limitation where imports must be at the top of an `.astro` file, fixes various edge cases around `getStaticPaths` hoisting
+Removes limitation where imports/exports must be at the top of an `.astro` file. Fixes various edge cases around `getStaticPaths` hoisting.

--- a/.changeset/twenty-spoons-perform.md
+++ b/.changeset/twenty-spoons-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Removes limitation where imports must be at the top of an `.astro` file, fixes various edge cases around `getStaticPaths` hoisting

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -145,12 +145,6 @@ outer:
 	}
 }
 
-var keywords = map[string]bool{
-	"interface": true,
-	"async":     true,
-	"await":     true,
-}
-
 func isKeyword(value []byte) bool {
 	return js.Keywords[string(value)] != 0
 }

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -319,6 +319,11 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 					}
 				}
 
+				// do not hoist dynamic imports
+				if next == js.OpenParenToken && len(specifier) == 0 {
+					break
+				}
+
 				// if this is import.meta.*, ignore (watch for first dot)
 				if next == js.DotToken && len(specifier) == 0 {
 					break

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -1,165 +1,13 @@
 package js_scanner
 
 import (
-	"fmt"
+	"bytes"
 	"io"
 
 	"github.com/tdewolff/parse/v2"
 	"github.com/tdewolff/parse/v2/js"
+	"github.com/withastro/compiler/internal/loc"
 )
-
-// This function returns the index at which we should split the frontmatter.
-// The first slice contains any top-level imports/exports, which are global.
-// The second slice contains any non-exported declarations, which are scoped to the render body
-//
-// Why use a lexical scan here?
-//   1. We can stop lexing as soon as we hit a non-exported token
-//   2. Lexing supports malformed modules, they'll throw at runtime instead of compilation
-//   3. `tdewolff/parse/v2` doesn't support TypeScript parsing yet, but we can lex it fine
-func FindRenderBody(source []byte) int {
-	l := js.NewLexer(parse.NewInputBytes(source))
-	i := 0
-	pairs := make(map[byte]int)
-
-	// Let's lex the script until we find what we need!
-	for {
-		token, value := l.Next()
-		if token == js.DivToken || token == js.DivEqToken {
-			token, value = l.RegExp()
-		}
-		openPairs := pairs['{'] > 0 || pairs['('] > 0 || pairs['['] > 0
-		if token == js.ErrorToken {
-			break
-		}
-
-		// Common delimeters. Track their length, then skip.
-		if token == js.WhitespaceToken || token == js.LineTerminatorToken || token == js.SemicolonToken {
-			i += len(value)
-			continue
-		}
-
-		// Imports should be consumed up until we find a specifier,
-		// then we can exit after the following line terminator or semicolon
-		if token == js.ImportToken {
-			i += len(value)
-			foundSpecifier := false
-			foundAssertion := false
-			for {
-				next, nextValue := l.Next()
-				if token == js.DivToken || token == js.DivEqToken {
-					next, nextValue = l.RegExp()
-				}
-				if next == js.ErrorToken {
-					break
-				}
-				i += len(nextValue)
-				if next == js.StringToken {
-					foundSpecifier = true
-				}
-				if foundSpecifier && (next == js.LineTerminatorToken || next == js.SemicolonToken) && pairs['{'] == 0 && pairs['('] == 0 && pairs['['] == 0 {
-					break
-				}
-				if !foundAssertion && next == js.IdentifierToken && string(nextValue) == "assert" {
-					foundAssertion = true
-				}
-				if foundSpecifier {
-					if nextValue[0] == '{' || nextValue[0] == '(' || nextValue[0] == '[' {
-						pairs[nextValue[0]]++
-					} else if nextValue[0] == '}' {
-						pairs['{']--
-					} else if nextValue[0] == ')' {
-						pairs['(']--
-					} else if nextValue[0] == ']' {
-						pairs['[']--
-					}
-				}
-			}
-			continue
-		}
-
-		// Exports should be consumed until all opening braces are closed,
-		// a specifier is found, and a line terminator has been found
-		if token == js.ExportToken {
-			foundIdentifier := false
-			foundSemicolonOrLineTerminator := false
-			i += len(value)
-			for {
-				next, nextValue := l.Next()
-				if next == js.DivToken || next == js.DivEqToken {
-					next, nextValue = l.RegExp()
-				}
-				if next == js.ErrorToken {
-					break
-				}
-				i += len(nextValue)
-				if js.IsIdentifier(next) {
-					foundIdentifier = true
-				} else if next == js.LineTerminatorToken || next == js.SemicolonToken {
-					foundSemicolonOrLineTerminator = true
-				} else if js.IsPunctuator(next) {
-					if nextValue[0] == '{' || nextValue[0] == '(' || nextValue[0] == '[' {
-						pairs[nextValue[0]]++
-					} else if nextValue[0] == '}' {
-						pairs['{']--
-					} else if nextValue[0] == ')' {
-						pairs['(']--
-					} else if nextValue[0] == ']' {
-						pairs['[']--
-					}
-				}
-
-				if foundIdentifier && foundSemicolonOrLineTerminator && pairs['{'] == 0 && pairs['('] == 0 && pairs['['] == 0 {
-					break
-				}
-			}
-			continue
-		}
-
-		// Track opening and closing braces
-		if js.IsPunctuator(token) {
-			if value[0] == '{' || value[0] == '(' || value[0] == '[' {
-				pairs[value[0]]++
-				i += len(value)
-				continue
-			} else if value[0] == '}' {
-				pairs['{']--
-			} else if value[0] == ')' {
-				pairs['(']--
-			} else if value[0] == ']' {
-				pairs['[']--
-			}
-		}
-
-		// If there are no open pairs and we hit anything other than a comment
-		// return our index! This is the first non-exported declaration
-		if !openPairs && token != js.CommentToken {
-			return i
-		}
-
-		// Track our current position
-		i += len(value)
-	}
-
-	// If we haven't found anything... there's nothing to find! Split at the start.
-	return i
-}
-
-func HasExports(source []byte) bool {
-	l := js.NewLexer(parse.NewInputBytes(source))
-	var prevToken js.TokenType
-	for {
-		token, _ := l.Next()
-		if token == js.ErrorToken {
-			// EOF or other error
-			return false
-		}
-		if token == js.ExportToken {
-			fmt.Println(prevToken, token)
-			return true
-		}
-		prevToken = token
-	}
-}
 
 type HoistedScripts struct {
 	Hoisted [][]byte
@@ -182,6 +30,13 @@ func HoistExports(source []byte) HoistedScripts {
 	for {
 		token, value := l.Next()
 
+		if token == js.DivToken || token == js.DivEqToken {
+			lns := bytes.Split(source[i+1:], []byte{'\n'})
+			if bytes.Contains(lns[0], []byte{'/'}) {
+				token, value = l.RegExp()
+			}
+		}
+
 		if token == js.ErrorToken {
 			if l.Err() != io.EOF {
 				return HoistedScripts{
@@ -202,10 +57,19 @@ func HoistExports(source []byte) HoistedScripts {
 		if token == js.ExportToken {
 			foundGetStaticPaths := false
 			foundSemicolonOrLineTerminator := false
-			start := i - 1
+			start := 0
+			if i > 0 {
+				start = i - 1
+			}
 			i += len(value)
 			for {
 				next, nextValue := l.Next()
+				if next == js.DivToken || next == js.DivEqToken {
+					lns := bytes.Split(source[i+1:], []byte{'\n'})
+					if bytes.Contains(lns[0], []byte{'/'}) {
+						next, nextValue = l.RegExp()
+					}
+				}
 				i += len(nextValue)
 
 				if js.IsIdentifier(next) {
@@ -271,6 +135,22 @@ func HoistExports(source []byte) HoistedScripts {
 	}
 }
 
+func HoistImports(source []byte) HoistedScripts {
+	imports := make([][]byte, 0)
+	body := make([]byte, 0)
+	prev := 0
+	for i, statement := NextImportStatement(source, 0); i > -1; i, statement = NextImportStatement(source, i) {
+		body = append(body, source[prev:statement.Span.Start]...)
+		imports = append(imports, statement.Value)
+		prev = i
+	}
+	if prev == 0 {
+		return HoistedScripts{Body: source}
+	}
+	body = append(body, source[prev:]...)
+	return HoistedScripts{Hoisted: imports, Body: body}
+}
+
 func hasGetStaticPaths(source []byte) bool {
 	l := js.NewLexer(parse.NewInputBytes(source))
 	for {
@@ -285,27 +165,17 @@ func hasGetStaticPaths(source []byte) bool {
 	}
 }
 
-func AccessesPrivateVars(source []byte) bool {
-	l := js.NewLexer(parse.NewInputBytes(source))
-	for {
-		token, value := l.Next()
-		if token == js.ErrorToken {
-			// EOF or other error
-			return false
-		}
-		if js.IsIdentifier(token) && len(value) > 1 && value[0] == '$' && value[1] == '$' {
-			return true
-		}
-	}
-}
-
 type Import struct {
+	IsType     bool
 	ExportName string
 	LocalName  string
 	Assertions string
 }
 
 type ImportStatement struct {
+	Span       loc.Span
+	Value      []byte
+	IsType     bool
 	Imports    []Import
 	Specifier  string
 	Assertions string
@@ -323,6 +193,14 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 	i := pos
 	for {
 		token, value := l.Next()
+
+		if token == js.DivToken || token == js.DivEqToken {
+			lns := bytes.Split(source[i+1:], []byte{'\n'})
+			if bytes.Contains(lns[0], []byte{'/'}) {
+				token, value = l.RegExp()
+			}
+		}
+
 		if token == js.ErrorToken {
 			// EOF or other error
 			return -1, ImportStatement{}
@@ -331,6 +209,8 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 		// then we can exit after the following line terminator or semicolon
 		if token == js.ImportToken {
 			i += len(value)
+			text := []byte(value)
+			isType := false
 			specifier := ""
 			assertion := ""
 			foundSpecifier := false
@@ -341,12 +221,27 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 			pairs := make(map[byte]int)
 			for {
 				next, nextValue := l.Next()
+				if next == js.DivToken || next == js.DivEqToken {
+					lns := bytes.Split(source[i+1:], []byte{'\n'})
+					if bytes.Contains(lns[0], []byte{'/'}) {
+						next, nextValue = l.RegExp()
+					}
+				}
 				i += len(nextValue)
+				text = append(text, nextValue...)
+
+				if next == js.ErrorToken {
+					break
+				}
 
 				if !foundSpecifier && next == js.StringToken {
 					specifier = string(nextValue[1 : len(nextValue)-1])
 					foundSpecifier = true
 					continue
+				}
+
+				if !foundSpecifier && next == js.IdentifierToken && string(nextValue) == "type" {
+					isType = true
 				}
 
 				if foundSpecifier && (next == js.LineTerminatorToken || next == js.SemicolonToken) && pairs['{'] == 0 && pairs['('] == 0 && pairs['['] == 0 {
@@ -357,6 +252,9 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 						imports = append(imports, currImport)
 					}
 					return i, ImportStatement{
+						Span:       loc.Span{Start: i - len(text), End: i},
+						Value:      text,
+						IsType:     isType,
 						Imports:    imports,
 						Specifier:  specifier,
 						Assertions: assertion,

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -30,6 +30,13 @@ const b = await fetch();`,
 `,
 		},
 		{
+			name: "dynamic",
+			source: `const markdownDocs = await Astro.glob('../markdown/*.md')
+const article2 = await import('../markdown/article2.md')
+`,
+			want: "",
+		},
+		{
 			name: "big import",
 			source: `import {
   a,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -455,12 +455,12 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 				assertions += statement.Assertions
 			}
 
-			isCssImport := false
+			isCSSImport := false
 			if len(statement.Imports) == 0 && styleModuleSpecExp.MatchString(statement.Specifier) {
-				isCssImport = true
+				isCSSImport = true
 			}
 
-			if !isCssImport {
+			if !isCSSImport && !statement.IsType {
 				p.print(fmt.Sprintf("\nimport * as $$module%v from '%s'%s;", modCount, statement.Specifier, assertions))
 				specs = append(specs, statement.Specifier)
 				asrts = append(asrts, statement.Assertions)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -55,7 +55,6 @@ type want struct {
 	scripts        []string
 	getStaticPaths string
 	code           string
-	skipHoist      bool // HACK: sometimes `getStaticPaths()` appears in a slightly-different location. Only use this if needed!
 	metadata
 }
 
@@ -88,6 +87,13 @@ func TestPrinter(t *testing.T) {
 	}
 
 	tests := []testcase{
+		{
+			name:   "text only",
+			source: `Foo`,
+			want: want{
+				code: `Foo`,
+			},
+		},
 		{
 			name:   "basic (no frontmatter)",
 			source: `<button>Click</button>`,
@@ -234,9 +240,9 @@ export const getStaticPaths = async () => {
 ---
 <div></div>`,
 			want: want{
-				frontmatter: []string{`export const getStaticPaths = async () => {
+				getStaticPaths: `export const getStaticPaths = async () => {
 	return { paths: [] }
-}`, ""},
+}`,
 				code: `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
@@ -298,7 +304,6 @@ import data from "test" assert { type: 'json' };
 					`import data from "test" assert { type: 'json' };`,
 				},
 				metadata: metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {type:'json'} }`}},
-				styles:   []string{},
 			},
 		},
 		{
@@ -308,6 +313,48 @@ import data from "test" assert { type: 'json' };
 				code: `${$$maybeRenderHead($$result)}<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\\colon X \\to \\mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
 			},
 		},
+		{
+			name: "import order",
+			source: `---
+let testWord = "Test"
+// comment
+import data from "test";
+---
+
+<div>{data}</div>
+`,
+			want: want{
+				frontmatter: []string{
+					`import data from "test";`,
+					"let testWord = \"Test\"\n// comment",
+				},
+				metadata: metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
+				code:     "${$$maybeRenderHead($$result)}<div>${data}</div>",
+			},
+		},
+		{
+			name: "type import",
+			source: `---
+import type data from "test"
+---
+
+<div>{data}</div>
+`,
+			want: want{
+				frontmatter: []string{
+					`import type data from "test"`,
+				},
+				code: "${$$maybeRenderHead($$result)}<div>${data}</div>",
+			},
+		},
+		{
+			name:   "no expressions in math",
+			source: `<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\colon X \to \mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\\colon X \\to \\mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
+			},
+		},
+
 		{
 			name: "css imports are not included in module metadata",
 			source: `---
@@ -929,9 +976,9 @@ const someProps = {
   </body>
 </html>`,
 			want: want{
-				frontmatter: []string{`// Component Imports
-import Counter from '../components/Counter.jsx'`,
-					`const someProps = {
+				frontmatter: []string{`import Counter from '../components/Counter.jsx'`,
+					`// Component Imports
+const someProps = {
   count: 0,
 }
 
@@ -1607,7 +1654,6 @@ import ProductPageContent from '../../components/ProductPageContent.jsx';`,
     };
   });
 }`, BACKTICK, BACKTICK),
-				skipHoist: true,
 				metadata: metadata{
 					modules: []string{`{ module: $$module1, specifier: '../../components/Header.jsx', assert: {} }`,
 						`{ module: $$module2, specifier: '../../components/Footer.astro', assert: {} }`,
@@ -2150,11 +2196,6 @@ const items = ["Dog", "Cat", "Platipus"];
 			if len(tt.want.frontmatter) > 0 {
 				toMatch += test_utils.Dedent(tt.want.frontmatter[0])
 			}
-			// Fixes some tests where getStaticPaths appears in a different location
-			if tt.want.skipHoist == true && len(tt.want.getStaticPaths) > 0 {
-				toMatch += "\n\n"
-				toMatch += strings.TrimSpace(test_utils.Dedent(tt.want.getStaticPaths)) + "\n"
-			}
 			moduleSpecRe := regexp.MustCompile(`specifier:\s*('[^']+'),\s*assert:\s*([^}]+\})`)
 			if len(tt.want.metadata.modules) > 0 {
 				toMatch += "\n\n"
@@ -2227,7 +2268,7 @@ const items = ["Dog", "Cat", "Platipus"];
 
 			toMatch += "\n\n" + fmt.Sprintf("export const %s = %s(import.meta.url, %s);\n\n", METADATA, CREATE_METADATA, metadata)
 			toMatch += test_utils.Dedent(CREATE_ASTRO_CALL) + "\n\n"
-			if tt.want.skipHoist != true && len(tt.want.getStaticPaths) > 0 {
+			if len(tt.want.getStaticPaths) > 0 {
 				toMatch += strings.TrimSpace(test_utils.Dedent(tt.want.getStaticPaths)) + "\n\n"
 			}
 			toMatch += test_utils.Dedent(PRELUDE) + "\n"

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1274,6 +1274,20 @@ let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');`},
 			},
 		},
 		{
+			name: "dynamic import",
+			source: `---
+const markdownDocs = await Astro.glob('../markdown/*.md')
+const article2 = await import('../markdown/article2.md')
+---
+<div />
+`, want: want{
+				frontmatter: []string{"", `const markdownDocs = await Astro.glob('../markdown/*.md')
+const article2 = await import('../markdown/article2.md')`},
+				styles: []string{},
+				code:   "${$$maybeRenderHead($$result)}<div></div>",
+			},
+		},
+		{
 			name: "Component names A-Z",
 			source: `---
 import AComponent from '../components/AComponent.jsx';


### PR DESCRIPTION
## Changes

- Reworks our logic to automatically hoist all imports in a file to the top
- Removes confusing `FindRenderBody` heuristic that caused some weird edge cases
- Improves `getStaticPaths` hoisting (properly handles RegExps
- Improves `js_scanner` test coverages
- Removes dead code, including an old `skipHoist` workaround in our tests
- Improves output consistency across the board
- Closes https://github.com/withastro/compiler/issues/354
- Closes https://github.com/withastro/compiler/issues/195 (our oldest issue!)

## Testing

- Tests for `js_scanner` updated.
- `printer` tests updated to remove old `skipHoist` workaround


## Docs

Will open a PR to remove this warning from the docs! 🎉 

https://github.com/withastro/docs/pull/1001