### PR TITLE
Include end location in literal mode

### DIFF
--- a/.changeset/young-pugs-retire.md
+++ b/.changeset/young-pugs-retire.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix: include element end location in `parse` AST

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2678,6 +2678,7 @@ func inLiteralIM(p *parser) bool {
 		}
 		return true
 	case EndTagToken:
+		p.addLoc()
 		p.oe.pop()
 		return true
 	case StartExpressionToken:

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -1,0 +1,15 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { parse } from '@astrojs/compiler';
+
+test('include start and end positions', async () => {
+  const input = `---
+// Hello world!
+---
+
+<iframe>Hello</iframe><div></div>`;
+  const { ast } = await parse(input);
+  assert.ok(ast.children.slice(1)[0].position.end, `Expected serialized output to contain an end position`);
+});
+
+test.run();

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -9,7 +9,11 @@ test('include start and end positions', async () => {
 
 <iframe>Hello</iframe><div></div>`;
   const { ast } = await parse(input);
-  assert.ok(ast.children.slice(1)[0].position.end, `Expected serialized output to contain an end position`);
+
+  const iframe = ast.children[1];
+  assert.is(iframe.name, 'iframe');
+  assert.ok(iframe.position.start, `Expected serialized output to contain a start position`);
+  assert.ok(iframe.position.end, `Expected serialized output to contain an end position`);
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/575
- Includes end location when `inLiteralIM`, which happens for `parse()`

## Testing

Added a test

## Docs

Bug fix only
