### PR TITLE
Fix assertion parsing to always happen after the specifier

### DIFF
--- a/.changeset/gorgeous-cooks-jog.md
+++ b/.changeset/gorgeous-cooks-jog.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Prevent import assertion from being scanned too soon

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -365,7 +365,7 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 					continue
 				}
 
-				if !foundAssertion && next == js.IdentifierToken && string(nextValue) == "assert" {
+				if !foundAssertion && foundSpecifier && next == js.IdentifierToken && string(nextValue) == "assert" {
 					foundAssertion = true
 					continue
 				}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -315,6 +315,19 @@ import data from "test" assert { type: 'json' };
 			},
 		},
 		{
+			name: "import to identifier named assert",
+
+			source: `---
+import assert from 'test';
+---`,
+			want: want{
+				frontmatter: []string{
+					`import assert from 'test';`,
+				},
+				metadata: metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
+			},
+		},
+		{
 			name:   "no expressions in math",
 			source: `<p>Hello, world! This is a <em>buggy</em> formula: <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mi>f</mi><mspace></mspace><mspace width="0.1111em"></mspace><mo lspace="0em" rspace="0.17em"></mo><mtext> ⁣</mtext><mo lspace="0em" rspace="0em">:</mo><mspace width="0.3333em"></mspace><mi>X</mi><mo>→</mo><msup><mi mathvariant="double-struck">R</mi><mrow><mn>2</mn><mi>x</mi></mrow></msup></mrow><annotation encoding="application/x-tex">f\colon X \to \mathbb R^{2x}</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.8889em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mspace nobreak"></span><span class="mspace" style="margin-right:0.1111em;"></span><span class="mpunct"></span><span class="mspace" style="margin-right:-0.1667em;"></span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord"><span class="mrel">:</span></span><span class="mspace" style="margin-right:0.3333em;"></span><span class="mord mathnormal" style="margin-right:0.07847em;">X</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">→</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8141em;"></span><span class="mord"><span class="mord mathbb">R</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8141em;"><span style="top:-3.063em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight"><span class="mord mtight">2</span><span class="mord mathnormal mtight">x</span></span></span></span></span></span></span></span></span></span></span></span></span></p>`,
 			want: want{


### PR DESCRIPTION
## Changes

- For https://github.com/withastro/astro/issues/4632
- The js scanner was looking for `assert` as an identifier anywhere in the statement, but it should only look after we've scanned the specifier.

## Testing

- Test added

## Docs

N/A, bug fix.