### PR TITLE
Handle edge case with noscript tags

### DIFF
--- a/.changeset/funny-elephants-bathe.md
+++ b/.changeset/funny-elephants-bathe.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Handle edge case with `noscript` tags

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -523,6 +523,13 @@ import * as ns from '../components';
 			},
 		},
 		{
+			name:   "noscript only",
+			source: `<noscript><h1>Hello world</h1></noscript>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<noscript><h1>Hello world</h1></noscript>`,
+			},
+		},
+		{
 			name: "client:only component (default)",
 			source: `---
 import Component from '../components';


### PR DESCRIPTION
## Changes

- Closes #519 
- Handle edge case where `noscript` tags were not being handled properly
- Removed `p.scripting` default of true because there's no JS when we're parsing

## Testing

Test added

## Docs

Bug fix only
