### PR TITLE
fix(#5308): duplicate style bug with define:vars

### DIFF
--- a/.changeset/tender-kids-film.md
+++ b/.changeset/tender-kids-film.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix #5308, duplicate style bug when using `define:vars`

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -293,16 +293,7 @@ func (p *printer) printStyleOrScript(opts RenderOptions, n *astro.Node) {
 	// styles should be included in the STYLES array
 	transformOpts := opts.opts
 	if transformOpts.StaticExtraction {
-		hasDefineVars := false
-		for _, attr := range n.Attr {
-			if attr.Key == "define:vars" {
-				hasDefineVars = true
-			}
-		}
-
-		if !hasDefineVars {
-			return
-		}
+		return
 	}
 
 	p.addNilSourceMapping()

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -40,7 +40,6 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		}
 		if len(definedVars) > 0 {
 			didAdd := AddDefineVars(n, definedVars)
-			fmt.Println(didAdd, n.Data)
 			if !didAddDefinedVars {
 				didAddDefinedVars = didAdd
 			}

--- a/packages/compiler/test/styles/define-vars.ts
+++ b/packages/compiler/test/styles/define-vars.ts
@@ -1,0 +1,36 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+import { preprocessStyle } from '../utils';
+
+const FIXTURE = `
+---
+let color = 'red';
+---
+
+<style lang="scss" define:vars={{ color }}>
+  div {
+    color: var(--color);
+  }
+</style>
+
+<div>Hello world!</div>
+
+<div>Ahhh</div>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    sourcemap: true,
+    preprocessStyle,
+    experimentalStaticExtraction: true,
+  });
+});
+
+test('does not include define:vars in generated markup', () => {
+  assert.ok(result.code.includes('STYLES = [\n];'));
+  assert.equal(result.css.length, 1);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/5308
- Ignores `define:vars` styles when `experimentalStaticExtraction` is true.

## Testing

WASM test added

## Docs

Bug fix only