### PR TITLE
Fix resolution of JSX modules

### DIFF
--- a/.changeset/thin-beers-ring.md
+++ b/.changeset/thin-beers-ring.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix resolution of .jsx modules

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1035,7 +1035,7 @@ const someProps = {
   ` + RENDER_HEAD_RESULT + `</head>
   <body class="astro-HMNNHVCQ">
     <main class="astro-HMNNHVCQ">
-      ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":("../components/Counter.jsx"),"client:component-export":("default"),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
+      ${$$renderComponent($$result,'Counter',Counter,{...(someProps),"client:visible":true,"client:component-hydration":"visible","client:component-path":("../components/Counter"),"client:component-export":("default"),"class":"astro-HMNNHVCQ"},{"default": () => $$render` + "`" + `<h1 class="astro-HMNNHVCQ">Hello React!</h1>` + "`" + `,})}
     </main>
   </body></html>
   `,
@@ -1675,7 +1675,7 @@ const { product } = Astro.props;
   ${$$renderComponent($$result,'Header',Header,{})}
   <div class="product-page">
     <article>
-      ${$$renderComponent($$result,'ProductPageContent',ProductPageContent,{"client:visible":true,"product":(product.node),"client:component-hydration":"visible","client:component-path":("../../components/ProductPageContent.jsx"),"client:component-export":("default")})}
+      ${$$renderComponent($$result,'ProductPageContent',ProductPageContent,{"client:visible":true,"product":(product.node),"client:component-hydration":"visible","client:component-path":("../../components/ProductPageContent"),"client:component-export":("default")})}
     </article>
   </div>
   ${$$renderComponent($$result,'Footer',Footer,{})}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -388,6 +388,14 @@ func safeURL(pathname string) string {
 	return escaped
 }
 
+func trimExtension(pathname string) string {
+	// Runtime will be unable to resolve `.jsx` so we need to trim it off
+	if strings.HasSuffix(pathname, ".jsx") {
+		return pathname[0 : len(pathname)-4]
+	}
+	return pathname
+}
+
 func resolveIdForMatch(match *ImportMatch, opts *TransformOptions) string {
 	if strings.HasPrefix(match.Specifier, ".") && len(opts.Pathname) > 0 {
 		pathname := safeURL(opts.Pathname)
@@ -397,12 +405,11 @@ func resolveIdForMatch(match *ImportMatch, opts *TransformOptions) string {
 			ref, _ := url.Parse(spec)
 			ou := u.ResolveReference(ref)
 			unescaped, _ := url.PathUnescape(ou.String())
-			fmt.Println(unescaped)
-			return unescaped
+			return trimExtension(unescaped)
 		}
 	}
 	// If we can't manipulate the URLs, fallback to the exact specifier
-	return match.Specifier
+	return trimExtension(match.Specifier)
 }
 
 func eachImportStatement(doc *astro.Node, cb func(stmt js_scanner.ImportStatement) bool) {

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -44,14 +44,14 @@ test('Hydrated components: default export', () => {
   let components = result.hydratedComponents;
   assert.equal(components[0].exportName, 'default');
   assert.equal(components[0].specifier, '../components/one.jsx');
-  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/one.jsx');
+  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/one');
 });
 
 test('Hydrated components: star export', () => {
   let components = result.hydratedComponents;
   assert.equal(components[1].exportName, 'someName');
   assert.equal(components[1].specifier, '../components/two.jsx');
-  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/two.jsx');
+  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/two');
 });
 
 test('Hydrated components: named export', () => {
@@ -65,7 +65,7 @@ test('Hydrated components: deep nested export', () => {
   let components = result.hydratedComponents;
   assert.equal(components[3].exportName, 'nested.deep.Component');
   assert.equal(components[3].specifier, '../components/four.jsx');
-  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four.jsx');
+  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/four');
 });
 
 test('ClientOnly component', () => {
@@ -77,28 +77,28 @@ test('ClientOnly components: star export', () => {
   let components = result.clientOnlyComponents;
   assert.equal(components[0].exportName, 'someName');
   assert.equal(components[0].specifier, '../components/five.jsx');
-  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five.jsx');
+  assert.equal(components[0].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/five');
 });
 
 test('ClientOnly components: named export', () => {
   let components = result.clientOnlyComponents;
   assert.equal(components[1].exportName, 'Six');
   assert.equal(components[1].specifier, '../components/six.jsx');
-  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/six.jsx');
+  assert.equal(components[1].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/six');
 });
 
 test('ClientOnly components: default export', () => {
   let components = result.clientOnlyComponents;
   assert.equal(components[2].exportName, 'default');
   assert.equal(components[2].specifier, '../components/seven.jsx');
-  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/seven.jsx');
+  assert.equal(components[2].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/seven');
 });
 
 test('ClientOnly components: deep nested export', () => {
   let components = result.clientOnlyComponents;
   assert.equal(components[3].exportName, 'nested.deep.Component');
   assert.equal(components[3].specifier, '../components/eight.jsx');
-  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/eight.jsx');
+  assert.equal(components[3].resolvedPath, '/@fs/users/astro/apps/pacman/src/components/eight');
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- https://github.com/withastro/compiler/pull/497 removed the need for `metadata.resolveSpecifier`, but there was code in that path that trimmed `.jsx` from a specifier.
- This moves that logic into the compiler to match existing behavior
- Without this, builds will fail!

## Testing

Tests updated

## Docs

Bug fix only
