### PR TITLE
Fix edge case with line comments and export hoisting

### DIFF
--- a/.changeset/quick-seas-end.md
+++ b/.changeset/quick-seas-end.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with line comments and export hoisting

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -66,10 +66,7 @@ outer:
 			flags := make(map[string]bool, 0)
 			foundIdent := false
 			foundSemicolonOrLineTerminator := false
-			start := 0
-			if i > 0 {
-				start = i - 1
-			}
+			start := i
 			i += len(value)
 			for {
 				next, nextValue := l.Next()

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -453,6 +453,14 @@ export interface RemoteImageProps extends TransformOptions, ImageAttributes {
 }
 export type Props = LocalImageProps | RemoteImageProps;`,
 		},
+		{
+			name: "comments",
+			source: `//
+export const foo = 0
+/*
+*/`,
+			want: `export const foo = 0`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -290,6 +290,7 @@ const b = 0;
 <div></div>`,
 			want: want{
 				frontmatter: []string{"", `const a = 0;
+
 const b = 0;`},
 				getStaticPaths: `export async function getStaticPaths() {
 	return { paths: [] }
@@ -306,6 +307,19 @@ mod.export();
 			want: want{
 				frontmatter: []string{``, `mod.export();`},
 				code:        `${$$maybeRenderHead($$result)}<div></div>`,
+			},
+		},
+		{
+			name: "export comments",
+			source: `---
+//
+export const foo = 0
+/*
+*/
+---`,
+			want: want{
+				frontmatter:    []string{"", "//\n/*\n*/"},
+				getStaticPaths: "export const foo = 0",
 			},
 		},
 		{


### PR DESCRIPTION
## Changes

- Closes #535
- Export hoisting caused an interesting edge case with line comments because newlines were being removed with the `export` statements.
- This PR retains newlines when hoisting the `export` statements.

## Testing

Tests updated to match new behavior

## Docs

Bug fix only