### PR TITLE
Self-closing tags now generate end position

### DIFF
--- a/.changeset/heavy-mice-begin.md
+++ b/.changeset/heavy-mice-begin.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Self-closing tags will now retreive "end" positional data

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2675,6 +2675,7 @@ func inLiteralIM(p *parser) bool {
 	case StartTagToken:
 		p.addElement()
 		if p.hasSelfClosingToken {
+			p.addLoc()
 			p.oe.pop()
 			p.acknowledgeSelfClosingTag()
 		}

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -45,7 +45,6 @@ Hello world!`;
   assert.ok(text.position.end, `Expected serialized output to contain an end position`);
 });
 
-
 test('include start and end positions for self-closing tags', async () => {
   const input = `<input/>`;
   const { ast } = await parse(input);

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -45,4 +45,16 @@ Hello world!`;
   assert.ok(text.position.end, `Expected serialized output to contain an end position`);
 });
 
+
+test('include start and end positions for self-closing tags', async () => {
+  const input = `<input/>`;
+  const { ast } = await parse(input);
+
+  const element = ast.children[0];
+  assert.is(element.type, 'element');
+  assert.is(element.name, 'input');
+  assert.ok(element.position.start, `Expected serialized output to contain a start position`);
+  assert.ok(element.position.end, `Expected serialized output to contain an end position`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

While attempting to use `prettier-plugin-astro` and self-closing HTML tags, I ran into this issue:

https://github.com/withastro/prettier-plugin-astro/issues/306

Here, we can see that our self-closing tag is not receiving an `end` positional data, unlike other tags.

To do this, we simply had to `push` a `loc` data into the `SelfClosingTag` token.

We can see a similar issue that occurred in:

https://github.com/withastro/compiler/pull/588

Which was fixed in a similar manner.


## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

There are tests added in `position.ts` and I've verified this behavior in a manual Go debugger instance.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

No docs are need, this was only a bug fix.