### PR TITLE
Fix `getStaticPaths` hoisting

### DIFF
--- a/.changeset/proud-peas-pull.md
+++ b/.changeset/proud-peas-pull.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge cases with `getStaticPaths` where valid JS syntax was improperly handled

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -62,6 +62,7 @@ outer:
 		// Exports should be consumed until all opening braces are closed,
 		// a specifier is found, and a line terminator has been found
 		if token == js.ExportToken {
+			flags := make(map[string]bool, 0)
 			foundIdent := false
 			foundSemicolonOrLineTerminator := false
 			start := 0
@@ -78,6 +79,7 @@ outer:
 					}
 				}
 				i += len(nextValue)
+				flags[string(nextValue)] = true
 
 				if js.IsIdentifier(next) {
 					if isKeyword(nextValue) && next != js.FromToken {
@@ -87,9 +89,13 @@ outer:
 						foundIdent = true
 					}
 				} else if next == js.LineTerminatorToken || next == js.SemicolonToken || (next == js.ErrorToken && l.Err() == io.EOF) {
+					if (flags["function"] || flags["=>"]) && !flags["{"] {
+						continue
+					}
 					foundSemicolonOrLineTerminator = true
 				} else if js.IsPunctuator(next) {
 					if nextValue[0] == '{' || nextValue[0] == '(' || nextValue[0] == '[' {
+						flags[string(nextValue[0])] = true
 						pairs[nextValue[0]]++
 					} else if nextValue[0] == '}' {
 						pairs['{']--

--- a/packages/compiler/test/basic/get-static-paths.ts
+++ b/packages/compiler/test/basic/get-static-paths.ts
@@ -1,0 +1,59 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+test('getStaticPaths with braces on newline', async () => {
+  const FIXTURE = `---
+import A from './A.astro';
+export async function getStaticPaths()
+{
+  return [
+    { params: { id: '1' } },
+    { params: { id: '2' } },
+    { params: { id: '3' } }
+  ];
+}
+---
+
+<div></div>
+`;
+  const result = await transform(FIXTURE);
+  assert.match(result.code, 'export async function getStaticPaths()\n{', 'Expected output to contain getStaticPaths output');
+});
+
+test('getStaticPaths as const without braces', async () => {
+  const FIXTURE = `---
+import A from './A.astro';
+export const getStaticPaths = () => ([
+  { params: { id: '1' } },
+  { params: { id: '2' } },
+  { params: { id: '3' } }
+])
+---
+
+<div></div>
+`;
+  const result = await transform(FIXTURE);
+  assert.match(result.code, 'export const getStaticPaths = () => ([', 'Expected output to contain getStaticPaths output');
+});
+
+test('getStaticPaths as const with braces on newline', async () => {
+  const FIXTURE = `---
+import A from './A.astro';
+export const getStaticPaths = () =>
+{
+  return [
+    { params: { id: '1' } },
+    { params: { id: '2' } },
+    { params: { id: '3' } }
+  ];
+}
+---
+
+<div></div>
+`;
+  const result = await transform(FIXTURE);
+  assert.match(result.code, 'export const getStaticPaths = () =>\n{', 'Expected output to contain getStaticPaths output');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Fixes various edge cases where `getStaticPaths` wouldn't be hoisted if there was a valid newline
- `js_scanner` now tracks seen tokens (like `function` and `=>`) to verify that we must also see a `{` token before closing.
- Tests were added for `function` and `const` style functions
- Closes [withastro/astro#4685](https://github.com/withastro/astro/issues/4685), #512 

## Testing

Tests added

## Docs

N/A, bug fix only