### PR TITLE
Warn on invalid spread attributes

### DIFF
--- a/.changeset/healthy-actors-occur.md
+++ b/.changeset/healthy-actors-occur.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add warning for invalid spread attributes

--- a/internal/loc/diagnostics.go
+++ b/internal/loc/diagnostics.go
@@ -16,6 +16,7 @@ const (
 	WARNING_UNSUPPORTED_EXPRESSION    DiagnosticCode = 2005
 	WARNING_SET_WITH_CHILDREN         DiagnosticCode = 2006
 	WARNING_CANNOT_DEFINE_VARS        DiagnosticCode = 2007
+	WARNING_INVALID_SPREAD            DiagnosticCode = 2008
 	INFO                              DiagnosticCode = 3000
 	HINT                              DiagnosticCode = 4000
 )

--- a/packages/compiler/test/errors/invalid-spread.ts
+++ b/packages/compiler/test/errors/invalid-spread.ts
@@ -1,0 +1,18 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+test('...spread has warning', async () => {
+  const result = await transform(`<Head ...seo />`, { pathname: '/src/components/Foo.astro' });
+  assert.ok(Array.isArray(result.diagnostics));
+  assert.is(result.diagnostics.length, 1);
+  assert.is(result.diagnostics[0].code, 2008);
+});
+
+test('{...spread} does not have warning', async () => {
+  const result = await transform(`<Head {...seo} />`, { pathname: '/src/components/Foo.astro' });
+  assert.ok(Array.isArray(result.diagnostics));
+  assert.is(result.diagnostics.length, 0);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Closes #334
- Although attributes like `<Head ...seo />` are supported, they are most likely a mistake
- This PR adds a new warning for this, with a suggested fix (wrap the attribute in a `{}` expression).

## Testing

Test added

## Docs

N/A, QoL Improvement
