### PR TITLE
Fix empty style hashing markup

### DIFF
--- a/.changeset/dull-countries-taste.md
+++ b/.changeset/dull-countries-taste.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Do not scope empty style blocks

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -21,6 +21,7 @@ func TestTransformScoping(t *testing.T) {
 			`,
 			want: `<div class="astro-XXXXXX"></div>`,
 		},
+
 		{
 			name: "global empty",
 			source: `
@@ -52,6 +53,32 @@ func TestTransformScoping(t *testing.T) {
 				<div />
 			`,
 			want: `<div></div>`,
+		},
+		{
+			name: "empty (space)",
+			source: `
+				<style>
+				
+				</style>
+				<div />
+			`,
+			want: `<div></div>`,
+		},
+		{
+			name: "empty (nil)",
+			source: `
+				<style></style>
+				<div />
+			`,
+			want: `<div></div>`,
+		},
+		{
+			name: "empty (define:vars)",
+			source: `
+				<style define:vars={{ a }}></style>
+				<div />
+			`,
+			want: `<div class="astro-XXXXXX" style={$$definedVars}></div>`,
 		},
 		{
 			name: "scoped multiple",


### PR DESCRIPTION
## Changes

- Closes #516
- Empty styles (containing a string with only spaces) should not cause any markup to be scoped

## Testing

Go tests added

## Docs

Bug fix only
