### PR TITLE
Fix `import.meta` usage above normal imports

### DIFF
--- a/.changeset/seven-monkeys-try.md
+++ b/.changeset/seven-monkeys-try.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix import.meta.env usage above normal imports

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -330,6 +330,22 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 					break
 				}
 
+				if next == js.DotToken {
+					isMeta := false
+					for {
+						next, _ := l.Next()
+						if next == js.MetaToken {
+							isMeta = true
+						}
+						if next != js.WhitespaceToken && next != js.MetaToken {
+							break
+						}
+					}
+					if isMeta {
+						continue
+					}
+				}
+
 				if !foundSpecifier && next == js.StringToken {
 					specifier = string(nextValue[1 : len(nextValue)-1])
 					foundSpecifier = true

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -88,6 +88,23 @@ const b = await fetch();`,
 `,
 		},
 		{
+			name: "import.meta.env",
+			source: `console.log(import.meta.env.FOO);
+import Test from "../components/Test.astro";`,
+			want: `import Test from "../components/Test.astro";`,
+		},
+		{
+			name: "import.meta.env II",
+			source: `console.log(
+	import
+		.meta
+		.env
+		.FOO
+);
+import Test from "../components/Test.astro";`,
+			want: `import Test from "../components/Test.astro";`,
+		},
+		{
 			name: "import/export",
 			source: `import { fn } from "package";
 export async fn() {}


### PR DESCRIPTION
## Changes

- Closes #508
- Properly handle `import.meta` when scanning for imports

## Testing

Tests added, one for `import.meta.env` and one for `import\n.meta\n.env` usage

## Docs

Bug fix only
