### PR TITLE
Prevent wrapping module script with scope

### DIFF
--- a/.changeset/wet-socks-glow.md
+++ b/.changeset/wet-socks-glow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Prevent wraping module scripts with scope

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -133,6 +133,14 @@ func (p *printer) printTemplateLiteralClose() {
 	p.print(BACKTICK)
 }
 
+func isTypeModuleScript(n *astro.Node) bool {
+	t := astro.GetAttribute(n, "type")
+	if t != nil && t.Val == "module" {
+		return true
+	}
+	return false
+}
+
 func (p *printer) printDefineVarsOpen(n *astro.Node) {
 	// Only handle <script> or <style>
 	if !(n.DataAtom == atom.Script || n.DataAtom == atom.Style) {
@@ -142,7 +150,9 @@ func (p *printer) printDefineVarsOpen(n *astro.Node) {
 		return
 	}
 	if n.DataAtom == atom.Script {
-		p.print("{")
+		if !isTypeModuleScript(n) {
+			p.print("{")
+		}
 	}
 	for _, attr := range n.Attr {
 		if attr.Key == "define:vars" {
@@ -177,7 +187,9 @@ func (p *printer) printDefineVarsClose(n *astro.Node) {
 	if !transform.HasAttr(n, "define:vars") {
 		return
 	}
-	p.print("}")
+	if !isTypeModuleScript(n) {
+		p.print("}")
+	}
 }
 
 func (p *printer) printFuncPrelude(opts transform.TransformOptions) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2179,6 +2179,15 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name: "define:vars on a module script with imports",
+			// Should not wrap with { } scope.
+			source:           `<script type="module" define:vars={{foo:'bar'}}>import 'foo';\nvar three = foo;</script>`,
+			staticExtraction: true,
+			want: want{
+				code: `<script type="module">${$$defineScriptVars({foo:'bar'})}import 'foo';\\nvar three = foo;</script>`,
+			},
+		},
+		{
 			name:   "comments removed from attribute list",
 			source: `<div><h1 {/* comment 1 */} value="1" {/* comment 2 */}>Hello</h1><Component {/* comment 1 */} value="1" {/* comment 2 */} /></div>`,
 			want: want{


### PR DESCRIPTION
## Changes

- New `define:vars` logic wraps the entire script with `{ }` to create a scope to prevent global errors.
- Module scripts are already scoped, and adding `{ }` around them causes errors because `import` cannot be inside of a scope.
- This now makes it so that module scripts are not wrapped.

## Testing

- test added

## Docs

N/A, bug fix.