### PR TITLE
Add test for text containing `<` and `>`

### DIFF
--- a/packages/compiler/test/basic/lt-gt-text.ts
+++ b/packages/compiler/test/basic/lt-gt-text.ts
@@ -1,0 +1,47 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `---
+// Component Imports
+import MainHead from '../components/MainHead.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import PortfolioPreview from '../components/PortfolioPreview.astro';
+
+// Data Fetching: List all Markdown posts in the repo.
+const projects = await Astro.glob('./project/**/*.md');
+const featuredProject = projects[0];
+
+// Full Astro Component Syntax:
+// https://docs.astro.build/core-concepts/astro-components/
+---
+
+<html lang="en">
+	<head>
+		<MainHead
+			title="Jeanine White: Personal Site"
+			description="Jeanine White: Developer, Speaker, and Writer..."
+		/>
+		
+	</head>
+	<body>
+	    <Nav />
+		<small>< header ></small>
+	    <Footer />
+	</body>
+</html>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('< and > as raw text', () => {
+  assert.ok(result.code, 'Expected to compile');
+  console.log(result.code);
+  assert.match(result.code, '< header >', 'Expected output to contain < header >');
+});
+
+test.run();

--- a/packages/compiler/test/basic/lt-gt-text.ts
+++ b/packages/compiler/test/basic/lt-gt-text.ts
@@ -40,6 +40,7 @@ test.before(async () => {
 
 test('< and > as raw text', () => {
   assert.ok(result.code, 'Expected to compile');
+  assert.ok(result.diagnostics.length, 0, 'Expected no diagnostics');
   assert.match(result.code, '< header >', 'Expected output to contain < header >');
 });
 

--- a/packages/compiler/test/basic/lt-gt-text.ts
+++ b/packages/compiler/test/basic/lt-gt-text.ts
@@ -40,7 +40,6 @@ test.before(async () => {
 
 test('< and > as raw text', () => {
   assert.ok(result.code, 'Expected to compile');
-  console.log(result.code);
   assert.match(result.code, '< header >', 'Expected output to contain < header >');
 });
 


### PR DESCRIPTION
## Changes

- Added regression test for `< header >` behavior as raw text
- Intentionally not including a changeset, this is internal only

## Testing

It's all tests!

## Docs

Bug fix only
