### PR TITLE
Support multi-line export hoisting

### DIFF
--- a/.changeset/tidy-feet-join.md
+++ b/.changeset/tidy-feet-join.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with multi-line export hoisting

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -86,6 +86,10 @@ outer:
 					if isKeyword(nextValue) && next != js.FromToken {
 						continue
 					}
+					// ensure type declarations are defined or exported from package
+					if flags["type"] && !(flags["="] || flags["from"]) {
+						continue
+					}
 					if !foundIdent {
 						foundIdent = true
 					}
@@ -93,7 +97,7 @@ outer:
 						flags["&"] = false
 					}
 				} else if next == js.LineTerminatorToken || next == js.SemicolonToken || (next == js.ErrorToken && l.Err() == io.EOF) {
-					if (flags["function"] || flags["=>"]) && !flags["{"] {
+					if (flags["function"] || flags["=>"] || flags["interface"]) && !flags["{"] {
 						continue
 					}
 					if flags["&"] {

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -384,6 +384,28 @@ export B from "./_types"
 export type C from "./_types"`,
 		},
 		{
+			name: "multi-line export",
+			source: `export interface Props
+{
+	foo: 'bar';
+}`,
+			want: `export interface Props
+{
+	foo: 'bar';
+}`,
+		},
+		{
+			name: "multi-line type export",
+			source: `export type Props =
+{
+	foo: 'bar';
+}`,
+			want: `export type Props =
+{
+	foo: 'bar';
+}`,
+		},
+		{
 			name: "Picture",
 			source: `// @ts-ignore
 import loader from 'virtual:image-loader';


### PR DESCRIPTION
## Changes

- Closes #536
- Handles edge case with multi-line export hoisting
- Ensures types and interfaces are handled similarly to functions

## Testing

Test added

## Docs

Bug fix only
