### PR TITLE
Fix regression in generics logic

### DIFF
--- a/.changeset/fast-rules-fix.md
+++ b/.changeset/fast-rules-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix regression with expression rendering

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -208,6 +208,13 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "custom-element",
+			source: "{show && <client-only-element></client-only-element>}",
+			want: want{
+				code: "${show && $$render`${$$renderComponent($$result,'client-only-element','client-only-element',{})}`}",
+			},
+		},
+		{
 			name:   "attribute with template literal",
 			source: "<a :href=\"`/home`\">Home</a>",
 			want: want{

--- a/internal/token.go
+++ b/internal/token.go
@@ -1015,7 +1015,7 @@ func (z *Tokenizer) readStartTag() TokenType {
 			originalLen := len(text)
 			// If this "StartTagToken" does not include any spaces between it and the end of the expression
 			// we can roughly assume it is a TypeScript generic rather than an element. Rough but it works!
-			if len(strings.TrimRightFunc(text, unicode.IsSpace)) == originalLen {
+			if len(text) != 0 && len(strings.TrimRightFunc(text, unicode.IsSpace)) == originalLen {
 				return TextToken
 			}
 		}


### PR DESCRIPTION
## Changes

- Fixes issue outlined in https://github.com/withastro/astro/pull/4175#issuecomment-1206863934
- When checking for generics, we should probably check that the expression length isn't `0`. This is the fix!

## Testing

Test added

## Docs

Bug fix only
