### PR TITLE
Ensure text/comment nodes have end positions

### DIFF
--- a/.changeset/flat-apples-turn.md
+++ b/.changeset/flat-apples-turn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Ensure comment and text nodes have end positions when generating an AST from `parse`

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -209,6 +209,12 @@ func (p *parser) parseGenericRawTextElement() {
 func (p *parser) generateLoc() []loc.Loc {
 	locs := make([]loc.Loc, 0, 2)
 	locs = append(locs, p.tok.Loc)
+	switch p.tok.Type {
+	case TextToken:
+		locs = append(locs, loc.Loc{Start: p.tok.Loc.Start + len(p.tok.Data)})
+	case CommentToken:
+		locs = append(locs, loc.Loc{Start: p.tok.Loc.Start + len(p.tok.Data) + 3})
+	}
 	return locs
 }
 

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -16,4 +16,33 @@ test('include start and end positions', async () => {
   assert.ok(iframe.position.end, `Expected serialized output to contain an end position`);
 });
 
+test('include start and end positions for comments', async () => {
+  const input = `---
+// Hello world!
+---
+
+<!-- prettier:ignore -->
+<iframe>Hello</iframe><div></div>`;
+  const { ast } = await parse(input);
+
+  const comment = ast.children[1];
+  assert.is(comment.type, 'comment');
+  assert.ok(comment.position.start, `Expected serialized output to contain a start position`);
+  assert.ok(comment.position.end, `Expected serialized output to contain an end position`);
+});
+
+test('include start and end positions for text', async () => {
+  const input = `---
+// Hello world!
+---
+
+Hello world!`;
+  const { ast } = await parse(input);
+
+  const text = ast.children[1];
+  assert.is(text.type, 'text');
+  assert.ok(text.position.start, `Expected serialized output to contain a start position`);
+  assert.ok(text.position.end, `Expected serialized output to contain an end position`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Fixes `parse` AST to include end positions for `text` and `comment` nodes.
- Unblocks https://github.com/withastro/prettier-plugin-astro/pull/297

## Testing

Test added

## Docs

N/A, bug fix only
