### PR TITLE
Move attributes containing dots to spread in TSX output

### DIFF
--- a/.changeset/healthy-books-fetch.md
+++ b/.changeset/healthy-books-fetch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Update TSX output to also generate TSX-compatible code for attributes containing dots

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -36,6 +36,10 @@ var ScriptMimeTypes map[string]bool = map[string]bool{
 	"application/node":       true,
 }
 
+func isInvalidTSXAttributeName(k string) bool {
+	return strings.HasPrefix(k, "@") || strings.Contains(k, ".")
+}
+
 type TextType uint32
 
 const (
@@ -176,7 +180,7 @@ func renderTsx(p *printer, n *Node) {
 	p.print(n.Data)
 	invalidTSXAttributes := make([]Attribute, 0)
 	for _, a := range n.Attr {
-		if strings.HasPrefix(a.Key, "@") || strings.Contains(a.Key, ".") {
+		if isInvalidTSXAttributeName(a.Key) {
 			invalidTSXAttributes = append(invalidTSXAttributes, a)
 			continue
 		}

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -176,7 +176,7 @@ func renderTsx(p *printer, n *Node) {
 	p.print(n.Data)
 	invalidTSXAttributes := make([]Attribute, 0)
 	for _, a := range n.Attr {
-		if strings.HasPrefix(a.Key, "@") {
+		if strings.HasPrefix(a.Key, "@") || strings.Contains(a.Key, ".") {
 			invalidTSXAttributes = append(invalidTSXAttributes, a)
 			continue
 		}

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -59,3 +59,17 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}
   const { code } = await convertToTSX(input);
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
+
+test('moves attributes with dots in them to spread', async () => {
+  const input = `<div x-on:keyup.shift.enter="alert('Astro')" name="value"></div>`;
+  const output = `<Fragment>
+<div name="value" {...{"x-on:keyup.shift.enter":"alert('Astro')"}}></div>
+</Fragment>
+
+export default function __AstroComponent_(_props: Record<string, any>): any {}
+`;
+  const { code } = await convertToTSX(input);
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Much like attributes containing `@`, attributes containing dots are not supported in TSX. A common usage of them is Alpine's events, ex: `<input type="text" x-on:keyup.shift.enter="alert('Submitted!')">` so they need to be moved to a spread

## Testing

Added a test

## Docs

N/A
