### PR TITLE
Copies `snapshot-release.yml` from withastro/astro

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,0 +1,101 @@
+name: Create a Snapshot Release
+
+on:
+  issue_comment:
+    types: [created]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  FORCE_COLOR: true
+
+jobs:
+  snapshot-release:
+    name: Create a snapshot release of a pull request
+    if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && startsWith(github.event.comment.body, '!preview') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check if user has admin access (only admins can publish snapshot releases).'
+        uses: 'lannonbr/repo-permission-check-action@2.0.0'
+        with:
+          permission: 'admin'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract the snapshot name from comment body
+        id: getSnapshotName
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const splitComment = context.payload.comment.body.split(' ');
+            splitComment.length !== 2 && (github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Invalid comment format. Expected: "!preview <one-word-snapshot-name>"',
+            }) || core.setFailed('Invalid comment format. Expected: "!preview <one-word-snapshot-name>"'));
+            return splitComment[1].trim();
+          result-encoding: string
+
+      - name: resolve pr refs
+        id: refs
+        uses: eficode/resolve-pr-refs@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2.2.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Packages
+        run: pnpm run build
+
+      - name: Bump Package Versions
+        id: changesets
+        run: |
+          pnpm exec changeset version --snapshot ${{ steps.getSnapshotName.outputs.result }} > changesets.output.txt 2>&1
+          echo ::set-output name=result::`cat changesets.output.txt`
+        env:
+          # Needs access to run the script
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Release
+        id: publish
+        run: |
+          pnpm run release --tag next--${{ steps.getSnapshotName.outputs.result }} > publish.output.txt 2>&1
+          echo ::set-output name=result::`cat publish.output.txt`
+        env:
+          # Needs access to publish to npm
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Pull Request Notification
+        uses: actions/github-script@v6
+        env:
+          MESSAGE: ${{ steps.publish.outputs.result }}
+        with:
+          script: |
+            console.log(process.env.MESSAGE);
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '```\n' + process.env.MESSAGE + '\n```',
+            })


### PR DESCRIPTION
Hopefully this can just work out of the box! I think there might be a couple of necessary secrets to set up but otherwise we might be good :thumbsup:

## Changes

- Adds the `snapshot-release.yml` workflow, which will publish a snapshot release of a branch when `!preview snapshot-name` is posted in a PR comment. This requires that the comment was posted by an admin of the repo

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Not sure how to test except for live 🤔 

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
