### PR TITLE
fix: avoid nil pointer dereference in table parsing

### DIFF
--- a/.changeset/giant-chairs-rest.md
+++ b/.changeset/giant-chairs-rest.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+fix: avoid nil pointer dereference in table parsing

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1751,11 +1751,14 @@ func inTableIM(p *parser) bool {
 	switch p.tok.Type {
 	case TextToken:
 		p.tok.Data = strings.Replace(p.tok.Data, "\x00", "", -1)
-		switch p.oe.top().DataAtom {
-		case a.Table, a.Tbody, a.Tfoot, a.Thead, a.Tr:
-			if strings.Trim(p.tok.Data, whitespace) == "" {
-				p.addText(p.tok.Data)
-				return true
+		top := p.oe.top()
+		if top != nil {
+			switch top.DataAtom {
+			case a.Table, a.Tbody, a.Tfoot, a.Thead, a.Tr:
+				if strings.Trim(p.tok.Data, whitespace) == "" {
+					p.addText(p.tok.Data)
+					return true
+				}
 			}
 		}
 	case StartExpressionToken:


### PR DESCRIPTION
## Changes

- What does this change? 
Avoid nil pointer dereference in `inTableIM`, fixes https://github.com/withastro/astro/issues/5488.

## Testing

I couldn't create a failing test, the bug only happens when the table is inside a slot so I tested it manually.

## Docs

Bug fix.