### PR TITLE
Include the id in createComponent

### DIFF
--- a/.changeset/sharp-tools-knock.md
+++ b/.changeset/sharp-tools-knock.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Provide the moduleId of the astro component

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -227,7 +227,7 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
 func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
 	componentName := getComponentName(opts.Pathname)
 	p.addNilSourceMapping()
-	p.println(fmt.Sprintf("}, %s);", opts.ModuleId))
+	p.println(fmt.Sprintf("}, '%s');", opts.ModuleId))
 	p.println(fmt.Sprintf("export default %s;", componentName))
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -227,7 +227,7 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
 func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
 	componentName := getComponentName(opts.Pathname)
 	p.addNilSourceMapping()
-	p.println("});")
+	p.println(fmt.Sprintf("}, %s);", opts.ModuleId))
 	p.println(fmt.Sprintf("export default %s;", componentName))
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -227,7 +227,11 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
 func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
 	componentName := getComponentName(opts.Pathname)
 	p.addNilSourceMapping()
-	p.println(fmt.Sprintf("}, '%s');", opts.ModuleId))
+	if len(opts.ModuleId) > 0 {
+		p.println(fmt.Sprintf("}, '%s');", opts.ModuleId))
+	} else {
+		p.println("});")
+	}
 	p.println(fmt.Sprintf("export default %s;", componentName))
 }
 


### PR DESCRIPTION
## Changes

- Passes the module's `moduleId` as the second argument to createComponent.
- This is used to enable head propagation. The Astro runtime creates a dependency map so that it can trace modules with head propagation to what pages they belong to, so that we wait for those components to run before sending out the head.
- This is an optional argument and is backwards compatible.

## Testing

- Test added to confirm that the passed in moduleId is include as the second argument.
- Head propagation tests are in core.

## Docs

N/A