### PR TITLE
Handle bad CSS better

### DIFF
--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -6,6 +6,10 @@ export interface PreprocessorResult {
   map?: string;
 }
 
+export interface PreprocessorError {
+  error: string;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ParseOptions {
   position?: boolean;
@@ -24,7 +28,7 @@ export interface TransformOptions {
    */
   as?: 'document' | 'fragment';
   projectRoot?: string;
-  preprocessStyle?: (content: string, attrs: Record<string, string>) => Promise<PreprocessorResult>;
+  preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
   experimentalStaticExtraction?: boolean;
 }
 
@@ -54,6 +58,7 @@ export interface TransformResult {
   code: string;
   map: string;
   scope: string;
+  styleError: string;
 }
 
 export interface TSXResult {

--- a/packages/compiler/test/bad-styles/sass.ts
+++ b/packages/compiler/test/bad-styles/sass.ts
@@ -1,0 +1,26 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<style lang="scss">
+	article:global(:is(h1, h2, h3, h4, h5, h6):hover {
+		color: purple;
+	}
+</style>
+`;
+
+test('it works', async () => {
+  let result = await transform(FIXTURE, {
+    experimentalStaticExtraction: true,
+    pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro',
+    async preprocessStyle() {
+      return {
+        error: new Error('Unable to convert').message,
+      };
+    },
+  });
+  assert.equal(result.styleError, 'Unable to convert');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Currently the compiler expects preprocessStyle to return valid CSS. However if there is an error preprocessing it might now.
- This makes it so that preprocessStyle can return an error. The compiler uses that to know the CSS is bad.
- The styleError is returned in the transform result and the caller can use that error to do whatever it needs.
- Part of https://github.com/withastro/astro/issues/4615, still need core update to completely fix.

## Testing

Test added

## Docs

N/A