### PR TITLE
Handle `slot` before <head>

### DIFF
--- a/.changeset/nervous-ducks-fetch.md
+++ b/.changeset/nervous-ducks-fetch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+handle slots that contains the head element

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -702,6 +702,14 @@ func beforeHeadIM(p *parser) bool {
 		return true
 	case StartTagToken:
 		switch p.tok.DataAtom {
+		case a.Slot:
+			p.addElement()
+			if p.hasSelfClosingToken {
+				p.addLoc()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
+			return true
 		case a.Head:
 			p.addElement()
 			p.head = p.top()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -110,6 +110,13 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "head inside slot",
+			source: `<html><slot><head></head></html>`,
+			want: want{
+				code: `<html>${$$renderSlot($$result,$$slots["default"],$$render` + BACKTICK + `<head>` + RENDER_HEAD_RESULT + `</head>` + BACKTICK + `)}</html>`,
+			},
+		},
+		{
 			name:   "head slot",
 			source: `<html><head><slot /></html>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -111,7 +111,7 @@ func TestPrinter(t *testing.T) {
 		},
 		{
 			name:   "head inside slot",
-			source: `<html><slot><head></head></html>`,
+			source: `<html><slot><head></head></slot></html>`,
 			want: want{
 				code: `<html>${$$renderSlot($$result,$$slots["default"],$$render` + BACKTICK + `<head>` + RENDER_HEAD_RESULT + `</head>` + BACKTICK + `)}</html>`,
 			},


### PR DESCRIPTION
## Changes

- Closes #531
- Fixes edge case where `slot` content was not picked up

## Testing

Go test added

## Docs

N/A, bug fix only
