### PR TITLE
Stable scoped class

### DIFF
--- a/.changeset/strange-badgers-exist.md
+++ b/.changeset/strange-badgers-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Generate a stable scoped class that does _NOT_ factor in local styles. This will allow us to safely do style HMR without needing to update the DOM as well.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -152,6 +152,7 @@ type TSXResult struct {
 type TransformResult struct {
 	Code                 string              `js:"code"`
 	Map                  string              `js:"map"`
+	Scope                string              `js:"scope"`
 	CSS                  []string            `js:"css"`
 	Scripts              []HoistedScript     `js:"scripts"`
 	HydratedComponents   []HydratedComponent `js:"hydratedComponents"`
@@ -233,6 +234,11 @@ func Transform() interface{} {
 
 				// Hoist styles and scripts to the top-level
 				transform.ExtractStyles(doc)
+
+				if len(doc.Styles) > 0 {
+					newHash := astro.HashFromDoc(doc)
+					transformOptions.Scope = newHash
+				}
 
 				// Pre-process styles
 				// Important! These goroutines need to be spawned from this file or they don't work
@@ -354,6 +360,7 @@ func Transform() interface{} {
 						CSS:                  css,
 						Code:                 string(result.Output),
 						Map:                  "",
+						Scope:                transformOptions.Scope,
 						Scripts:              scripts,
 						HydratedComponents:   hydratedComponents,
 						ClientOnlyComponents: clientOnlyComponents,
@@ -395,6 +402,7 @@ func createExternalSourceMap(source string, result printer.PrintResult, css []st
 		CSS:                  css,
 		Code:                 string(result.Output),
 		Map:                  createSourceMapString(source, result, transformOptions),
+		Scope:                transformOptions.Scope,
 		Scripts:              *scripts,
 		HydratedComponents:   *hydratedComponents,
 		ClientOnlyComponents: *clientOnlyComponents,
@@ -408,6 +416,7 @@ func createInlineSourceMap(source string, result printer.PrintResult, css []stri
 		CSS:                  css,
 		Code:                 string(result.Output) + "\n" + inlineSourcemap,
 		Map:                  "",
+		Scope:                transformOptions.Scope,
 		Scripts:              *scripts,
 		HydratedComponents:   *hydratedComponents,
 		ClientOnlyComponents: *clientOnlyComponents,
@@ -421,6 +430,7 @@ func createBothSourceMap(source string, result printer.PrintResult, css []string
 		CSS:                  css,
 		Code:                 string(result.Output) + "\n" + inlineSourcemap,
 		Map:                  sourcemapString,
+		Scope:                transformOptions.Scope,
 		Scripts:              *scripts,
 		HydratedComponents:   *hydratedComponents,
 		ClientOnlyComponents: *clientOnlyComponents,

--- a/internal/hash.go
+++ b/internal/hash.go
@@ -2,9 +2,18 @@ package astro
 
 import (
 	"encoding/base32"
+	"strings"
 
 	"github.com/withastro/compiler/internal/xxhash"
 )
+
+// This is used in `Transform` to ensure a stable hash when updating styles
+func HashFromDoc(doc *Node) string {
+	var b strings.Builder
+	PrintToSource(&b, doc)
+	source := strings.TrimSpace(b.String())
+	return HashFromSource(source)
+}
 
 func HashFromSource(source string) string {
 	h := xxhash.New()

--- a/internal/print-to-source.go
+++ b/internal/print-to-source.go
@@ -12,11 +12,13 @@ func PrintToSource(buf *strings.Builder, node *Node) {
 			PrintToSource(buf, c)
 		}
 	case FrontmatterNode:
-		buf.WriteString("---")
-		for c := node.FirstChild; c != nil; c = c.NextSibling {
-			PrintToSource(buf, c)
+		if node.FirstChild != nil {
+			buf.WriteString("---")
+			for c := node.FirstChild; c != nil; c = c.NextSibling {
+				PrintToSource(buf, c)
+			}
+			buf.WriteString("---")
 		}
-		buf.WriteString("---")
 	case TextNode:
 		buf.WriteString(node.Data)
 	case ElementNode:

--- a/internal/print-to-source.go
+++ b/internal/print-to-source.go
@@ -11,6 +11,12 @@ func PrintToSource(buf *strings.Builder, node *Node) {
 		for c := node.FirstChild; c != nil; c = c.NextSibling {
 			PrintToSource(buf, c)
 		}
+	case FrontmatterNode:
+		buf.WriteString("---")
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			PrintToSource(buf, c)
+		}
+		buf.WriteString("---")
 	case TextNode:
 		buf.WriteString(node.Data)
 	case ElementNode:

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -52,6 +52,7 @@ export interface TransformResult {
   clientOnlyComponents: HydratedComponent[];
   code: string;
   map: string;
+  scope: string;
 }
 
 export interface TSXResult {

--- a/packages/compiler/test/styles/emit-scope.ts
+++ b/packages/compiler/test/styles/emit-scope.ts
@@ -1,0 +1,26 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+let value = 'world';
+---
+
+<style>div { color: red; }</style>
+
+<div>Hello world!</div>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    sourcemap: true,
+  });
+});
+
+test('emits a scope', () => {
+  assert.ok(result.scope, 'Expected to return a scope');
+});
+
+test.run();

--- a/packages/compiler/test/styles/hash.ts
+++ b/packages/compiler/test/styles/hash.ts
@@ -1,0 +1,55 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE_A = `
+<style>
+  h1 { color: red; }
+</style>
+
+<h1>Hello world!</h1>
+`;
+const FIXTURE_B = `
+<style>
+  h1 { color: blue; }
+</style>
+
+<h1>Hello world!</h1>
+`;
+const FIXTURE_C = `
+<style>
+  h1 { color: red; }
+</style>
+
+<script>console.log("Hello world")</script>
+`;
+const FIXTURE_D = `
+<style>
+  h1 { color: red; }
+</style>
+
+<script>console.log("Hello world!")</script>
+`;
+
+const scopes: string[] = [];
+test.before(async () => {
+  const [{ scope: a }, { scope: b }, { scope: c }, { scope: d }] = await Promise.all([FIXTURE_A, FIXTURE_B, FIXTURE_C, FIXTURE_D].map((source) => transform(source)));
+  scopes.push(a, b, c, d);
+});
+
+test('hash is stable when styles change', () => {
+  const [a, b] = scopes;
+  assert.equal(a, b, 'Expected scopes to be equal');
+});
+
+test('hash changes when content outside of style change', () => {
+  const [, b, c] = scopes;
+  assert.not.equal(b, c, 'Expected scopes to not be equal');
+});
+
+test('hash changes when scripts change', () => {
+  const [, , c, d] = scopes;
+  assert.not.equal(c, d, 'Expected scopes to not be equal');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Updates hashing algorithm to **ignore** the contents of hoisted `<style>` blocks.
- This will make style HMR significantly easier, since we won't have to update all the `class` attributes in the DOM

## Testing

Tests added. Only happens in `transform` so these are JS tests.

## Docs

Internal change only
