### PR TITLE
Do not hoist `script` or `style` inside of `noscript` or `template`

### DIFF
--- a/.changeset/shaggy-sheep-pump.md
+++ b/.changeset/shaggy-sheep-pump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Do not attempt to hoist styles or scripts inside of `<noscript>`

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -467,6 +467,20 @@ import * as ns from '../components';
 			},
 		},
 		{
+			name:   "noscript styles",
+			source: `<noscript><style>div { color: red; }</style></noscript>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<noscript><style>div { color: red; }</style></noscript>`,
+			},
+		},
+		{
+			name:   "noscript deep styles",
+			source: `<body><noscript><div><div><div><style>div { color: red; }</style></div></div></div></noscript></body>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<body><noscript><div><div><div><style>div { color: red; }</style></div></div></div></noscript></body>`,
+			},
+		},
+		{
 			name: "client:only component (default)",
 			source: `---
 import Component from '../components';

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -9,7 +9,6 @@ import (
 	astro "github.com/withastro/compiler/internal"
 	"github.com/withastro/compiler/internal/js_scanner"
 	"github.com/withastro/compiler/internal/loc"
-	"golang.org/x/net/html/atom"
 	a "golang.org/x/net/html/atom"
 )
 
@@ -70,8 +69,8 @@ func ExtractStyles(doc *astro.Node) {
 			if HasSetDirective(n) || HasInlineDirective(n) {
 				return
 			}
-			// Do not extract <style> inside of SVGs
-			if n.Parent != nil && n.Parent.DataAtom == atom.Svg {
+			// Ignore styles in svg/noscript/etc
+			if !IsHoistable(n) {
 				return
 			}
 			// prepend node to maintain authored order
@@ -241,6 +240,10 @@ func collapseWhitespace(doc *astro.Node) {
 func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Script {
 		if HasSetDirective(n) || HasInlineDirective(n) {
+			return
+		}
+		// Ignore scripts in svg/noscript/etc
+		if !IsHoistable(n) {
 			return
 		}
 

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	astro "github.com/withastro/compiler/internal"
+	"golang.org/x/net/html/atom"
 )
 
 func hasTruthyAttr(n *astro.Node, key string) bool {
@@ -31,6 +32,13 @@ func HasAttr(n *astro.Node, key string) bool {
 		}
 	}
 	return false
+}
+
+func IsHoistable(n *astro.Node) bool {
+	parent := n.Closest(func(p *astro.Node) bool {
+		return p.DataAtom == atom.Svg || p.DataAtom == atom.Noscript || p.DataAtom == atom.Template
+	})
+	return parent == nil
 }
 
 func IsImplictNode(n *astro.Node) bool {


### PR DESCRIPTION
## Changes

- Supercedes https://github.com/withastro/compiler/pull/396
- Closes https://github.com/withastro/compiler/issues/395
- Does not hoist `script` or `style` elements inside of `noscript` or `template` nodes

## Testing

Tests updated

## Docs

Bug fix only
