### PR TITLE
Remove `astro.ParseFragment` / Require an error handler for `astro.ParseFragmentWithOptions`

### DIFF
--- a/.changeset/nine-ladybugs-exist.md
+++ b/.changeset/nine-ladybugs-exist.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/compiler': patch
+---
+
+Replace `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`.
+
+We now check whether an error handler is passed when calling `astro.ParseFragmentWithOptions`

--- a/.changeset/nine-ladybugs-exist.md
+++ b/.changeset/nine-ladybugs-exist.md
@@ -2,6 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Replace `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`.
-
-We now check whether an error handler is passed when calling `astro.ParseFragmentWithOptions`
+Internally, replace `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`. We now check whether an error handler is passed when calling `astro.ParseFragmentWithOptions`

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2979,15 +2979,6 @@ func Parse(r io.Reader) (*Node, error) {
 	return ParseWithOptions(r)
 }
 
-// ParseFragment parses a fragment of HTML and returns the nodes that were
-// found. If the fragment is the InnerHTML for an existing element, pass that
-// element in context.
-//
-// It has the same intricacies as Parse.
-func ParseFragment(r io.Reader, context *Node) ([]*Node, error) {
-	return ParseFragmentWithOptions(r, context)
-}
-
 // ParseOption configures a parser.
 type ParseOption func(p *parser)
 
@@ -3038,7 +3029,9 @@ func ParseWithOptions(r io.Reader, opts ...ParseOption) (*Node, error) {
 	return p.doc, nil
 }
 
-// ParseFragmentWithOptions is like ParseFragment, with options.
+// ParseFragmentWithOptions parses a fragment of HTML and returns the nodes that were
+// found. If the fragment is the InnerHTML for an existing element, pass that
+// element in context.
 func ParseFragmentWithOptions(r io.Reader, context *Node, opts ...ParseOption) ([]*Node, error) {
 	contextTag := ""
 	if context != nil {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -3073,6 +3073,10 @@ func ParseFragmentWithOptions(r io.Reader, context *Node, opts ...ParseOption) (
 		f(p)
 	}
 
+	if p.handler == nil {
+		return nil, errors.New("html: handler must be passed to ParseFragmentWithOptions")
+	}
+
 	root := &Node{
 		Type:     ElementNode,
 		DataAtom: a.Html,

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	astro "github.com/withastro/compiler/internal"
+	"github.com/withastro/compiler/internal/handler"
 	"golang.org/x/net/html/atom"
 )
 
@@ -92,7 +93,8 @@ func TestScopeHTML(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			nodes, err := astro.ParseFragment(strings.NewReader(tt.source), &astro.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()})
+			h := handler.NewHandler(tt.source, "FuzzScopeHTML.astro")
+			nodes, err := astro.ParseFragmentWithOptions(strings.NewReader(tt.source), &astro.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()}, astro.ParseOptionWithHandler(h))
 			if err != nil {
 				t.Error(err)
 			}
@@ -104,7 +106,8 @@ func TestScopeHTML(t *testing.T) {
 				t.Errorf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got)
 			}
 			// check whether another pass doesn't error
-			nodes, err = astro.ParseFragment(strings.NewReader(got), &astro.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()})
+
+			nodes, err = astro.ParseFragmentWithOptions(strings.NewReader(tt.source), &astro.Node{Type: astro.ElementNode, DataAtom: atom.Body, Data: atom.Body.String()}, astro.ParseOptionWithHandler(h))
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
## Changes

- Removes `astro.ParseFragment` in favor of `astro.ParseFragmentWithOptions`
- Updates `astro.ParseFragmentWithOptions` to return an error when called w/o an error handler. Should it panic instead?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Might be worth adding a "expect error" test for `astro.ParseFragmentWithOptions` though idk where this function is tested, other than transitively via `scope_html_test.go`

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
