### PR TITLE
Fix `define:vars`

### DIFF
--- a/.changeset/yellow-pots-fry.md
+++ b/.changeset/yellow-pots-fry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+New handling for `define:vars` scripts and styles

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/norunners/vert"
 	astro "github.com/withastro/compiler/internal"
-	"github.com/withastro/compiler/internal/js_scanner"
 	"github.com/withastro/compiler/internal/loc"
 	"github.com/withastro/compiler/internal/printer"
 	"github.com/withastro/compiler/internal/sourcemap"
@@ -267,7 +265,6 @@ func Transform() interface{} {
 
 					// Append hoisted scripts
 					for _, node := range doc.Scripts {
-						defineVars := astro.GetAttribute(node, "define:vars")
 						src := astro.GetAttribute(node, "src")
 						script := HoistedScript{
 							Src:  "",
@@ -279,86 +276,6 @@ func Transform() interface{} {
 						if src != nil {
 							script.Type = "external"
 							script.Src = src.Val
-						} else if node.FirstChild != nil && defineVars != nil {
-							script.Type = "define:vars"
-							keys := js_scanner.GetObjectKeys([]byte(defineVars.Val))
-							params := make([]byte, 0)
-							for i, key := range keys {
-								params = append(params, key...)
-								if i < len(keys)-1 {
-									params = append(params, ',')
-								}
-							}
-							if transformOptions.SourceMap != "" {
-								output := make([]byte, 0)
-								builder := sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(source, len(strings.Split(source, "\n"))))
-								sourcesContent, _ := json.Marshal(source)
-								src := []byte(node.FirstChild.Data)
-								hoisted := js_scanner.HoistImports(src)
-								if len(node.FirstChild.Loc) > 0 {
-									i := node.FirstChild.Loc[0].Start
-									for _, statement := range hoisted.Hoisted {
-										j := bytes.Index(src, statement)
-										start := i + j
-										for k, b := range statement {
-											if k == 0 || !unicode.IsSpace(rune(b)) {
-												builder.AddSourceMapping(loc.Loc{Start: start}, output)
-											}
-											output = append(output, b)
-											start += 1
-										}
-										builder.AddSourceMapping(loc.Loc{}, output)
-										output = append(output, '\n')
-									}
-									builder.AddSourceMapping(loc.Loc{}, output)
-									output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
-									body := bytes.TrimSpace(hoisted.Body)
-									j := bytes.Index(src, body)
-									start := i + j
-									for _, ln := range bytes.Split(body, []byte{'\n'}) {
-										content := []byte(ln)
-										content = append(content, '\n')
-										for _, b := range content {
-											if !unicode.IsSpace(rune(b)) {
-												builder.AddSourceMapping(loc.Loc{Start: start}, output)
-											}
-											output = append(output, b)
-											start += 1
-										}
-									}
-									builder.AddSourceMapping(loc.Loc{}, output)
-									output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
-									output = append(output, '\n')
-								} else {
-									for _, statement := range hoisted.Hoisted {
-										output = append(output, statement...)
-									}
-									output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
-									output = append(output, hoisted.Body...)
-									output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
-								}
-
-								sourcemap := fmt.Sprintf(
-									`{ "version": 3, "sources": ["%s"], "sourcesContent": [%s], "mappings": "%s", "names": [] }`,
-									transformOptions.Filename,
-									string(sourcesContent),
-									string(builder.GenerateChunk(output).Buffer),
-								)
-								script.Map = sourcemap
-								script.Code = string(output)
-							} else {
-								src := []byte(node.FirstChild.Data)
-								hoisted := js_scanner.HoistImports(src)
-								output := make([]byte, 0)
-								for _, statement := range hoisted.Hoisted {
-									output = append(output, statement...)
-								}
-								output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
-								output = append(output, hoisted.Body...)
-								output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
-
-								script.Code = string(output)
-							}
 						} else if node.FirstChild != nil {
 							script.Type = "inline"
 

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -10,10 +10,14 @@ import (
 	"strings"
 	"sync"
 	"syscall/js"
+	"unicode"
 
 	"github.com/norunners/vert"
 	astro "github.com/withastro/compiler/internal"
+	"github.com/withastro/compiler/internal/js_scanner"
+	"github.com/withastro/compiler/internal/loc"
 	"github.com/withastro/compiler/internal/printer"
+	"github.com/withastro/compiler/internal/sourcemap"
 	t "github.com/withastro/compiler/internal/t"
 	"github.com/withastro/compiler/internal/transform"
 	wasm_utils "github.com/withastro/compiler/internal_wasm/utils"
@@ -128,6 +132,8 @@ type HoistedScript struct {
 	Code string `js:"code"`
 	Src  string `js:"src"`
 	Type string `js:"type"`
+	Keys string `js:"keys"`
+	Map  string `js:"map"`
 }
 
 type HydratedComponent struct {
@@ -261,19 +267,73 @@ func Transform() interface{} {
 
 					// Append hoisted scripts
 					for _, node := range doc.Scripts {
+						defineVars := astro.GetAttribute(node, "define:vars")
 						src := astro.GetAttribute(node, "src")
 						script := HoistedScript{
 							Src:  "",
 							Code: "",
 							Type: "",
+							Keys: "",
+							Map:  "",
 						}
+
 						if src != nil {
 							script.Type = "external"
 							script.Src = src.Val
 						} else if node.FirstChild != nil {
-							script.Type = "inline"
-							script.Code = node.FirstChild.Data
+							if defineVars != nil {
+								script.Type = "define:vars"
+								keys := js_scanner.GetObjectKeys([]byte(defineVars.Val))
+								params := make([]byte, 0)
+								for i, key := range keys {
+									params = append(params, key...)
+									if i < len(keys)-1 {
+										params = append(params, ',')
+									}
+								}
+								script.Keys = string(params)
+							} else {
+								script.Type = "inline"
+							}
+							if transformOptions.SourceMap != "" {
+								isLine := func(r rune) bool { return r == '\r' || r == '\n' }
+								isNotLine := func(r rune) bool { return !(r == '\r' || r == '\n') }
+								output := make([]byte, 0)
+								builder := sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(source, len(strings.Split(source, "\n"))))
+								sourcesContent, _ := json.Marshal(source)
+								if len(node.FirstChild.Loc) > 0 {
+									i := node.FirstChild.Loc[0].Start
+									nonWS := strings.IndexFunc(node.FirstChild.Data, isNotLine)
+									i += nonWS
+									for _, ln := range strings.Split(strings.TrimFunc(node.FirstChild.Data, isLine), "\n") {
+										content := []byte(ln)
+										content = append(content, '\n')
+										for j, b := range content {
+											if j == 0 || !unicode.IsSpace(rune(b)) {
+												builder.AddSourceMapping(loc.Loc{Start: i}, output)
+											}
+											output = append(output, b)
+											i += 1
+										}
+									}
+									output = append(output, '\n')
+								} else {
+									output = append(output, []byte(strings.TrimSpace(node.FirstChild.Data))...)
+								}
+								sourcemap := fmt.Sprintf(
+									`{ "version": 3, "sources": ["%s"], "sourcesContent": [%s], "mappings": "%s", "names": [] }`,
+									transformOptions.Filename,
+									string(sourcesContent),
+									string(builder.GenerateChunk(output).Buffer),
+								)
+								script.Map = sourcemap
+								script.Code = string(output)
+							} else {
+								script.Code = node.FirstChild.Data
+							}
 						}
+						// sourcemapString := createSourceMapString(source, result, transformOptions)
+						// inlineSourcemap := `//# sourceMappingURL=data:application/json;charset=utf-8;base64,` + base64.StdEncoding.EncodeToString([]byte(sourcemapString))
 						scripts = append(scripts, script)
 					}
 

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -300,7 +300,6 @@ func Transform() interface{} {
 									for _, statement := range hoisted.Hoisted {
 										j := bytes.Index(src, statement)
 										start := i + j
-										fmt.Println(string(statement), start)
 										for k, b := range statement {
 											if k == 0 || !unicode.IsSpace(rune(b)) {
 												builder.AddSourceMapping(loc.Loc{Start: start}, output)
@@ -320,7 +319,6 @@ func Transform() interface{} {
 										content := []byte(ln)
 										content = append(content, '\n')
 										for _, b := range content {
-											fmt.Println(string(b), start)
 											if !unicode.IsSpace(rune(b)) {
 												builder.AddSourceMapping(loc.Loc{Start: start}, output)
 											}

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -132,7 +133,6 @@ type HoistedScript struct {
 	Code string `js:"code"`
 	Src  string `js:"src"`
 	Type string `js:"type"`
-	Keys string `js:"keys"`
 	Map  string `js:"map"`
 }
 
@@ -273,28 +273,97 @@ func Transform() interface{} {
 							Src:  "",
 							Code: "",
 							Type: "",
-							Keys: "",
 							Map:  "",
 						}
 
 						if src != nil {
 							script.Type = "external"
 							script.Src = src.Val
-						} else if node.FirstChild != nil {
-							if defineVars != nil {
-								script.Type = "define:vars"
-								keys := js_scanner.GetObjectKeys([]byte(defineVars.Val))
-								params := make([]byte, 0)
-								for i, key := range keys {
-									params = append(params, key...)
-									if i < len(keys)-1 {
-										params = append(params, ',')
-									}
+						} else if node.FirstChild != nil && defineVars != nil {
+							script.Type = "define:vars"
+							keys := js_scanner.GetObjectKeys([]byte(defineVars.Val))
+							params := make([]byte, 0)
+							for i, key := range keys {
+								params = append(params, key...)
+								if i < len(keys)-1 {
+									params = append(params, ',')
 								}
-								script.Keys = string(params)
-							} else {
-								script.Type = "inline"
 							}
+							if transformOptions.SourceMap != "" {
+								output := make([]byte, 0)
+								builder := sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(source, len(strings.Split(source, "\n"))))
+								sourcesContent, _ := json.Marshal(source)
+								src := []byte(node.FirstChild.Data)
+								hoisted := js_scanner.HoistImports(src)
+								if len(node.FirstChild.Loc) > 0 {
+									i := node.FirstChild.Loc[0].Start
+									for _, statement := range hoisted.Hoisted {
+										j := bytes.Index(src, statement)
+										start := i + j
+										fmt.Println(string(statement), start)
+										for k, b := range statement {
+											if k == 0 || !unicode.IsSpace(rune(b)) {
+												builder.AddSourceMapping(loc.Loc{Start: start}, output)
+											}
+											output = append(output, b)
+											start += 1
+										}
+										builder.AddSourceMapping(loc.Loc{}, output)
+										output = append(output, '\n')
+									}
+									builder.AddSourceMapping(loc.Loc{}, output)
+									output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
+									body := bytes.TrimSpace(hoisted.Body)
+									j := bytes.Index(src, body)
+									start := i + j
+									for _, ln := range bytes.Split(body, []byte{'\n'}) {
+										content := []byte(ln)
+										content = append(content, '\n')
+										for _, b := range content {
+											fmt.Println(string(b), start)
+											if !unicode.IsSpace(rune(b)) {
+												builder.AddSourceMapping(loc.Loc{Start: start}, output)
+											}
+											output = append(output, b)
+											start += 1
+										}
+									}
+									builder.AddSourceMapping(loc.Loc{}, output)
+									output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
+									output = append(output, '\n')
+								} else {
+									for _, statement := range hoisted.Hoisted {
+										output = append(output, statement...)
+									}
+									output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
+									output = append(output, hoisted.Body...)
+									output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
+								}
+
+								sourcemap := fmt.Sprintf(
+									`{ "version": 3, "sources": ["%s"], "sourcesContent": [%s], "mappings": "%s", "names": [] }`,
+									transformOptions.Filename,
+									string(sourcesContent),
+									string(builder.GenerateChunk(output).Buffer),
+								)
+								script.Map = sourcemap
+								script.Code = string(output)
+							} else {
+								src := []byte(node.FirstChild.Data)
+								hoisted := js_scanner.HoistImports(src)
+								output := make([]byte, 0)
+								for _, statement := range hoisted.Hoisted {
+									output = append(output, statement...)
+								}
+								output = append(output, []byte(fmt.Sprintf(`import deserialize from 'astro/client/deserialize.js'; export default (str) => (async function({%s}) {%s`, params, "\n"))...)
+								output = append(output, hoisted.Body...)
+								output = append(output, []byte(fmt.Sprintf(`%s})(deserialize(str))`, "\n"))...)
+
+								script.Code = string(output)
+							}
+						} else if node.FirstChild != nil {
+							script.Type = "inline"
+
 							if transformOptions.SourceMap != "" {
 								isLine := func(r rune) bool { return r == '\r' || r == '\n' }
 								isNotLine := func(r rune) bool { return !(r == '\r' || r == '\n') }
@@ -332,6 +401,7 @@ func Transform() interface{} {
 								script.Code = node.FirstChild.Data
 							}
 						}
+
 						// sourcemapString := createSourceMapString(source, result, transformOptions)
 						// inlineSourcemap := `//# sourceMappingURL=data:application/json;charset=utf-8;base64,` + base64.StdEncoding.EncodeToString([]byte(sourcemapString))
 						scripts = append(scripts, script)

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -2,8 +2,10 @@ package js_scanner
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
+	"github.com/iancoleman/strcase"
 	"github.com/tdewolff/parse/v2"
 	"github.com/tdewolff/parse/v2/js"
 	"github.com/withastro/compiler/internal/loc"
@@ -163,6 +165,94 @@ func HoistImports(source []byte) HoistedScripts {
 	}
 	body = append(body, source[prev:]...)
 	return HoistedScripts{Hoisted: imports, Body: body}
+}
+
+func isIdentifier(value []byte) bool {
+	valid := true
+	for i, b := range value {
+		if i == 0 {
+			valid = js.IsIdentifierStart([]byte{b})
+		} else if i < len(value)-1 {
+			valid = js.IsIdentifierContinue([]byte{b})
+		} else {
+			valid = js.IsIdentifierEnd([]byte{b})
+		}
+		if !valid {
+			break
+		}
+	}
+	return valid
+}
+
+func GetObjectKeys(source []byte) [][]byte {
+	keys := make([][]byte, 0)
+	pairs := make(map[byte]int)
+
+	if source[0] == '{' && source[len(source)-1] == '}' {
+		l := js.NewLexer(parse.NewInputBytes(source[1 : len(source)-1]))
+		i := 0
+		var prev js.TokenType
+
+		for {
+			token, value := l.Next()
+			openPairs := pairs['{'] > 0 || pairs['('] > 0 || pairs['['] > 0
+
+			if token == js.DivToken || token == js.DivEqToken {
+				lns := bytes.Split(source[i+1:], []byte{'\n'})
+				if bytes.Contains(lns[0], []byte{'/'}) {
+					token, value = l.RegExp()
+				}
+			}
+			i += len(value)
+
+			if token == js.ErrorToken {
+				return keys
+			}
+
+			if js.IsPunctuator(token) {
+				if value[0] == '{' || value[0] == '(' || value[0] == '[' {
+					pairs[value[0]]++
+					continue
+				} else if value[0] == '}' {
+					pairs['{']--
+				} else if value[0] == ')' {
+					pairs['(']--
+				} else if value[0] == ']' {
+					pairs['[']--
+				}
+			}
+
+			if prev != js.ColonToken {
+				push := func() {
+					if token != js.StringToken {
+						keys = append(keys, value)
+					} else {
+						key := value[1 : len(value)-1]
+						ident := string(key)
+						if !isIdentifier(key) {
+							ident = strcase.ToLowerCamel(string(key))
+						}
+						if string(key) == ident {
+							keys = append(keys, []byte(key))
+						} else {
+							keys = append(keys, []byte(fmt.Sprintf("%s: %s", value, ident)))
+						}
+					}
+				}
+				if !openPairs && (token == js.IdentifierToken || token == js.StringToken) {
+					push()
+				} else if pairs['['] == 1 && token == js.StringToken {
+					push()
+				}
+			}
+
+			if !openPairs && token != js.WhitespaceToken {
+				prev = token
+			}
+		}
+	}
+
+	return keys
 }
 
 type Import struct {

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -450,7 +450,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	}
 
 	if n.DataAtom == atom.Script || n.DataAtom == atom.Style {
-		p.printDefineVars(n)
+		p.printDefineVarsOpen(n)
 	}
 
 	// Render any child nodes.
@@ -661,6 +661,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		p.addSourceMapping(n.Loc[1])
 	} else {
 		p.addSourceMapping(n.Loc[0])
+	}
+	if n.DataAtom == atom.Script || n.DataAtom == atom.Style {
+		p.printDefineVarsClose(n)
 	}
 	if isComponent || isSlot {
 		p.print(")}")

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -169,6 +169,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				// Print empty just to ensure a newline
 				p.println("")
 				if len(n.Parent.Styles) > 0 {
+					definedVars := transform.GetDefineVars(n.Parent.Styles)
+					if len(definedVars) > 0 {
+						p.printf("const $$definedVars = %s([%s]);\n", DEFINE_STYLE_VARS, strings.Join(definedVars, ","))
+					}
 					p.println("const STYLES = [")
 					for _, style := range n.Parent.Styles {
 						p.printStyleOrScript(opts, style)
@@ -214,6 +218,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 		// If we haven't printed the funcPrelude but we do have Styles/Scripts, we need to print them!
 		if len(n.Parent.Styles) > 0 {
+			definedVars := transform.GetDefineVars(n.Parent.Styles)
+			if len(definedVars) > 0 {
+				p.printf("const $$definedVars = %s([%s]);\n", DEFINE_STYLE_VARS, strings.Join(definedVars, ","))
+			}
 			p.println("const STYLES = [")
 			for _, style := range n.Parent.Styles {
 				p.printStyleOrScript(opts, style)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1071,8 +1071,7 @@ import Widget2 from '../components/Widget2.astro';`},
 			staticExtraction: true,
 			source:           `<script define:vars={{ value: 0 }}>console.log(value);</script>`,
 			want: want{
-				code:     `<script type="module">${$$defineScriptVars({ value: 0 })}</script>`,
-				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'define:vars', value: %sconsole.log(value);%s, keys: 'value' }`, BACKTICK, BACKTICK)}},
+				code: `<script>{${$$defineScriptVars({ value: 0 })}console.log(value);}</script>`,
 			},
 		},
 		{
@@ -1080,8 +1079,7 @@ import Widget2 from '../components/Widget2.astro';`},
 			staticExtraction: true,
 			source:           `<script define:vars={{ "dash-case": true }}>console.log(dashCase);</script>`,
 			want: want{
-				code:     `<script type="module">${$$defineScriptVars({ "dash-case": true })}</script>`,
-				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'define:vars', value: %sconsole.log(dashCase);%s, keys: '"dash-case": dashCase' }`, BACKTICK, BACKTICK)}},
+				code: `<script>{${$$defineScriptVars({ "dash-case": true })}console.log(dashCase);}</script>`,
 			},
 		},
 		{
@@ -2150,12 +2148,12 @@ const items = ["Dog", "Cat", "Platipus"];
 			// 2. A hoisted script - wrong, shown up in scripts.add
 			// 3. A define:vars hoisted script
 			// 4. A define:vars inline script
-			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline type="module" define:vars={{foo:'bar'}}>var four = foo;</script>`,
+			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline define:vars={{foo:'bar'}}>var four = foo;</script>`,
 			staticExtraction: true,
 			want: want{
-				code: `<script>var one = 'one';</script><script type="module">${$$defineScriptVars({foo:'bar'})}</script><script type="module">${$$defineScriptVars({foo:'bar'})}var four = foo;</script>`,
+				code: `<script>var one = 'one';</script><script>{${$$defineScriptVars({foo:'bar'})}var three = foo;}</script><script>{${$$defineScriptVars({foo:'bar'})}var four = foo;}</script>`,
 				metadata: metadata{
-					hoisted: []string{"{ type: 'define:vars', value: `var three = foo;`, keys: 'foo' }", "{ type: 'inline', value: `var two = 'two';` }"},
+					hoisted: []string{"{ type: 'inline', value: `var two = 'two';` }"},
 				},
 			},
 		},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -51,6 +51,7 @@ var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS
 
 type want struct {
 	frontmatter    []string
+	definedVars    []string
 	styles         []string
 	scripts        []string
 	getStaticPaths string
@@ -1044,19 +1045,6 @@ import Widget2 from '../components/Widget2.astro';`},
 			},
 		},
 		{
-			name: "script hoist remote",
-			source: `---
----
-<script type="module" hoist src="url" />`,
-			want: want{
-				frontmatter: []string{"\n"},
-				styles:      []string{},
-				scripts:     []string{`{props:{"type":"module","hoist":true,"src":"url"}}`},
-				metadata:    metadata{hoisted: []string{`{ type: 'remote', src: 'url' }`}},
-				code:        "",
-			},
-		},
-		{
 			name: "script hoist without frontmatter",
 			source: `
 							<main>
@@ -1079,10 +1067,21 @@ import Widget2 from '../components/Widget2.astro';`},
 			},
 		},
 		{
-			name:   "script define:vars",
-			source: `<main><script define:vars={{ value: 0 }} type="module">console.log(value);</script>`,
+			name:             "script define:vars I",
+			staticExtraction: true,
+			source:           `<script define:vars={{ value: 0 }}>console.log(value);</script>`,
 			want: want{
-				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<main><script type="module">${%s({ value: 0 })}console.log(value);</script></main>`, DEFINE_SCRIPT_VARS),
+				code:     `<script type="module">${$$defineScriptVars({ value: 0 })}</script>`,
+				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'define:vars', value: %sconsole.log(value);%s, keys: 'value' }`, BACKTICK, BACKTICK)}},
+			},
+		},
+		{
+			name:             "script define:vars II",
+			staticExtraction: true,
+			source:           `<script define:vars={{ "dash-case": true }}>console.log(dashCase);</script>`,
+			want: want{
+				code:     `<script type="module">${$$defineScriptVars({ "dash-case": true })}</script>`,
+				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'define:vars', value: %sconsole.log(dashCase);%s, keys: '"dash-case": dashCase' }`, BACKTICK, BACKTICK)}},
 			},
 		},
 		{
@@ -1369,8 +1368,9 @@ const title = 'icon';
 			name:   "Empty style",
 			source: `<style define:vars={{ color: "Gainsboro" }}></style>`,
 			want: want{
-				styles: []string{`{props:{"define:vars":({ color: "Gainsboro" }),"data-astro-id":"7HAAVZPE"}}`},
-				code:   ``,
+				definedVars: []string{`{ color: "Gainsboro" }`},
+				styles:      []string{`{props:{"define:vars":({ color: "Gainsboro" }),"data-astro-id":"7HAAVZPE"}}`},
+				code:        ``,
 			},
 		},
 		{
@@ -2124,9 +2124,23 @@ const items = ["Dog", "Cat", "Platipus"];
 			source:           "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			staticExtraction: true,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<h1 class="astro-VFS5OEMV">testing</h1>`,
+				code:        `${$$maybeRenderHead($$result)}<h1 class="astro-VFS5OEMV"${$$addAttribute($$definedVars, "style")}>testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
 				styles: []string{
 					"{props:{\"define:vars\":({color:'green'}),\"data-astro-id\":\"VFS5OEMV\"},children:`h1.astro-VFS5OEMV{color:var(--color)}`}",
+				},
+			},
+		},
+		{
+			name:             "multiple define:vars on style",
+			source:           "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><style define:vars={{color:'red'}}>h2{color:var(--color)}</style><h1>foo</h1><h2>bar</h2>",
+			staticExtraction: true,
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1 class="astro-6OXBQCST"${$$addAttribute($$definedVars, "style")}>foo</h1><h2 class="astro-6OXBQCST"${$$addAttribute($$definedVars, "style")}>bar</h2>`,
+				definedVars: []string{"{color:'red'}", "{color:'green'}"},
+				styles: []string{
+					"{props:{\"define:vars\":({color:'red'}),\"data-astro-id\":\"6OXBQCST\"},children:`h2.astro-6OXBQCST{color:var(--color)}`}",
+					"{props:{\"define:vars\":({color:'green'}),\"data-astro-id\":\"6OXBQCST\"},children:`h1.astro-6OXBQCST{color:var(--color)}`}",
 				},
 			},
 		},
@@ -2134,14 +2148,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name: "define:vars on script with StaticExpression turned on",
 			// 1. An inline script with is:inline - right
 			// 2. A hoisted script - wrong, shown up in scripts.add
-			// 3. A define:vars module script - right
-			// 4. A define:vars hoisted script - wrong, not inlined
-			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script type="module">var three = foo;</script><script type="module" define:vars={{foo:'bar'}}>var four = foo;</script>`,
+			// 3. A define:vars hoisted script
+			// 4. A define:vars inline script
+			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline type="module" define:vars={{foo:'bar'}}>var four = foo;</script>`,
 			staticExtraction: true,
 			want: want{
-				code: `<script>var one = 'one';</script><script type="module">var three = foo;</script><script type="module">${$$defineScriptVars({foo:'bar'})}var four = foo;</script>`,
+				code: `<script>var one = 'one';</script><script type="module">${$$defineScriptVars({foo:'bar'})}</script><script type="module">${$$defineScriptVars({foo:'bar'})}var four = foo;</script>`,
 				metadata: metadata{
-					hoisted: []string{"{ type: 'inline', value: `var two = 'two';` }"},
+					hoisted: []string{"{ type: 'define:vars', value: `var three = foo;`, keys: 'foo' }", "{ type: 'inline', value: `var two = 'two';` }"},
 				},
 			},
 		},
@@ -2290,6 +2304,16 @@ const items = ["Dog", "Cat", "Platipus"];
 				toMatch += test_utils.Dedent(tt.want.frontmatter[1])
 			}
 			toMatch += "\n"
+			if len(tt.want.definedVars) > 0 {
+				toMatch = toMatch + "const $$definedVars = $$defineStyleVars(["
+				for i, d := range tt.want.definedVars {
+					if i > 0 {
+						toMatch += ","
+					}
+					toMatch += d
+				}
+				toMatch += "]);\n"
+			}
 			if len(tt.want.styles) > 0 {
 				toMatch = toMatch + STYLE_PRELUDE
 				for _, style := range tt.want.styles {

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -45,3 +45,28 @@ outer:
 
 	return didScope
 }
+
+func GetDefineVars(styles []*astro.Node) []string {
+	values := make([]string, 0)
+	for _, n := range styles {
+		if n.DataAtom != a.Style {
+			continue
+		}
+		if !HasAttr(n, "define:vars") {
+			continue
+		}
+		attr := GetAttr(n, "define:vars")
+		if attr != nil {
+			switch attr.Type {
+			case astro.QuotedAttribute:
+				values = append(values, fmt.Sprintf("'%s'", attr.Val))
+			case astro.TemplateLiteralAttribute:
+				values = append(values, fmt.Sprintf("`%s`", attr.Val))
+			case astro.ExpressionAttribute:
+				values = append(values, fmt.Sprintf("%s", attr.Val))
+			}
+		}
+	}
+
+	return values
+}

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -63,7 +63,7 @@ func GetDefineVars(styles []*astro.Node) []string {
 			case astro.TemplateLiteralAttribute:
 				values = append(values, fmt.Sprintf("`%s`", attr.Val))
 			case astro.ExpressionAttribute:
-				values = append(values, fmt.Sprintf("%s", attr.Val))
+				values = append(values, attr.Val)
 			}
 		}
 	}

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -18,7 +18,6 @@ func AddDefineVars(n *astro.Node, values []string) {
 	if n.Type == astro.ElementNode && !n.Component {
 		if _, noScope := NeverScopedElements[n.Data]; !noScope {
 			if n.Parent == nil || IsImplictNode(n.Parent) || n.Parent.Component {
-				// parent := n.Closest(func(p *astro.Node) bool { return p.Type == astro.ElementNode && HasAttr(p, "style") })
 				injectDefineVars(n, values)
 			}
 		}

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -17,7 +17,7 @@ func ScopeElement(n *astro.Node, opts TransformOptions) {
 func AddDefineVars(n *astro.Node, values []string) {
 	if n.Type == astro.ElementNode && !n.Component {
 		if _, noScope := NeverScopedElements[n.Data]; !noScope {
-			if n.Parent == nil || IsImplictNode(n.Parent) || n.Parent.Component {
+			if IsTopLevel(n) {
 				injectDefineVars(n, values)
 			}
 		}
@@ -45,13 +45,7 @@ var NeverScopedSelectors map[string]bool = map[string]bool{
 }
 
 func injectDefineVars(n *astro.Node, values []string) {
-	hasSpreadAttr := false
 	definedVars := "$$definedVars"
-	for _, attr := range n.Attr {
-		if !hasSpreadAttr && attr.Type == astro.SpreadAttribute {
-			hasSpreadAttr = true
-		}
-	}
 	for i, attr := range n.Attr {
 		if attr.Key == "style" {
 			switch attr.Type {
@@ -77,9 +71,6 @@ func injectDefineVars(n *astro.Node, values []string) {
 				return
 			}
 		}
-	}
-	if hasSpreadAttr {
-		return
 	}
 	n.Attr = append(n.Attr, astro.Attribute{
 		Key:  "style",

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -42,25 +42,7 @@ func Transform(doc *astro.Node, opts TransformOptions) *astro.Node {
 	NormalizeSetDirectives(doc)
 
 	// Important! Remove scripts from original location *after* walking the doc
-	for i, script := range doc.Scripts {
-		for _, attr := range script.Attr {
-			if attr.Key == "define:vars" {
-				handler := &astro.Node{
-					Type:     astro.ElementNode,
-					Data:     "script",
-					DataAtom: a.Script,
-					Loc:      make([]loc.Loc, 2),
-					Attr: []astro.Attribute{
-						{Key: "type", Val: "module"},
-						{Key: "define:vars-src", Val: opts.Filename},
-						{Key: "define:vars-index", Val: fmt.Sprintf("%d", i)},
-						attr,
-					},
-				}
-				script.Parent.InsertBefore(handler, script)
-				attr.Val = fmt.Sprintf("%d", i)
-			}
-		}
+	for _, script := range doc.Scripts {
 		script.Parent.RemoveChild(script)
 	}
 
@@ -269,7 +251,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 		// if <script>, hoist to the document root
 		// If also using define:vars, that overrides the hoist tag.
 		if (hasTruthyAttr(n, "hoist")) ||
-			len(n.Attr) == 0 || (len(n.Attr) == 1 && n.Attr[0].Key == "src" || len(n.Attr) == 1 && n.Attr[0].Key == "define:vars") {
+			len(n.Attr) == 0 || (len(n.Attr) == 1 && n.Attr[0].Key == "src") {
 			shouldAdd := true
 			for _, attr := range n.Attr {
 				if attr.Key == "hoist" {

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -50,6 +50,20 @@ func IsImplictNodeMarker(attr astro.Attribute) bool {
 	return attr.Key == astro.ImplicitNodeMarker
 }
 
+func IsTopLevel(n *astro.Node) bool {
+	p := n.Parent
+	if p == nil {
+		return true
+	}
+	if IsImplictNode(p) || p.Data == "" {
+		return true
+	}
+	if p.Component {
+		return IsTopLevel(p)
+	}
+	return false
+}
+
 func GetQuotedAttr(n *astro.Node, key string) string {
 	for _, attr := range n.Attr {
 		if attr.Key == key {

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -33,6 +33,15 @@ func HasAttr(n *astro.Node, key string) bool {
 	return false
 }
 
+func GetAttr(n *astro.Node, key string) *astro.Attribute {
+	for _, attr := range n.Attr {
+		if attr.Key == key {
+			return &attr
+		}
+	}
+	return nil
+}
+
 func IsImplictNode(n *astro.Node) bool {
 	return HasAttr(n, astro.ImplicitNodeMarker)
 }

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -37,11 +37,6 @@ export type HoistedScript = { type: string } & (
       code: string;
       map: string;
     }
-  | {
-      type: 'define:vars';
-      code: string;
-      map: string;
-    }
 );
 
 export interface HydratedComponent {

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -35,11 +35,12 @@ export type HoistedScript = { type: string } & (
   | {
       type: 'inline';
       code: string;
+      map: string;
     }
   | {
       type: 'define:vars';
       code: string;
-      keys: string;
+      map: string;
     }
 );
 

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -36,6 +36,11 @@ export type HoistedScript = { type: string } & (
       type: 'inline';
       code: string;
     }
+  | {
+      type: 'define:vars';
+      code: string;
+      keys: string;
+    }
 );
 
 export interface HydratedComponent {


### PR DESCRIPTION
## Changes

- Update output to wrap `define:vars` scripts with a scope (`{}`), so we can redeclare variables
- Update output to inject `define:vars` styles directly into each top-level element's `style` attribute
- Improve sourcemaps for hoisted `script`
- Blocks https://github.com/withastro/astro/pull/3976

## Testing

Tests updated

## Docs

Bug fix only
