### PR TITLE
Remove css print escape for experimentalStaticExtraction

### DIFF
--- a/.changeset/gorgeous-zoos-think.md
+++ b/.changeset/gorgeous-zoos-think.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Remove css print escape for experimentalStaticExtraction

--- a/internal/printer/print-css.go
+++ b/internal/printer/print-css.go
@@ -27,7 +27,7 @@ func PrintCSS(sourcetext string, doc *Node, opts transform.TransformOptions) Pri
 		for _, style := range doc.Styles {
 			if style.FirstChild != nil && strings.TrimSpace(style.FirstChild.Data) != "" {
 				p.addSourceMapping(style.Loc[0])
-				p.print(escapeText(strings.TrimSpace(style.FirstChild.Data)))
+				p.print(strings.TrimSpace(style.FirstChild.Data))
 				result.Output = append(result.Output, p.output)
 				p.output = []byte{}
 				p.addNilSourceMapping()

--- a/packages/compiler/test/static-extraction/css.ts
+++ b/packages/compiler/test/static-extraction/css.ts
@@ -8,6 +8,7 @@ const FIXTURE = `
 <style>
     .thing { color: green; }
     .url-space { background: url('/white space.png'); }
+    .escape:not(#\\#) { color: red; }
 </style>
 `;
 
@@ -24,6 +25,10 @@ test('extracts styles', () => {
 
 test('escape url with space', () => {
   assert.match(result.css[0], 'background:url(/white\\ space.png)');
+});
+
+test('escape css syntax', () => {
+  assert.match(result.css[0], ':not(#\\#)');
 });
 
 test.run();

--- a/packages/compiler/test/static-extraction/css.ts
+++ b/packages/compiler/test/static-extraction/css.ts
@@ -7,6 +7,7 @@ const FIXTURE = `
 ---
 <style>
     .thing { color: green; }
+    .url-space { background: url('/white space.png'); }
 </style>
 `;
 
@@ -19,6 +20,10 @@ test.before(async () => {
 
 test('extracts styles', () => {
   assert.equal(result.css.length, 1, `Incorrect CSS returned. Expected a length of 1 and got ${result.css.length}`);
+});
+
+test('escape url with space', () => {
+  assert.match(result.css[0], 'background:url(/white\\ space.png)');
 });
 
 test.run();


### PR DESCRIPTION
## Changes

Fix #502 

I may be missing something big, but it doesn't seem like CSS needs to be escaped as it's not JS 🤔 I've removed it for CSS printing for static extraction

## Testing

Added test to `css.ts`

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
N/A
