### PR TITLE
Handle unterminated template literal attributes

### DIFF
--- a/.changeset/honest-lemons-pump.md
+++ b/.changeset/honest-lemons-pump.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix handling of unterminated template literal attributes

--- a/internal/loc/diagnostics.go
+++ b/internal/loc/diagnostics.go
@@ -8,6 +8,7 @@ const (
 	ERROR_FRAGMENT_SHORTHAND_ATTRS    DiagnosticCode = 1002
 	ERROR_UNMATCHED_IMPORT            DiagnosticCode = 1003
 	ERROR_UNSUPPORTED_SLOT_ATTRIBUTE  DiagnosticCode = 1004
+	ERROR_UNTERMINATED_STRING         DiagnosticCode = 1005
 	WARNING                           DiagnosticCode = 2000
 	WARNING_UNTERMINATED_HTML_COMMENT DiagnosticCode = 2001
 	WARNING_UNCLOSED_HTML_TAG         DiagnosticCode = 2002

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -393,18 +393,22 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	}
 	isSelfClosing := false
 	tmpLoc := endLoc
-	for i := 0; i < len(p.sourcetext[tmpLoc:]); i++ {
-		c := p.sourcetext[endLoc : endLoc+1][0]
-		if c == '/' && p.sourcetext[endLoc+1:][0] == '>' {
-			isSelfClosing = true
-			break
-		} else if c == '>' {
-			p.addSourceMapping(loc.Loc{Start: endLoc})
-			endLoc++
-			break
-		} else {
-			endLoc++
+	if len(p.sourcetext) > tmpLoc {
+		for i := 0; i < len(p.sourcetext[tmpLoc:]); i++ {
+			c := p.sourcetext[endLoc : endLoc+1][0]
+			if c == '/' && p.sourcetext[endLoc+1:][0] == '>' {
+				isSelfClosing = true
+				break
+			} else if c == '>' {
+				p.addSourceMapping(loc.Loc{Start: endLoc})
+				endLoc++
+				break
+			} else {
+				endLoc++
+			}
 		}
+	} else {
+		endLoc++
 	}
 
 	if voidElements[n.Data] && n.FirstChild == nil {

--- a/internal/token.go
+++ b/internal/token.go
@@ -1258,6 +1258,18 @@ func (z *Tokenizer) readTagAttrVal() {
 		for {
 			c := z.readByte()
 			if z.err != nil {
+				if z.err == io.EOF {
+					z.pendingAttr[1].End = z.pendingAttr[1].Start
+					z.handler.AppendError(&loc.ErrorWithRange{
+						Code: loc.ERROR_UNTERMINATED_STRING,
+						Text: `Unterminated template literal attribute`,
+						Range: loc.Range{
+							Loc: loc.Loc{Start: z.data.Start},
+							Len: z.raw.End,
+						},
+					})
+					return
+				}
 				z.pendingAttr[1].End = z.raw.End
 				return
 			}

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -1,0 +1,18 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { convertToTSX } from '@astrojs/compiler';
+
+const input = `<div class=\`></div>
+`;
+
+test('does not panic on unfinished template literal attribute', async () => {
+  let error = 0;
+  try {
+    const output = await convertToTSX(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    assert.match(output.code, `class={\`\`}`);
+  } catch (e) {
+    error = 1;
+  }
+
+  assert.equal(error, 0, `compiler should not have paniced`);
+});


### PR DESCRIPTION
## Changes

- Previously "<div foo=`></div>" would cause a panic
- Now this is properly handled and surfaces error
- In the TSX output, this is treated as `<div foo={``}></div>`

## Testing

Test added

## Docs

Bug fix only
