### PR TITLE
[🚧 WIP] Add SBOM (and automate the process)

### DIFF
--- a/packages/compiler/bom.xml
+++ b/packages/compiler/bom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:c559849a-fcad-4500-addf-19903625bd02" version="1">
+    <metadata>
+        <timestamp>2022-07-31T17:43:44.398Z</timestamp>
+        <tools>
+            <tool>
+                <vendor>CycloneDX</vendor>
+                <name>Node.js module</name>
+                <version>3.10.4</version>
+            </tool>
+        </tools>
+        <component type="library" bom-ref="pkg:npm/%40astrojs/compiler@0.21.0">
+            <author>withastro</author>
+            <group>@astrojs</group>
+            <name>compiler</name>
+            <version>0.21.0</version>
+            <description>
+                <![CDATA[Astro’s [Go](https://golang.org/) + WASM compiler.]]>
+            </description>
+            <licenses>
+                <license>
+                    <id>MIT</id>
+                </license>
+            </licenses>
+            <purl>pkg:npm/%40astrojs/compiler@0.21.0</purl>
+            <externalReferences>
+                <reference type="website">
+                    <url>https://astro.build</url>
+                </reference>
+                <reference type="issue-tracker">
+                    <url>https://github.com/withastro/compiler/issues</url>
+                </reference>
+                <reference type="vcs">
+                    <url>git+https://github.com/withastro/compiler.git</url>
+                </reference>
+            </externalReferences>
+        </component>
+    </metadata>
+    <components/>
+    <dependencies>
+        <dependency ref="pkg:npm/%40astrojs/compiler@0.21.0"/>
+    </dependencies>
+</bom>


### PR DESCRIPTION
[![Please Don't ship WIP](https://img.shields.io/badge/Please-Don't%20Ship%20WIP-yellow)](https://dont-ship.it/)

This commit adds an SBOM to the repository and will automate the process for future use.

SBOM is using [the Cyclone DX 1.4 SBOM specification](https://cyclonedx.org/docs/1.4/json/) and is currently being generated in XML (this may change in the future to JSON, if it's determined preferable).

Special Thanks to @aFuzzyBear for assistance with the Astro-specific knowledge required to complete these audits.