### PR TITLE
Add `literal` parsing option for AST/TSX

### DIFF
--- a/.changeset/silly-coats-fix.md
+++ b/.changeset/silly-coats-fix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix parse/tsx output to gracefully handle invalid HTML (style outside of body, etc)

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -198,7 +198,7 @@ func Parse() interface{} {
 		parseOptions := makeParseOptions(js.Value(args[1]))
 
 		var doc *astro.Node
-		doc, err := astro.Parse(strings.NewReader(source))
+		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionEnableLiteral(true))
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -217,7 +217,7 @@ func ConvertToTSX() interface{} {
 		transformOptions.Scope = "XXXXXX"
 
 		var doc *astro.Node
-		doc, err := astro.Parse(strings.NewReader(source))
+		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionEnableLiteral(true))
 		if err != nil {
 			fmt.Println(err)
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2494,6 +2494,16 @@ const c = '\''
 			source: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></svg>`,
 			want:   []ASTNode{{Type: "element", Name: "svg", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xmlns", Value: "http://www.w3.org/2000/svg"}, {Type: "attribute", Kind: "quoted", Name: "xmlns:xlink", Value: "http://www.w3.org/1999/xlink"}}, Children: []ASTNode{{Type: "element", Name: "rect", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xlink:href", Value: "#id"}}}}}},
 		},
+		{
+			name:   "style before html",
+			source: `<style></style><html><body><h1>Hello world!</h1></body></html>`,
+			want:   []ASTNode{{Type: "element", Name: "style"}, {Type: "element", Name: "html", Children: []ASTNode{{Type: "element", Name: "body", Children: []ASTNode{{Type: "element", Name: "h1", Children: []ASTNode{{Type: "text", Value: "Hello world!"}}}}}}}},
+		},
+		{
+			name:   "style after html",
+			source: `<html><body><h1>Hello world!</h1></body></html><style></style>`,
+			want:   []ASTNode{{Type: "element", Name: "html", Children: []ASTNode{{Type: "element", Name: "body", Children: []ASTNode{{Type: "element", Name: "h1", Children: []ASTNode{{Type: "text", Value: "Hello world!"}}}}}, {Type: "element", Name: "style"}}}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2501,7 +2511,7 @@ const c = '\''
 			// transform output from source
 			code := test_utils.Dedent(tt.source)
 
-			doc, err := astro.Parse(strings.NewReader(code))
+			doc, err := astro.ParseWithOptions(strings.NewReader(code), astro.ParseOptionEnableLiteral(true))
 
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/318
- Currently, parsing "corrects" markup according to the HTML spec.
- For our AST output, we should handle things more literally to avoid issues like https://github.com/withastro/prettier-plugin-astro/issues/260
- This adds a `literal` mode to the parser, which handles elements before and after `html` gracefully.

## Testing

`print-to-json` tests added

## Docs

Bug fix only
