### PR TITLE
Fix import hoisting edge case

### DIFF
--- a/.changeset/quick-deers-kiss.md
+++ b/.changeset/quick-deers-kiss.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Do not hoist import inside object

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -599,6 +599,11 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 					break
 				}
 
+				// do not hoist `{ import: "value" }`
+				if next == js.ColonToken && len(specifier) == 0 {
+					break
+				}
+
 				// if this is import.meta.*, ignore (watch for first dot)
 				if next == js.DotToken && len(specifier) == 0 {
 					break

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1741,6 +1741,19 @@ import ProductPageContent from '../../components/ProductPageContent.jsx';`,
 			},
 		},
 		{
+			name: "import.meta",
+			source: `---
+const components = import.meta.glob("../components/*.astro", {
+  import: 'default'
+});
+---`,
+			want: want{
+				frontmatter: []string{"", `const components = import.meta.glob("../components/*.astro", {
+  import: 'default'
+});`},
+			},
+		},
+		{
 			name:   "doctype",
 			source: `<!DOCTYPE html><div/>`,
 			want: want{


### PR DESCRIPTION
## Changes

- Closes #530
- Avoid hoisting `import` when followed by a `:` token (inside an object)

## Testing

Test added

## Docs

Bug fix only
