### PR TITLE
Remove Markdown special-casing

### DIFF
--- a/.changeset/hot-rings-burn.md
+++ b/.changeset/hot-rings-burn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Removes compiler special casing for the Markdown component

--- a/internal/token.go
+++ b/internal/token.go
@@ -984,9 +984,6 @@ func (z *Tokenizer) readStartTag() TokenType {
 		raw = z.startTagIn("xmp")
 	}
 	if !raw {
-		raw = z.hasAttribute("data-astro-raw")
-	}
-	if !raw {
 		raw = z.hasAttribute("is:raw")
 	}
 	if raw {

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -1,7 +1,6 @@
 package astro
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -271,16 +270,6 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartExpressionToken, TextToken, StartTagToken, TextToken, EndTagToken, EndExpressionToken, TextToken, StartExpressionToken, TextToken, SelfClosingTagToken, EndExpressionToken, TextToken},
 		},
 		{
-			"Markdown Inside markdown backtick treated as a string",
-			"<Markdown>`{}`</Markdown>",
-			[]TokenType{StartTagToken, TextToken, EndTagToken},
-		},
-		{
-			"Quotes in elements in Markdown",
-			"<Markdown><span>can't</span></Markdown>",
-			[]TokenType{StartTagToken, StartTagToken, TextToken, EndTagToken, EndTagToken},
-		},
-		{
 			"text containing a /",
 			"<span>next/router</span>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},
@@ -389,15 +378,6 @@ func TestBasic(t *testing.T) {
 			"extra close brace",
 			"<main id={`${}}`}></main>",
 			[]TokenType{StartTagToken, EndTagToken},
-		},
-		{
-			"Markdown codeblock",
-			fmt.Sprintf(`<Markdown>
-		%s%s%s
-		open brace {
-		%s%s%s
-		</Markdown>`, "`", "`", "`", "`", "`", "`"),
-			[]TokenType{StartTagToken, TextToken, TextToken, TextToken, TextToken, EndTagToken},
 		},
 		{
 			"Empty expression",

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -280,11 +280,6 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, EndTagToken},
 		},
 		{
-			"data-astro-raw allows children to be parsed as Text",
-			"<span data-astro-raw>function foo() { }</span>",
-			[]TokenType{StartTagToken, TextToken, EndTagToken},
-		},
-		{
 			"is:raw allows children to be parsed as Text",
 			"<span is:raw>function foo() { }</span>",
 			[]TokenType{StartTagToken, TextToken, EndTagToken},

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -167,7 +167,7 @@ func isRawElement(n *astro.Node) bool {
 	if n.Type == astro.FrontmatterNode {
 		return true
 	}
-	rawTags := []string{"Markdown", "pre", "listing", "iframe", "noembed", "noframes", "math", "plaintext", "script", "style", "textarea", "title", "xmp"}
+	rawTags := []string{"pre", "listing", "iframe", "noembed", "noframes", "math", "plaintext", "script", "style", "textarea", "title", "xmp"}
 	for _, tag := range rawTags {
 		if n.Data == tag {
 			return true

--- a/packages/compiler/test/basic/trailing-space.ts
+++ b/packages/compiler/test/basic/trailing-space.ts
@@ -15,7 +15,7 @@ import Layout from '../layouts/content.astro';
 
 <Layout>
   <div id="root">
-    <Markdown>
+    <Markdown is:raw>
       ## Interesting Topic
     </Markdown>
   </div>

--- a/packages/compiler/test/parse/serialize.ts
+++ b/packages/compiler/test/parse/serialize.ts
@@ -20,7 +20,7 @@ let content = "Testing 123";
 
 <Fragment set:html={content} />
 
-<Markdown>
+<Markdown is:raw>
   # Hello world!
 </Markdown>
 `;


### PR DESCRIPTION
## Changes

- Removes special Markdown component parsing, need to use `is:raw` in the future.

## Testing

- Tests updated

## Docs

N/A