### PR TITLE
Add warning when unable to inject `define:vars`

### DIFF
--- a/.changeset/sour-toys-join.md
+++ b/.changeset/sour-toys-join.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add warning when `define:vars` won't work because of compilation limitations

--- a/internal/loc/diagnostics.go
+++ b/internal/loc/diagnostics.go
@@ -15,6 +15,7 @@ const (
 	WARNING_IGNORED_DIRECTIVE         DiagnosticCode = 2004
 	WARNING_UNSUPPORTED_EXPRESSION    DiagnosticCode = 2005
 	WARNING_SET_WITH_CHILDREN         DiagnosticCode = 2006
+	WARNING_CANNOT_DEFINE_VARS        DiagnosticCode = 2007
 	INFO                              DiagnosticCode = 3000
 	HINT                              DiagnosticCode = 4000
 )

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2224,7 +2224,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:             "define:vars on style with StaticExpression turned on",
+			name:             "define:vars on style with StaticExtraction turned on",
 			source:           "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			staticExtraction: true,
 			want: want{

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -14,14 +14,16 @@ func ScopeElement(n *astro.Node, opts TransformOptions) {
 	}
 }
 
-func AddDefineVars(n *astro.Node, values []string) {
+func AddDefineVars(n *astro.Node, values []string) bool {
 	if n.Type == astro.ElementNode && !n.Component {
 		if _, noScope := NeverScopedElements[n.Data]; !noScope {
 			if IsTopLevel(n) {
 				injectDefineVars(n, values)
+				return true
 			}
 		}
 	}
+	return false
 }
 
 var NeverScopedElements map[string]bool = map[string]bool{
@@ -37,6 +39,7 @@ var NeverScopedElements map[string]bool = map[string]bool{
 	"noscript": true,
 	"script":   true,
 	"style":    true,
+	"slot":     true,
 	"title":    true,
 }
 

--- a/internal/transform/utils.go
+++ b/internal/transform/utils.go
@@ -59,6 +59,9 @@ func IsImplictNodeMarker(attr astro.Attribute) bool {
 }
 
 func IsTopLevel(n *astro.Node) bool {
+	if IsImplictNode(n) || n.Data == "" {
+		return false
+	}
 	p := n.Parent
 	if p == nil {
 		return true

--- a/packages/compiler/test/errors/define-vars.ts
+++ b/packages/compiler/test/errors/define-vars.ts
@@ -1,0 +1,26 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+test('define:vars warning', async () => {
+  const result = await transform(
+    `<Fragment><slot /></Fragment>
+<style define:vars={{ color: 'red' }}></style>`,
+    { pathname: '/src/components/Foo.astro' }
+  );
+  assert.ok(Array.isArray(result.diagnostics));
+  assert.is(result.diagnostics.length, 1);
+  assert.is(result.diagnostics[0].code, 2007);
+});
+
+test('define:vars no warning', async () => {
+  const result = await transform(
+    `<div><slot /></div>
+<style define:vars={{ color: 'red' }}></style>`,
+    { pathname: '/src/components/Foo.astro' }
+  );
+  assert.ok(Array.isArray(result.diagnostics));
+  assert.is(result.diagnostics.length, 0);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/4400
- Adds a warning when `<style define:vars>` doesn't work because of limitations of static analysis.

## Testing

Test added

## Docs

Bug fix only
