### PR TITLE
Handle unbalanced quotes in expression attributes

### DIFF
--- a/.changeset/nervous-jobs-live.md
+++ b/.changeset/nervous-jobs-live.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of unbalanced quotes in expression attributes

--- a/internal/token.go
+++ b/internal/token.go
@@ -1274,6 +1274,10 @@ func (z *Tokenizer) readTagAttrExpression() {
 			if z.attrTemplateLiteralStack[z.attrExpressionStack-1] != 0 && c == '/' {
 				continue
 			}
+			inTemplateLiteral := len(z.attrTemplateLiteralStack) >= z.attrExpressionStack && z.attrTemplateLiteralStack[z.attrExpressionStack-1] > 0
+			if inTemplateLiteral {
+				continue
+			}
 			end := z.data.End
 			if c == '/' {
 				// Also stop when we hit a '}' character (end of attribute expression)

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -409,6 +409,16 @@ func TestBasic(t *testing.T) {
 			"<h1 set:html={`Oh \"no...`}></h1>",
 			[]TokenType{StartTagToken, EndTagToken},
 		},
+		{
+			"attribute expression with unmatched quotes inside matched quotes",
+			"<h1 set:html={\"hello y'all\"}></h1>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
+		{
+			"attribute expression with unmatched quotes inside matched quotes II",
+			"<h1 set:html={'\"Did Nate handle this case, too?\", Fred pondered...'}></h1>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -399,6 +399,16 @@ func TestBasic(t *testing.T) {
 			`<div>{() => { switch(value) { case 'a': return <A>{value}</A>; case 'b': return <B />; case 'c': return <C>{value.map(i => <span>{i}</span>)}</C> }}}</div>`,
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, SelfClosingTagToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
 		},
+		{
+			"attribute expression with unmatched quotes",
+			"<h1 set:text={`Houston we've got a problem`}></h1>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
+		{
+			"attribute expression with unmatched quotes",
+			"<h1 set:html={`Oh \"no...`}></h1>",
+			[]TokenType{StartTagToken, EndTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/4122
- Skip handling quotes when inside a template literal

## Testing

Tokenizer tests added

## Docs

N/A, bug fix only