### PR TITLE
Fix parse crashing when a component with a client directive was unfound

### DIFF
--- a/.changeset/slimy-fireants-kneel.md
+++ b/.changeset/slimy-fireants-kneel.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix `parse` causing a compiler panic when a component with a client directive was imported but didn't have a matching import

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -442,7 +442,7 @@ func resolveIdForMatch(match *ImportMatch, opts *TransformOptions) string {
 }
 
 func eachImportStatement(doc *astro.Node, cb func(stmt js_scanner.ImportStatement) bool) {
-	if doc.FirstChild.Type == astro.FrontmatterNode {
+	if doc.FirstChild.Type == astro.FrontmatterNode && doc.FirstChild.FirstChild != nil {
 		source := []byte(doc.FirstChild.FirstChild.Data)
 		loc, statement := js_scanner.NextImportStatement(source, 0)
 		for loc != -1 {

--- a/packages/compiler/test/parse/client-component-unfound.ts
+++ b/packages/compiler/test/parse/client-component-unfound.ts
@@ -1,0 +1,24 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { parse } from '@astrojs/compiler';
+
+const FIXTURE = `{
+	headers && (
+		<nav class="mobile-toc">
+			<TableOfContents
+				client:media="(max-width: 72em)"
+				headers={headers}
+				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
+				isMobile={true}
+			/>
+		</nav>
+	)
+}
+`;
+
+test('unfound client component', async () => {
+  const result = await parse(FIXTURE);
+  assert.ok(result.ast, 'Expected an AST to be generated');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Since 0.27.0, `parse` would crash on the following input:

```astro
{
	// For best cross-browser support of sticky or fixed elements, they must not be nested
	// inside elements that hide any overflow axis. The article content hides `overflow-x`,
	// so we must place the mobile TOC here.
	headers && (
		<nav class="mobile-toc">
			<TableOfContents
				client:media="(max-width: 72em)"
				headers={headers}
				labels={{ onThisPage: t('rightSidebar.onThisPage'), overview: t('rightSidebar.overview') }}
				isMobile={true}
			/>
		</nav>
	)
}
```

I eventually tracked this down to [this line](https://github.com/withastro/compiler/blob/38b0ea446bcbdcb1b69be5f8108136d9e23e7b49/internal/transform/transform.go#L446), `doc.FirstChild.FirstChild` was `nil`. Adding a if check fixed the issue and made tests pass. 

Not sure if there's a deeper issue or not (it seems weird that we even go in that code on this input considering the frontmatter check?), but it works


## Testing

Added a test

## Docs

N/A