### PR TITLE
Prevent printing the doctype in the JS output

### DIFF
--- a/.changeset/bright-socks-change.md
+++ b/.changeset/bright-socks-change.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Prevent printing the doctype in the JS output

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -262,31 +262,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		p.print("-->")
 		return
 	case DoctypeNode:
-		p.print("<!DOCTYPE ")
-		p.print(n.Data)
-		if n.Attr != nil {
-			var public, system string
-			for _, a := range n.Attr {
-				switch a.Key {
-				case "public":
-					public = a.Val
-				case "system":
-					system = a.Val
-				}
-			}
-			if public != "" {
-				p.print(" PUBLIC ")
-				p.print(fmt.Sprintf(`"%s"`, public))
-				if system != "" {
-					p.print(" ")
-					p.print(fmt.Sprintf(`"%s"`, system))
-				}
-			} else if system != "" {
-				p.print(" SYSTEM ")
-				p.print(fmt.Sprintf(`"%s"`, system))
-			}
-		}
-		p.print(">")
+		// Doctype doesn't get printed because the Astro runtime always appends it
 		return
 	case RawNode:
 		p.print(n.Data)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -913,7 +913,7 @@ const name = "world";
   </body>
 </html>`,
 			want: want{
-				code: `<!DOCTYPE html><html lang="en">
+				code: `<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -1641,7 +1641,7 @@ const { product } = Astro.props;
 </body>
 </html>`, BACKTICK, BACKTICK),
 			want: want{
-				code: `<!DOCTYPE html><html lang="en">
+				code: `<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -1694,7 +1694,7 @@ import ProductPageContent from '../../components/ProductPageContent.jsx';`,
 			name:   "doctype",
 			source: `<!DOCTYPE html><div/>`,
 			want: want{
-				code: `<!DOCTYPE html>${$$maybeRenderHead($$result)}<div></div>`,
+				code: `${$$maybeRenderHead($$result)}<div></div>`,
 			},
 		},
 		{


### PR DESCRIPTION
## Changes

- Prevents printing the doctype, just in the JS output. The astro runtime already prepends the doctype all of the time.
- Part of https://github.com/withastro/astro/issues/4166

## Testing

- Tests updated that expected the doctype to be printed.

## Docs

N/A