### PR TITLE
TSX: Ensure spread attributes are not treated as invalid

### DIFF
--- a/.changeset/long-planes-nail.md
+++ b/.changeset/long-planes-nail.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+TSX: fix edge case with spread attribute printing

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -40,8 +40,11 @@ var ScriptMimeTypes map[string]bool = map[string]bool{
 	"application/node":       true,
 }
 
-func isInvalidTSXAttributeName(k string) bool {
-	return strings.HasPrefix(k, "@") || strings.Contains(k, ".")
+func isInvalidTSXAttribute(a Attribute) bool {
+	if a.Type == SpreadAttribute {
+		return false
+	}
+	return strings.HasPrefix(a.Key, "@") || strings.Contains(a.Key, ".")
 }
 
 type TextType uint32
@@ -235,7 +238,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	invalidTSXAttributes := make([]Attribute, 0)
 	endLoc := n.Loc[0].Start + len(n.Data)
 	for _, a := range n.Attr {
-		if isInvalidTSXAttributeName(a.Key) {
+		if isInvalidTSXAttribute(a) {
 			invalidTSXAttributes = append(invalidTSXAttributes, a)
 			continue
 		}
@@ -356,9 +359,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 			p.print(`)`)
 			endLoc = eqStart + len(a.Val) + 2
 		case astro.SpreadAttribute:
-			p.addSourceMapping(a.ValLoc)
-			p.print(fmt.Sprintf(`...%s`, a.Val))
-			endLoc = a.ValLoc.Start + len(a.Val) + 3
+			// noop
 		case astro.ShorthandAttribute:
 			withoutComments, _ := removeComments(a.Key)
 			if len(withoutComments) == 0 {

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -172,4 +172,16 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}`;
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('spread object II', async () => {
+  const input = `<MainLayout {...Astro.props}>
+</MainLayout>`;
+  const output = `<Fragment>
+<MainLayout {...Astro.props}>
+</MainLayout>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Fixes edge case related to spread attributes like `{...Astro.props}` 

## Testing

Test added

## Docs

N/a