### PR TITLE
fix(#598, #466): fix ternary expression edge cases

### DIFF
--- a/.changeset/three-ligers-clap.md
+++ b/.changeset/three-ligers-clap.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix expression edge cases, improve literal parsing

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -139,6 +139,20 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "ternary component",
+			source: `{special ? <ChildDiv><p>Special</p></ChildDiv> : <p>Not special</p>}`,
+			want: want{
+				code: `${special ? $$render` + BACKTICK + `${$$renderComponent($$result,'ChildDiv',ChildDiv,{},{"default": () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<p>Special</p>` + BACKTICK + `,})}` + BACKTICK + ` : $$render` + BACKTICK + `<p>Not special</p>` + BACKTICK + `}`,
+			},
+		},
+		{
+			name:   "ternary layout",
+			source: `{toggleError ? <BaseLayout><h1>SITE: {Astro.site}</h1></BaseLayout> : <><h1>SITE: {Astro.site}</h1></>}`,
+			want: want{
+				code: `${toggleError ? $$render` + BACKTICK + `${$$renderComponent($$result,'BaseLayout',BaseLayout,{},{"default": () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<h1>SITE: ${Astro.site}</h1>` + BACKTICK + `,})}` + BACKTICK + ` : $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `<h1>SITE: ${Astro.site}</h1>` + BACKTICK + `,})}` + BACKTICK + `}`,
+			},
+		},
+		{
 			name:   "orphan slot",
 			source: `<slot />`,
 			want: want{


### PR DESCRIPTION
## Changes

- Fixes #598, fixes #466
- Introduces some better `inLiteralIM` handling, where we can pass a custom function for exiting `inLiteralIM`. In this case, we exit `inLiteralIM` when the stack of open elements returns to the state it was in when we entered.

## Testing

Both issues added as test cases

## Docs

N/A, bug fix