### PR TITLE
TSX: improve self-closing tag handling

### DIFF
--- a/.changeset/loud-pigs-fold.md
+++ b/.changeset/loud-pigs-fold.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+TSX: Improve self-closing tag behavior and mappings

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -387,7 +387,6 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	for i := 0; i < len(p.sourcetext[tmpLoc:]); i++ {
 		c := p.sourcetext[endLoc : endLoc+1][0]
 		if c == '/' && p.sourcetext[endLoc+1:][0] == '>' {
-			p.addSourceMapping(loc.Loc{Start: endLoc})
 			isSelfClosing = true
 			break
 		} else if c == '>' {
@@ -403,9 +402,12 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		p.print("/>")
 		return
 	}
-	if isSelfClosing && len(n.Attr) > 0 {
+	if isSelfClosing && n.FirstChild == nil {
+		p.addSourceMapping(loc.Loc{Start: endLoc - 1})
 		p.print(" ")
 		p.addSourceMapping(loc.Loc{Start: endLoc})
+		p.print("/>")
+		return
 	}
 	p.print(">")
 

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -162,4 +162,14 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}`;
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('spread object', async () => {
+  const input = `<DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />`;
+  const output = `<Fragment>
+<DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
 test.run();

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -248,7 +248,7 @@ import SvelteOptionalProps from './SvelteOptionalProps.svelte';
 import SvelteOptionalProps from './SvelteOptionalProps.svelte';
 
 <Fragment>
-<SvelteOptionalProps></SvelteOptionalProps>
+<SvelteOptionalProps />
 
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}`;


### PR DESCRIPTION
## Changes

- Self-closing tags were mapped to an end-tag that didn't exist.
- Now self-closing tags are maintained.
- Small mapping tweaks as well

## Testing

New test added, old tests updated

## Docs

Bug fix
