### PR TITLE
Move `end` position for elements

### DIFF
--- a/.changeset/cuddly-deers-bow.md
+++ b/.changeset/cuddly-deers-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+AST: move end position of elements to the last index of their end tag

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -143,6 +143,11 @@ func positionAt(p *printer, n *Node, opts t.ParseOptions) ASTPosition {
 	if len(n.Loc) == 2 {
 		s := n.Loc[0]
 		e := n.Loc[1]
+		// `e` marks the start location of the end tag
+		if n.Type == ElementNode {
+			// this adjusts it to be the last index of the end tag
+			e.Start = e.Start + len(n.Data) + 1
+		}
 		start := locToPoint(p, s)
 		end := locToPoint(p, e)
 


### PR DESCRIPTION
## Changes

- Internally, the end position of elements is the beginning of the end tag.
- For our public AST, it should be the final index of the end tag.
- This updates our AST to use the final index of the end tag for element nodes.

## Testing

Tested manually

## Docs

Bug fix only
