### PR TITLE
Remove non-existent sourcemap source

### DIFF
--- a/.changeset/lemon-cars-brush.md
+++ b/.changeset/lemon-cars-brush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix "missing sourcemap" issue

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -358,7 +358,7 @@ func Transform() interface{} {
 									output = append(output, []byte(strings.TrimSpace(node.FirstChild.Data))...)
 								}
 								sourcemap := fmt.Sprintf(
-									`{ "version": 3, "sources": ["%s", "astro:runtime"], "sourcesContent": [%s, "Please open an issue: https://astro.build/issues"], "mappings": "%s", "names": [] }`,
+									`{ "version": 3, "sources": ["%s"], "sourcesContent": [%s], "mappings": "%s", "names": [] }`,
 									transformOptions.Filename,
 									string(sourcesContent),
 									string(builder.GenerateChunk(output).Buffer),
@@ -436,8 +436,8 @@ func createSourceMapString(source string, result printer.PrintResult, transformO
 	}
 	return fmt.Sprintf(`{
   "version": 3,
-  "sources": ["%s", "astro:runtime"],
-  "sourcesContent": [%s, "Please open an issue: https://astro.build/issues"],
+  "sources": ["%s"],
+  "sourcesContent": [%s],
   "mappings": "%s",
   "names": []
 }`, sourcemap.Sources[0], sourcemap.SourcesContent[0], sourcemap.Mappings)

--- a/internal/sourcemap/sourcemap.go
+++ b/internal/sourcemap/sourcemap.go
@@ -646,7 +646,7 @@ func (b *ChunkBuilder) AddSourceMapping(location loc.Loc, output []byte) {
 		b.appendMapping(SourceMapState{
 			GeneratedLine:   b.prevState.GeneratedLine,
 			GeneratedColumn: b.generatedColumn,
-			SourceIndex:     1,
+			SourceIndex:     0,
 			OriginalLine:    0,
 			OriginalColumn:  0,
 		})


### PR DESCRIPTION
## Changes

- `astro:runtime` was introduced in the TSX sourcemap PR, but this was causing issues at runtime since Vite would log warnings about a missing sourcefile
- This PR removes the `astro:runtime` source (which did not exist)

## Testing

Manually, fixes the warning

## Docs

N/A