### PR TITLE
Prevent unescaping expression values

### DIFF
--- a/.changeset/blue-deers-beam.md
+++ b/.changeset/blue-deers-beam.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Prevents unescaping attribute expressions

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2132,6 +2132,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:html on Fragment",
+			source: "<Fragment set:html={\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\"} />",
+			want: want{
+				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\")}`,})}",
+			},
+		},
+		{
 			name:             "define:vars on style with StaticExpression turned on",
 			source:           "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			staticExtraction: true,

--- a/internal/token.go
+++ b/internal/token.go
@@ -1853,7 +1853,15 @@ func (z *Tokenizer) TagAttr() (key []byte, keyLoc loc.Loc, val []byte, valLoc lo
 			val = z.buf[x[1].Start:x[1].End]
 			keyLoc := loc.Loc{Start: x[0].Start}
 			valLoc := loc.Loc{Start: x[1].Start}
-			return key, keyLoc, unescape(convertNewlines(val), true), valLoc, attrType, z.nAttrReturned < len(z.attr)
+
+			var attrVal []byte
+			if attrType == ExpressionAttribute {
+				attrVal = val
+			} else {
+				attrVal = unescape(convertNewlines(val), true)
+			}
+
+			return key, keyLoc, attrVal, valLoc, attrType, z.nAttrReturned < len(z.attr)
 		}
 	}
 	return nil, loc.Loc{Start: 0}, nil, loc.Loc{Start: 0}, QuotedAttribute, false


### PR DESCRIPTION
## Changes

- Prevents unescaping expression attribute values. 
- Fixes https://github.com/withastro/astro/issues/3916

## Testing

- Test added to ensure the markdown Fragment set:html condition holds.

## Docs

N/A