### PR TITLE
fix regression for inLiteralIM handling

### DIFF
--- a/.changeset/cold-mice-stare.md
+++ b/.changeset/cold-mice-stare.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix regression introduced by https://github.com/withastro/compiler/pull/617

--- a/packages/compiler/test/basic/body-after-head-component.ts
+++ b/packages/compiler/test/basic/body-after-head-component.ts
@@ -23,7 +23,6 @@ test.before(async () => {
 });
 
 test('has body in output', () => {
-  console.log(result.code);
   assert.match(result.code, '<body>', 'Expected output to contain body element!');
 });
 

--- a/packages/compiler/test/basic/body-after-head-component.ts
+++ b/packages/compiler/test/basic/body-after-head-component.ts
@@ -1,0 +1,30 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <TestHead />
+    <title>document</title>
+  </head>
+  <body>
+    <main>
+       <h1>Welcome to <span class="text-gradient">Astro</span></h1>
+    </main>
+  </body>
+</html>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('has body in output', () => {
+  console.log(result.code);
+  assert.match(result.code, '<body>', 'Expected output to contain body element!');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Will address https://github.com/withastro/astro/issues/5379
- `inLiteralIM` was being handled properly, but we forgot to set `p.originalIM` to `inHeadIM`, which was causing `body` tags to be disregarded

## Testing

Test added

## Docs

Bug fix only
