### PR TITLE
Remove metadata export for `resolvePath`

### DIFF
--- a/.changeset/thin-trains-remember.md
+++ b/.changeset/thin-trains-remember.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Remove metadata export if `resolvePath` option provided

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -102,7 +102,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		p.addNilSourceMapping()
-		p.printInternalImports(p.opts.InternalURL)
+		p.printInternalImports(p.opts.InternalURL, &opts)
 		if opts.opts.StaticExtraction && n.FirstChild != nil && n.FirstChild.Type != FrontmatterNode {
 			p.printCSSImports(opts.cssLen)
 		}
@@ -132,7 +132,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				p.addNilSourceMapping()
-				p.printInternalImports(p.opts.InternalURL)
+				p.printInternalImports(p.opts.InternalURL, &opts)
 
 				if len(n.Loc) > 0 {
 					p.addSourceMapping(n.Loc[0])

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -80,7 +80,7 @@ func (p *printer) printTextWithSourcemap(text string, l loc.Loc) {
 	}
 }
 
-func (p *printer) printInternalImports(importSpecifier string) {
+func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptions) {
 	if p.hasInternalImports {
 		return
 	}
@@ -100,7 +100,10 @@ func (p *printer) printInternalImports(importSpecifier string) {
 	p.print("spreadAttributes as " + SPREAD_ATTRIBUTES + ",\n  ")
 	p.print("defineStyleVars as " + DEFINE_STYLE_VARS + ",\n  ")
 	p.print("defineScriptVars as " + DEFINE_SCRIPT_VARS + ",\n  ")
-	p.print("createMetadata as " + CREATE_METADATA)
+	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
+	if opts.opts.ResolvePath == nil {
+		p.print("createMetadata as " + CREATE_METADATA)
+	}
 	p.print("\n} from \"")
 	p.print(importSpecifier)
 	p.print("\";\n")
@@ -507,7 +510,7 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 				continue component_loop
 			}
 		}
-		if !isClientOnlyImport {
+		if !isClientOnlyImport && opts.ResolvePath == nil {
 			assertions := ""
 			if statement.Assertions != "" {
 				assertions += " assert "
@@ -541,6 +544,11 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 	// If we added imports, add a line break.
 	if modCount > 1 {
 		p.print("\n")
+	}
+
+	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
+	if opts.ResolvePath != nil {
+		return
 	}
 
 	// Call createMetadata

--- a/packages/compiler/test/resolve-path/preserve.ts
+++ b/packages/compiler/test/resolve-path/preserve.ts
@@ -5,6 +5,8 @@ import { transform } from '@astrojs/compiler';
 const FIXTURE = `
 ---
 import Foo from './Foo.jsx'
+import Bar from './Bar.jsx'
+import { name } './foo.module.css'
 ---
 <Foo />
 <Foo client:load />
@@ -21,6 +23,13 @@ test.before(async () => {
 test('preserve path', () => {
   assert.match(result.code, /"client:load":true.*"client:component-path":\("\.\/Foo\.jsx"\)/);
   assert.match(result.code, /"client:only":"react".*"client:component-path":\("\.\/Foo\.jsx"\)/);
+});
+
+test('no metadata', () => {
+  assert.not.match(result.code, /\$\$metadata/);
+  assert.not.match(result.code, /\$\$createMetadata/);
+  assert.not.match(result.code, /createMetadata as \$\$createMetadata/);
+  assert.not.match(result.code, /import \* as \$\$module\d/);
 });
 
 test.run();


### PR DESCRIPTION
## Changes

Remove unused code, e.g.

```js
import * as $$module1 from './foo/bar'
export const $$metadata = $$createMetadata(...)
```

...when `resolvePath` option is provided. Metadata isn't used for anything else other than `$$metadata.resolvePath` which is only called if no `resolvePath` is provided.

The main Astro repo also isn't using the `$$metadata` export for anything else. I've tested this on [this branch](https://github.com/withastro/astro/tree/resolve-path-option).

The removal of `import * as` helps to remove [this patch](https://github.com/withastro/astro/blob/9d195b0921b446a80e0c4c893b6cf29bef14312d/packages/astro/src/core/build/vite-plugin-css.ts#L227-L257) which fixes a bug with `.css?raw` imports. 

---

This PR sprinkles if conditions around 😬 but once `resolvePath` is solidified, we can remove the rest of unused code per [this comment](https://github.com/withastro/compiler/blob/307c83dd038e3ae5ce7adaf0818d2defb3ec76fd/internal/transform/transform.go#L435-L438).

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Updated `preserve.ts` test

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
N/A