### PR TITLE
Add `resolvePath` option

### DIFF
--- a/.changeset/six-owls-drop.md
+++ b/.changeset/six-owls-drop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Add `resolvePath` option to control hydration path resolution

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -114,6 +114,8 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		staticExtraction = true
 	}
 
+	resolvePath := options.Get("resolvePath")
+
 	preprocessStyle := options.Get("preprocessStyle")
 
 	return transform.TransformOptions{
@@ -125,6 +127,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		Site:             site,
 		ProjectRoot:      projectRoot,
 		Compact:          compact,
+		ResolvePath:      resolvePath,
 		PreprocessStyle:  preprocessStyle,
 		StaticExtraction: staticExtraction,
 	}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -456,7 +456,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 						// Inject metadata attributes to `client:only` Component
 						pathAttr := astro.Attribute{
 							Key:  "client:component-path",
-							Val:  fmt.Sprintf(`$$metadata.resolvePath("%s")`, statement.Specifier),
+							Val:  fmt.Sprintf(`"%s"`, transform.ResolveIdForMatch(statement.Specifier, &opts)),
 							Type: astro.ExpressionAttribute,
 						}
 						n.Attr = append(n.Attr, pathAttr)
@@ -477,7 +477,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 					// Inject metadata attributes to `client:only` Component
 					pathAttr := astro.Attribute{
 						Key:  "client:component-path",
-						Val:  fmt.Sprintf(`$$metadata.resolvePath("%s")`, statement.Specifier),
+						Val:  fmt.Sprintf(`"%s"`, transform.ResolveIdForMatch(statement.Specifier, &opts)),
 						Type: astro.ExpressionAttribute,
 					}
 					n.Attr = append(n.Attr, pathAttr)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -453,10 +453,14 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 					if strings.HasPrefix(n.Data, prefix) {
 						exportParts := strings.Split(n.Data[len(prefix):], ".")
 						exportName := exportParts[0]
+						attrTemplate :=`"%s"`
+						if opts.ResolvePath == nil {
+							attrTemplate = `$$metadata.resolvePath("%s")`
+						}
 						// Inject metadata attributes to `client:only` Component
 						pathAttr := astro.Attribute{
 							Key:  "client:component-path",
-							Val:  fmt.Sprintf(`"%s"`, transform.ResolveIdForMatch(statement.Specifier, &opts)),
+							Val:  fmt.Sprintf(attrTemplate, transform.ResolveIdForMatch(statement.Specifier, &opts)),
 							Type: astro.ExpressionAttribute,
 						}
 						n.Attr = append(n.Attr, pathAttr)
@@ -474,10 +478,14 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 						continue component_loop
 					}
 				} else if imported.LocalName == n.Data {
+					attrTemplate :=`"%s"`
+					if opts.ResolvePath == nil {
+						attrTemplate = `$$metadata.resolvePath("%s")`
+					}
 					// Inject metadata attributes to `client:only` Component
 					pathAttr := astro.Attribute{
 						Key:  "client:component-path",
-						Val:  fmt.Sprintf(`"%s"`, transform.ResolveIdForMatch(statement.Specifier, &opts)),
+						Val:  fmt.Sprintf(attrTemplate, transform.ResolveIdForMatch(statement.Specifier, &opts)),
 						Type: astro.ExpressionAttribute,
 					}
 					n.Attr = append(n.Attr, pathAttr)

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -432,6 +432,10 @@ func ResolveIdForMatch(id string, opts *TransformOptions) string {
 		return opts.ResolvePath(id)
 	}
 	// Else use default resolvePath
+	// NOTE: We want to remove this opinionated resolve in the future and simply
+	// return the `id` as is. The consumer would need to pass `resolvePath` option
+	// to customize it. The main Astro repo would have a custom `resolvePath` option
+	// by then so this won't be breaking it.
 	if strings.HasPrefix(id, ".") && len(opts.Pathname) > 0 {
 		pathname := safeURL(opts.Pathname)
 		u, err := url.Parse(pathname)

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -55,6 +55,7 @@ export interface TransformOptions {
    */
   as?: 'document' | 'fragment';
   projectRoot?: string;
+  resolvePath?: (specifier: string) => string | Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
   experimentalStaticExtraction?: boolean;
 }

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -55,7 +55,7 @@ export interface TransformOptions {
    */
   as?: 'document' | 'fragment';
   projectRoot?: string;
-  resolvePath?: (specifier: string) => string | Promise<string>;
+  resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
   experimentalStaticExtraction?: boolean;
 }

--- a/packages/compiler/test/resolve-path/preserve.ts
+++ b/packages/compiler/test/resolve-path/preserve.ts
@@ -1,0 +1,26 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+import Foo from './Foo.jsx'
+---
+<Foo />
+<Foo client:load />
+<Foo client:only="react" />
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    resolvePath: async (s) => s,
+  });
+});
+
+test('preserve path', () => {
+  assert.match(result.code, /"client:load":true.*"client:component-path":\("\.\/Foo\.jsx"\)/);
+  assert.match(result.code, /"client:only":"react".*"client:component-path":\("\.\/Foo\.jsx"\)/);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Add `resolvePath` option so we can control how hydration paths are resolved. This removes hacks made previously to undo the compiler path changes.

The Astro repo has [a branch](https://github.com/withastro/astro/tree/resolve-path-option) I'm working on integrating this PR, which is working nicely too.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a simple test for the new option.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
It doesn't look like we have documentation for the optional options. I could send a PR to update the readme was this new option stabilizes, documenting along the other options.