### PR TITLE
Handle comments with many * characters

### DIFF
--- a/.changeset/mean-houses-draw.md
+++ b/.changeset/mean-houses-draw.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with multi-line comment usage

--- a/packages/compiler/test/basic/comment.ts
+++ b/packages/compiler/test/basic/comment.ts
@@ -1,0 +1,22 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `---
+/***/
+---
+
+<div />
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('Can handle multi-* comments', () => {
+  assert.ok(result.code, 'Expected to compile');
+  assert.equal(result.diagnostics.length, 0, 'Expected no diagnostics');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Fixes #565 
- We weren't handling `/***/` comments properly because we assumed the opening `/*` and closing `*/` would be separated. This fixes that.

## Testing

Test added

## Docs

Bug fix only
