### PR TITLE
Fix: CSS order for imported CSS vs. Astro styles

### DIFF
--- a/.changeset/tricky-mugs-wash.md
+++ b/.changeset/tricky-mugs-wash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Make Astro styles being printed after user imports

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -106,7 +106,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		p.printInternalImports(p.opts.InternalURL)
-		if opts.opts.StaticExtraction {
+		if opts.opts.StaticExtraction && n.FirstChild != nil && n.FirstChild.Type != FrontmatterNode {
 			p.printCSSImports(opts.cssLen)
 		}
 
@@ -116,6 +116,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				isExpression:     false,
 				depth:            depth + 1,
 				opts:             opts.opts,
+				cssLen:           opts.cssLen,
 				printedMaybeHead: opts.printedMaybeHead,
 			})
 		}
@@ -130,9 +131,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				p.printInternalImports(p.opts.InternalURL)
-				if opts.opts.StaticExtraction {
-					p.printCSSImports(opts.cssLen)
-				}
 
 				if len(n.Loc) > 0 {
 					p.addSourceMapping(n.Loc[0])
@@ -151,6 +149,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					p.addSourceMapping(c.Loc[0])
 				}
 				p.println(strings.TrimSpace(importStatements))
+
+				if opts.opts.StaticExtraction {
+					p.printCSSImports(opts.cssLen)
+				}
 
 				// 1. Component imports, if any exist.
 				p.printComponentMetadata(n.Parent, opts.opts, []byte(importStatements))
@@ -199,6 +201,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					isExpression:     true,
 					depth:            depth + 1,
 					opts:             opts.opts,
+					cssLen:           opts.cssLen,
 					printedMaybeHead: opts.printedMaybeHead,
 				})
 				if len(n.Loc) > 1 {
@@ -294,6 +297,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				isExpression:     true,
 				depth:            depth + 1,
 				opts:             opts.opts,
+				cssLen:           opts.cssLen,
 				printedMaybeHead: opts.printedMaybeHead,
 			})
 			if c.NextSibling == nil || c.NextSibling.Type == TextNode {
@@ -441,6 +445,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					isExpression:     opts.isExpression,
 					depth:            depth + 1,
 					opts:             opts.opts,
+					cssLen:           opts.cssLen,
 					printedMaybeHead: opts.printedMaybeHead,
 				})
 			}
@@ -474,6 +479,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						isExpression:     opts.isExpression,
 						depth:            depth + 1,
 						opts:             opts.opts,
+						cssLen:           opts.cssLen,
 						printedMaybeHead: opts.printedMaybeHead,
 					})
 				}
@@ -577,6 +583,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 								isExpression:     opts.isExpression,
 								depth:            depth + 1,
 								opts:             opts.opts,
+								cssLen:           opts.cssLen,
 								printedMaybeHead: opts.printedMaybeHead,
 							})
 						}
@@ -597,6 +604,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 								isExpression:     opts.isExpression,
 								depth:            depth + 1,
 								opts:             opts.opts,
+								cssLen:           opts.cssLen,
 								printedMaybeHead: opts.printedMaybeHead,
 							})
 							if child.Type == ElementNode {
@@ -615,6 +623,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						isExpression:     opts.isExpression,
 						depth:            depth + 1,
 						opts:             opts.opts,
+						cssLen:           opts.cssLen,
 						printedMaybeHead: opts.printedMaybeHead,
 					})
 				}
@@ -626,6 +635,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						isExpression:     opts.isExpression,
 						depth:            depth + 1,
 						opts:             opts.opts,
+						cssLen:           opts.cssLen,
 						printedMaybeHead: opts.printedMaybeHead,
 					})
 				}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -128,6 +128,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 	// Render frontmatter (will be the first node, if it exists)
 	if n.Type == FrontmatterNode {
+		if n.FirstChild == nil {
+			p.printCSSImports(opts.cssLen)
+		}
+
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				p.printInternalImports(p.opts.InternalURL)

--- a/packages/compiler/test/css-order/astro-styles.ts
+++ b/packages/compiler/test/css-order/astro-styles.ts
@@ -1,0 +1,24 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<style>
+  body { color: green; }
+</style>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    sourcefile: 'test.astro',
+    experimentalStaticExtraction: true,
+  });
+});
+
+test('Astro style imports are included in the compiled JS', () => {
+  let idx = result.code.indexOf('test.astro?astro&type=style&index=0&lang.css');
+  assert.not.equal(idx, -1);
+});
+
+test.run();

--- a/packages/compiler/test/css-order/imported-styles.ts
+++ b/packages/compiler/test/css-order/imported-styles.ts
@@ -1,0 +1,28 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+import '../styles/global.css';
+---
+<style>
+  body { color: green; }
+</style>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    sourcefile: 'test.astro',
+    experimentalStaticExtraction: true,
+  });
+});
+
+test('Astro style imports placed after frontmatter imports', () => {
+  let idx1 = result.code.indexOf('../styles/global.css');
+  let idx2 = result.code.indexOf('test.astro?astro&type=style&index=0&lang.css');
+  assert.ok(idx2 > idx1);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Brings back https://github.com/withastro/compiler/pull/520
  - was reverted because it caused components with no frontmatter to not have their imports printed.
- This fixes that

## Testing

- Tests added,
  - testing that components without frontmatter have their css import.
  - testing that components with frontmatter imports come before the component style import.

## Docs

N/A, bug fix