### PR TITLE
Add a basic fuzzer - FuzzScopedHTML

### DIFF
--- a/.changeset/nine-ladybugs-exist.md
+++ b/.changeset/nine-ladybugs-exist.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/compiler': patch
+---
+
+Replace `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`.
+
+We now check whether an error handler is passed when calling `astro.ParseFragmentWithOptions`

--- a/.changeset/nine-ladybugs-exist.md
+++ b/.changeset/nine-ladybugs-exist.md
@@ -1,7 +1,0 @@
----
-'@astrojs/compiler': patch
----
-
-Replace `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`.
-
-We now check whether an error handler is passed when calling `astro.ParseFragmentWithOptions`

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -116,7 +116,6 @@ func TestScopeHTML(t *testing.T) {
 				t.Errorf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got)
 			}
 			// check whether another pass doesn't error
-
 			nodes, err = astro.ParseFragmentWithOptions(strings.NewReader(tt.source), &astro.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()}, astro.ParseOptionWithHandler(h))
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION
## Changes

Small bugfixes that will be eventually moved to other PRs

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
This PR is tracking the addition of a simple go based fuzzer to test the html parser / scoped styles generator.

I'll add fixes to bugs I discover as I go along, and then eventually I'll break out the bugs and this fuzzer into individually mergable PRs

This can be run via `go test ./internal/transform -fuzz=FuzzScopeHTML` from the root directory to run an ongoing fuzz test of the html scoping.

Uses https://tip.golang.org/doc/tutorial/fuzz

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
There should be contributor docs for how the fuzzer works, how to run it && how to update fuzz tests