### PR TITLE
fix(diagnostics): return proper diagnostic level

### DIFF
--- a/.changeset/tall-peas-sort.md
+++ b/.changeset/tall-peas-sort.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Return proper diagnostic code for warnings

--- a/internal/loc/loc.go
+++ b/internal/loc/loc.go
@@ -24,10 +24,10 @@ type Span struct {
 type DiagnosticSeverity int
 
 const (
-	ErrorType DiagnosticSeverity = 1
-	WarningType
-	InformationType
-	HintType
+	ErrorType       DiagnosticSeverity = 1
+	WarningType     DiagnosticSeverity = 2
+	InformationType DiagnosticSeverity = 3
+	HintType        DiagnosticSeverity = 4
 )
 
 type DiagnosticMessage struct {

--- a/packages/compiler/test/client-directive/warn.ts
+++ b/packages/compiler/test/client-directive/warn.ts
@@ -14,6 +14,7 @@ test.before(async () => {
 test('logs a warning for using a client directive', () => {
   assert.ok(Array.isArray(result.diagnostics));
   assert.is(result.diagnostics.length, 1);
+  assert.equal(result.diagnostics[0].severity, 2);
   assert.match(result.diagnostics[0].text, 'does not need the client:load directive');
 });
 


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/595
- Fix issue with diagnostic severity levels, would always return as errors (`1`)

## Testing

Test updated

## Docs

Bug fix only
