### PR TITLE
Better handling for namespaced components

### DIFF
--- a/.changeset/dirty-rice-work.md
+++ b/.changeset/dirty-rice-work.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve handling of namespaced components when they are multiple levels deep

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1021,7 +1021,7 @@ const someProps = {
   ` + RENDER_HEAD_RESULT + `</head>
   <body class="astro-HMNNHVCQ">
     <main class="astro-HMNNHVCQ">
-      ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":($$metadata.getPath(Counter)),"client:component-export":($$metadata.getExport(Counter)),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
+      ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":(""),"client:component-export":("default"),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
     </main>
   </body></html>
   `,
@@ -1186,9 +1186,9 @@ import 'custom-element';`,
 					hydratedComponents:  []string{"'my-element'", "Two", "One"},
 					hydrationDirectives: []string{"load"},
 				},
-				code: `${$$renderComponent($$result,'One',One,{"client:load":true,"client:component-hydration":"load","client:component-path":($$metadata.getPath(One)),"client:component-export":($$metadata.getExport(One))})}
-${$$renderComponent($$result,'Two',Two,{"client:load":true,"client:component-hydration":"load","client:component-path":($$metadata.getPath(Two)),"client:component-export":($$metadata.getExport(Two))})}
-${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"client:component-hydration":"load","client:component-path":($$metadata.getPath('my-element')),"client:component-export":($$metadata.getExport('my-element'))})}`,
+				code: `${$$renderComponent($$result,'One',One,{"client:load":true,"client:component-hydration":"load","client:component-path":(""),"client:component-export":("default")})}
+${$$renderComponent($$result,'Two',Two,{"client:load":true,"client:component-hydration":"load","client:component-path":(""),"client:component-export":("default")})}
+${$$renderComponent($$result,'my-element','my-element',{"client:load":true,"client:component-hydration":"load"})}`,
 			},
 		},
 		{
@@ -1661,7 +1661,7 @@ const { product } = Astro.props;
   ${$$renderComponent($$result,'Header',Header,{})}
   <div class="product-page">
     <article>
-      ${$$renderComponent($$result,'ProductPageContent',ProductPageContent,{"client:visible":true,"product":(product.node),"client:component-hydration":"visible","client:component-path":($$metadata.getPath(ProductPageContent)),"client:component-export":($$metadata.getExport(ProductPageContent))})}
+      ${$$renderComponent($$result,'ProductPageContent',ProductPageContent,{"client:visible":true,"product":(product.node),"client:component-hydration":"visible","client:component-path":(""),"client:component-export":("default")})}
     </article>
   </div>
   ${$$renderComponent($$result,'Footer',Footer,{})}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -288,11 +288,6 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 	if n.Type == astro.ElementNode && (n.Component || n.CustomElement) {
 		for _, attr := range n.Attr {
-			id := n.Data
-			if n.CustomElement {
-				id = fmt.Sprintf("'%s'", id)
-			}
-
 			if strings.HasPrefix(attr.Key, "client:") {
 				parts := strings.Split(attr.Key, ":")
 				directive := parts[1]

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -364,8 +364,12 @@ func matchNodeToImportStatement(doc *astro.Node, n *astro.Node) *ImportMatch {
 		for _, imported := range stmt.Imports {
 
 			if strings.Contains(n.Data, ".") && strings.HasPrefix(n.Data, fmt.Sprintf("%s.", imported.LocalName)) {
+				exportName := n.Data
+				if imported.ExportName == "*" {
+					exportName = strings.Replace(exportName, fmt.Sprintf("%s.", imported.LocalName), "", 1)
+				}
 				match = &ImportMatch{
-					ExportName: n.Data,
+					ExportName: exportName,
 					Specifier:  stmt.Specifier,
 				}
 				return false
@@ -380,11 +384,6 @@ func matchNodeToImportStatement(doc *astro.Node, n *astro.Node) *ImportMatch {
 
 		return true
 	})
-
-	if match != nil {
-		fmt.Println(match.ExportName, match.Specifier)
-	}
-
 	return match
 }
 

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -49,7 +49,7 @@ test('Hydrated components: default export', () => {
 
 test('Hydrated components: star export', () => {
   let components = result.hydratedComponents;
-  assert.equal(components[1].exportName, '*');
+  assert.equal(components[1].exportName, 'someName');
   assert.equal(components[1].specifier, '../components/two.jsx');
   assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/two.jsx');
 });
@@ -63,7 +63,7 @@ test('Hydrated components: named export', () => {
 
 test('Hydrated components: deep nested export', () => {
   let components = result.hydratedComponents;
-  assert.equal(components[3].exportName, '*');
+  assert.equal(components[3].exportName, 'nested.deep.Component');
   assert.equal(components[3].specifier, '../components/four.jsx');
   assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four.jsx');
 });
@@ -75,7 +75,7 @@ test('ClientOnly component', () => {
 
 test('ClientOnly components: star export', () => {
   let components = result.clientOnlyComponents;
-  assert.equal(components[0].exportName, '*');
+  assert.equal(components[0].exportName, 'someName');
   assert.equal(components[0].specifier, '../components/five.jsx');
   assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five.jsx');
 });
@@ -96,7 +96,7 @@ test('ClientOnly components: default export', () => {
 
 test('ClientOnly components: deep nested export', () => {
   let components = result.clientOnlyComponents;
-  assert.equal(components[3].exportName, '*');
+  assert.equal(components[3].exportName, 'nested.deep.Component');
   assert.equal(components[3].specifier, '../components/eight.jsx');
   assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/eight.jsx');
 });

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -7,20 +7,24 @@ const FIXTURE = `
 import One from '../components/one.jsx';
 import * as Two from '../components/two.jsx';
 import { Three } from '../components/three.tsx';
+import * as four from '../components/four.jsx';
 
-import Four from '../components/four.jsx';
 import * as Five from '../components/five.jsx';
 import { Six } from '../components/six.jsx';
+import Seven from '../components/seven.jsx';
+import * as eight from '../components/eight.jsx';
 ---
 
 <One client:load />
 <Two.someName client:load />
 <Three client:load />
+<four.nested.deep.Component client:load />
 
 <!-- client only tests -->
-<Four client:only />
 <Five.someName client:only />
 <Six client:only />
+<Seven client:only />
+<eight.nested.deep.Component client:only />
 `;
 
 let result: TransformResult;
@@ -33,7 +37,7 @@ test.before(async () => {
 
 test('Hydrated component', () => {
   let components = result.hydratedComponents;
-  assert.equal(components.length, 3);
+  assert.equal(components.length, 4);
 });
 
 test('Hydrated components: default export', () => {
@@ -45,7 +49,7 @@ test('Hydrated components: default export', () => {
 
 test('Hydrated components: star export', () => {
   let components = result.hydratedComponents;
-  assert.equal(components[1].exportName, 'someName');
+  assert.equal(components[1].exportName, '*');
   assert.equal(components[1].specifier, '../components/two.jsx');
   assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/two.jsx');
 });
@@ -57,30 +61,44 @@ test('Hydrated components: named export', () => {
   assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/three.tsx');
 });
 
-test('ClientOnly component', () => {
-  let components = result.clientOnlyComponents;
-  assert.equal(components.length, 3);
+test('Hydrated components: deep nested export', () => {
+  let components = result.hydratedComponents;
+  assert.equal(components[3].exportName, '*');
+  assert.equal(components[3].specifier, '../components/four.jsx');
+  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four.jsx');
 });
 
-test('ClientOnly components: default export', () => {
+test('ClientOnly component', () => {
   let components = result.clientOnlyComponents;
-  assert.equal(components[0].exportName, 'default');
-  assert.equal(components[0].specifier, '../components/four.jsx');
-  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four.jsx');
+  assert.equal(components.length, 4);
 });
 
 test('ClientOnly components: star export', () => {
   let components = result.clientOnlyComponents;
-  assert.equal(components[1].exportName, 'someName');
-  assert.equal(components[1].specifier, '../components/five.jsx');
-  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five.jsx');
+  assert.equal(components[0].exportName, '*');
+  assert.equal(components[0].specifier, '../components/five.jsx');
+  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five.jsx');
 });
 
 test('ClientOnly components: named export', () => {
   let components = result.clientOnlyComponents;
-  assert.equal(components[2].exportName, 'Six');
-  assert.equal(components[2].specifier, '../components/six.jsx');
-  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/six.jsx');
+  assert.equal(components[1].exportName, 'Six');
+  assert.equal(components[1].specifier, '../components/six.jsx');
+  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/six.jsx');
+});
+
+test('ClientOnly components: default export', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components[2].exportName, 'default');
+  assert.equal(components[2].specifier, '../components/seven.jsx');
+  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/seven.jsx');
+});
+
+test('ClientOnly components: deep nested export', () => {
+  let components = result.clientOnlyComponents;
+  assert.equal(components[3].exportName, '*');
+  assert.equal(components[3].specifier, '../components/eight.jsx');
+  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/eight.jsx');
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- Companion PR to https://github.com/withastro/astro/pull/4272
- Updates how we match namespaced `components.with.deep.members`.
- Properly match `*` exports and `import { components } from 'file'`
- Removes `$$metadata` matcher utils which are mostly dead code paths now. With this PR, they can probably be removed from the frontend!

## Testing

Tests updated

## Docs

Bug fix only
