### PR TITLE
Move `start` position for elements

### DIFF
--- a/.changeset/ninety-cherries-guess.md
+++ b/.changeset/ninety-cherries-guess.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+AST: move `start` position of elements to the first index of their opening tag

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -145,8 +145,10 @@ func positionAt(p *printer, n *Node, opts t.ParseOptions) ASTPosition {
 		e := n.Loc[1]
 		// `s` and `e` mark the start location of the tag name
 		if n.Type == ElementNode {
-			// this adjusts `s` to be the first index of the element tag
-			s.Start = s.Start - 1
+			if (s.Start != 0) {
+				// this adjusts `s` to be the first index of the element tag
+				s.Start = s.Start - 1
+			}
 			// this adjusts `e` to be the last index of the end tag
 			e.Start = e.Start + len(n.Data) + 1
 		}

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -143,9 +143,11 @@ func positionAt(p *printer, n *Node, opts t.ParseOptions) ASTPosition {
 	if len(n.Loc) == 2 {
 		s := n.Loc[0]
 		e := n.Loc[1]
-		// `e` marks the start location of the end tag
+		// `s` and `e` mark the start location of the tag name
 		if n.Type == ElementNode {
-			// this adjusts it to be the last index of the end tag
+			// this adjusts `s` to be the first index of the element tag
+			s.Start = s.Start - 1
+			// this adjusts `e` to be the last index of the end tag
 			e.Start = e.Start + len(n.Data) + 1
 		}
 		start := locToPoint(p, s)


### PR DESCRIPTION
## Changes

- Follow-up to #591
- Internally, the `start` position of elements is the beginning of the tag name.
- For our public AST, it should be the first index of the start tag.
- This updates our AST to use the first index of the start tag for element nodes.

## Testing

Tested manually

## Docs

Bug fix only
