### PR TITLE
Auto type `Astro.props` interface

### DIFF
--- a/.changeset/witty-tools-turn.md
+++ b/.changeset/witty-tools-turn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Implement automatic typing for Astro.props in the TSX output

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -64,6 +64,10 @@ func getTextType(n *astro.Node) TextType {
 func renderTsx(p *printer, n *Node) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
+		props := js_scanner.GetPropsType([]byte(p.sourcetext))
+		if props.Ident != "Record<string, any>" {
+			p.printf(`declare const Astro: { props: %s } & Omit<import('astro').AstroGlobal, 'props'>`, props.Ident)
+		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			// This checks for the first node that comes *after* the frontmatter
@@ -99,7 +103,6 @@ func renderTsx(p *printer, n *Node) {
 		if hasChildren {
 			p.print("</Fragment>\n")
 		}
-		props := js_scanner.GetPropsType(p.output)
 		componentName := getTSXComponentName(p.opts.Filename)
 
 		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}", componentName, props.Statement, props.Ident, props.Generics))

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -66,7 +66,7 @@ func renderTsx(p *printer, n *Node) {
 	if n.Type == DocumentNode {
 		props := js_scanner.GetPropsType([]byte(p.sourcetext))
 		if props.Ident != "Record<string, any>" {
-			p.printf(`declare const Astro: { props: %s } & Omit<import('astro').AstroGlobal, 'props'>`, props.Ident)
+			p.printf(`declare const Astro: import('astro').AstroGlobal<%s>`, props.Ident)
 		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -66,7 +66,7 @@ func renderTsx(p *printer, n *Node) {
 	if n.Type == DocumentNode {
 		props := js_scanner.GetPropsType([]byte(p.sourcetext))
 		if props.Ident != "Record<string, any>" {
-			p.printf(`declare const Astro: import('astro').AstroGlobal<%s>`, props.Ident)
+			p.printf(`declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -66,7 +66,12 @@ func renderTsx(p *printer, n *Node) {
 	if n.Type == DocumentNode {
 		props := js_scanner.GetPropsType([]byte(p.sourcetext))
 		if props.Ident != "Record<string, any>" {
-			p.printf(`declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
+			p.printf(`/**
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
+*/
+declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -33,7 +33,7 @@ interface Props {}
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props {}
 
 ;<Fragment>
@@ -53,7 +53,7 @@ import { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 import { Props } from './somewhere';
 
 <Fragment>
@@ -73,7 +73,7 @@ import { MyComponent as Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 import { MyComponent as Props } from './somewhere';
 
 <Fragment>
@@ -93,7 +93,7 @@ import type { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 import type { Props } from './somewhere';
 
 <Fragment>
@@ -113,7 +113,7 @@ type Props = {}
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 type Props = {}
 
 ;<Fragment>
@@ -133,7 +133,7 @@ interface Props<T> {}
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props<T> {}
 
 ;<Fragment>
@@ -153,7 +153,7 @@ interface Props<T extends Other<{ [key: string]: any }>> {}
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props<T extends Other<{ [key: string]: any }>> {}
 
 ;<Fragment>
@@ -173,7 +173,7 @@ interface Props<T extends { [key: string]: any }, P extends string ? { [key: str
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -193,7 +193,7 @@ interface Props<T extends Something<false> ? A : B, P extends string ? { [key: s
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -215,7 +215,7 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 
 <div></div>
 `;
-  const output = `
+  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
 interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<Tag> {
   as?: Tag;
 }

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -2,6 +2,13 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { convertToTSX } from '@astrojs/compiler';
 
+const PREFIX = `/**
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
+*/
+declare const Astro: Readonly<import('astro').AstroGlobal<Props>>`;
+
 test('no props', async () => {
   const input = `<div></div>`;
   const output = `<Fragment>
@@ -33,7 +40,7 @@ interface Props {}
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props {}
 
 ;<Fragment>
@@ -53,7 +60,7 @@ import { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 import { Props } from './somewhere';
 
 <Fragment>
@@ -73,7 +80,7 @@ import { MyComponent as Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 import { MyComponent as Props } from './somewhere';
 
 <Fragment>
@@ -93,7 +100,7 @@ import type { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 import type { Props } from './somewhere';
 
 <Fragment>
@@ -113,7 +120,7 @@ type Props = {}
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 type Props = {}
 
 ;<Fragment>
@@ -133,7 +140,7 @@ interface Props<T> {}
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props<T> {}
 
 ;<Fragment>
@@ -153,7 +160,7 @@ interface Props<T extends Other<{ [key: string]: any }>> {}
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props<T extends Other<{ [key: string]: any }>> {}
 
 ;<Fragment>
@@ -173,7 +180,7 @@ interface Props<T extends { [key: string]: any }, P extends string ? { [key: str
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -193,7 +200,7 @@ interface Props<T extends Something<false> ? A : B, P extends string ? { [key: s
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -215,7 +222,7 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 
 <div></div>
 `;
-  const output = `declare const Astro: import('astro').AstroGlobal<Props>
+  const output = `${PREFIX}
 interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<Tag> {
   as?: Tag;
 }

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -33,7 +33,7 @@ interface Props {}
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props {}
 
 ;<Fragment>
@@ -53,7 +53,7 @@ import { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 import { Props } from './somewhere';
 
 <Fragment>
@@ -73,7 +73,7 @@ import { MyComponent as Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 import { MyComponent as Props } from './somewhere';
 
 <Fragment>
@@ -93,7 +93,7 @@ import type { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 import type { Props } from './somewhere';
 
 <Fragment>
@@ -113,7 +113,7 @@ type Props = {}
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 type Props = {}
 
 ;<Fragment>
@@ -133,7 +133,7 @@ interface Props<T> {}
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props<T> {}
 
 ;<Fragment>
@@ -153,7 +153,7 @@ interface Props<T extends Other<{ [key: string]: any }>> {}
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props<T extends Other<{ [key: string]: any }>> {}
 
 ;<Fragment>
@@ -173,7 +173,7 @@ interface Props<T extends { [key: string]: any }, P extends string ? { [key: str
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -193,7 +193,7 @@ interface Props<T extends Something<false> ? A : B, P extends string ? { [key: s
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never> {}
 
 ;<Fragment>
@@ -215,7 +215,7 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 
 <div></div>
 `;
-  const output = `declare const Astro: { props: Props } & Omit<import('astro').AstroGlobal, 'props'>
+  const output = `declare const Astro: import('astro').AstroGlobal<Props>
 interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<Tag> {
   as?: Tag;
 }


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/499
- Implements automatic typing for `Astro.props`
- Does not support generics, but that's okay

## Testing

Tests updated

## Docs

N/A, this is how it currently works
