### PR TITLE
Use an IIFE to scope define:vars scripts

### DIFF
--- a/.changeset/seven-nails-compete.md
+++ b/.changeset/seven-nails-compete.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Use an IIFE for define:vars scripts

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -174,7 +174,7 @@ func (p *printer) printDefineVarsOpen(n *astro.Node) {
 	}
 	if n.DataAtom == atom.Script {
 		if !isTypeModuleScript(n) {
-			p.print("{")
+			p.print("(function(){")
 		}
 	}
 	for _, attr := range n.Attr {
@@ -211,7 +211,7 @@ func (p *printer) printDefineVarsClose(n *astro.Node) {
 		return
 	}
 	if !isTypeModuleScript(n) {
-		p.print("}")
+		p.print("})();")
 	}
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1148,7 +1148,7 @@ import Widget2 from '../components/Widget2.astro';`},
 			staticExtraction: true,
 			source:           `<script define:vars={{ value: 0 }}>console.log(value);</script>`,
 			want: want{
-				code: `<script>{${$$defineScriptVars({ value: 0 })}console.log(value);}</script>`,
+				code: `<script>(function(){${$$defineScriptVars({ value: 0 })}console.log(value);})();</script>`,
 			},
 		},
 		{
@@ -1156,7 +1156,7 @@ import Widget2 from '../components/Widget2.astro';`},
 			staticExtraction: true,
 			source:           `<script define:vars={{ "dash-case": true }}>console.log(dashCase);</script>`,
 			want: want{
-				code: `<script>{${$$defineScriptVars({ "dash-case": true })}console.log(dashCase);}</script>`,
+				code: `<script>(function(){${$$defineScriptVars({ "dash-case": true })}console.log(dashCase);})();</script>`,
 			},
 		},
 		{
@@ -2257,7 +2257,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline define:vars={{foo:'bar'}}>var four = foo;</script>`,
 			staticExtraction: true,
 			want: want{
-				code: `<script>var one = 'one';</script>${$$maybeRenderHead($$result)}<script>{${$$defineScriptVars({foo:'bar'})}var three = foo;}</script><script>{${$$defineScriptVars({foo:'bar'})}var four = foo;}</script>`,
+				code: `<script>var one = 'one';</script>${$$maybeRenderHead($$result)}<script>(function(){${$$defineScriptVars({foo:'bar'})}var three = foo;})();</script><script>(function(){${$$defineScriptVars({foo:'bar'})}var four = foo;})();</script>`,
 				metadata: metadata{
 					hoisted: []string{"{ type: 'inline', value: `var two = 'two';` }"},
 				},


### PR DESCRIPTION
## Changes

- Safari hoists function declarations out of a block scope, https://bugs.webkit.org/show_bug.cgi?id=179698
- This means that our use of block scope breaks any define:vars script (in Safari) that uses a function declaration.
- Part of https://github.com/withastro/astro/issues/5064
- Fix is to use an IIFE instead.

## Testing

Tests updated.

## Docs

N/A