### PR TITLE
fix: infinite loop regression in literal (parse/ast) mode

### DIFF
--- a/.changeset/thick-wombats-dance.md
+++ b/.changeset/thick-wombats-dance.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix regression introduced to `parse` handling in the last patch

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2672,16 +2672,22 @@ func frontmatterIM(p *parser) bool {
 func inLiteralIM(p *parser) bool {
 	shouldExit := p.exitLiteralIM()
 	switch p.tok.Type {
-	case ErrorToken:
-		// Stop parsing.
-	case TextToken:
-		p.addText(p.tok.Data)
 	case StartTagToken:
 		p.addElement()
 		if p.hasSelfClosingToken {
 			p.oe.pop()
 			p.acknowledgeSelfClosingTag()
 		}
+		// always continue `inLiteralIM`
+		return true
+	case StartExpressionToken:
+		p.addExpression()
+		// always continue `inLiteralIM`
+		return true
+	case ErrorToken:
+		// Stop parsing.
+	case TextToken:
+		p.addText(p.tok.Data)
 	case CommentToken:
 		p.addChild(&Node{
 			Type: CommentNode,
@@ -2691,8 +2697,6 @@ func inLiteralIM(p *parser) bool {
 	case EndTagToken:
 		p.addLoc()
 		p.oe.pop()
-	case StartExpressionToken:
-		p.addExpression()
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2670,36 +2670,38 @@ func frontmatterIM(p *parser) bool {
 
 // Handle content very literally
 func inLiteralIM(p *parser) bool {
-	if !p.exitLiteralIM() {
-		switch p.tok.Type {
-		case ErrorToken:
+	shouldExit := p.exitLiteralIM()
+	switch p.tok.Type {
+	case ErrorToken:
+		// Stop parsing.
+	case TextToken:
+		p.addText(p.tok.Data)
+	case StartTagToken:
+		p.addElement()
+		if p.hasSelfClosingToken {
 			p.oe.pop()
-		case TextToken:
-			p.addText(p.tok.Data)
-			return true
-		case StartTagToken:
-			p.addElement()
-			if p.hasSelfClosingToken {
-				p.oe.pop()
-				p.acknowledgeSelfClosingTag()
-			}
-			return true
-		case EndTagToken:
-			p.addLoc()
-			p.oe.pop()
-			return true
-		case StartExpressionToken:
-			p.addExpression()
-			return true
-		case EndExpressionToken:
-			p.addLoc()
-			p.oe.pop()
-			return true
+			p.acknowledgeSelfClosingTag()
 		}
+	case CommentToken:
+		p.addChild(&Node{
+			Type: CommentNode,
+			Data: p.tok.Data,
+			Loc:  p.generateLoc(),
+		})
+	case EndTagToken:
+		p.addLoc()
+		p.oe.pop()
+	case StartExpressionToken:
+		p.addExpression()
+	case EndExpressionToken:
+		p.addLoc()
+		p.oe.pop()
 	}
-	p.im = p.originalIM
-	p.originalIM = nil
-	return p.tok.Type == EndTagToken
+	if shouldExit {
+		p.im = p.originalIM
+		p.originalIM = nil
+	}
+	return true
 }
 
 func inExpressionIM(p *parser) bool {


### PR DESCRIPTION
## Changes

- [Literal Insertion Mode handling](https://github.com/withastro/compiler/pull/617) introduced a regression for consumers using `parse`. Only caught this when `format` on Astro's main repo was hanging.
- This refactors `inLiteralIM` to ensure that the mode is exited properly when tokens are unhandled.
- Blocks https://github.com/withastro/prettier-plugin-astro/pull/305, https://github.com/withastro/astro/pull/5369

## Testing

Tested locally in the `prettier-plugin-astro` repo, no more hanging

## Docs

Bug fix only