### PR TITLE
Fix `<` edge case in expressions

### DIFF
--- a/.changeset/red-rules-smash.md
+++ b/.changeset/red-rules-smash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case where `<` was not handled properly inside of expressions

--- a/internal/token.go
+++ b/internal/token.go
@@ -1977,7 +1977,18 @@ expression_loop:
 		}
 
 		if c == '<' {
-			z.raw.End--
+			// Check next byte to see if this is an element or a JS expression.
+			// Note: this is not a perfect check, just good enough for most cases!
+			c1 := z.readByte()
+			if z.err != nil {
+				break expression_loop
+			}
+			if unicode.IsSpace(rune(c1)) || unicode.IsNumber(rune(c1)) {
+				continue
+			}
+
+			// Otherwise, we have an element. Reset pointer and try again.
+			z.raw.End -= 2
 			z.data.End = z.raw.End
 			if z.rawTag != "" {
 				goto raw_with_expression_loop

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -217,6 +217,21 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"expression with < operators",
+			`<div>{() => {
+				if (value < 0.25) {
+					return <span>Default</span>
+				} else if (value <0.5) {
+					return <span>Another</span>
+				} else if (value < 0.75) {
+					return <span>Other</span>
+				}
+				return <span>Yet Other</span>
+			}}</div>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
+		},
+
+		{
 			"attribute expression with quoted braces",
 			`<div value={"{"} />`,
 			[]TokenType{SelfClosingTagToken},

--- a/packages/compiler/test/basic/expressions.ts
+++ b/packages/compiler/test/basic/expressions.ts
@@ -1,0 +1,40 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+test('Can handle < inside JSX expression', async () => {
+  const input = `<Layout>
+   {
+      new Array(totalPages).fill(0).map((_, index) => {
+        const active = currentPage === index;
+        if (
+          totalPages > 25 &&
+          ( index < currentPage - offset ||
+            index > currentPage + offset)
+        ) {
+          return 'HAAAA';
+        }
+      })
+    }
+</Layout>
+`;
+  const output = await transform(input);
+  assert.ok(output.code, 'Expected to compile');
+  assert.match(
+    output.code,
+    `new Array(totalPages).fill(0).map((_, index) => {
+        const active = currentPage === index;
+        if (
+          totalPages > 25 &&
+          ( index < currentPage - offset ||
+            index > currentPage + offset)
+        ) {
+          return 'HAAAA';
+        }
+      })`,
+    'Expected expression to be compiled properly'
+  );
+  assert.equal(output.diagnostics.length, 0, 'Expected no diagnostics');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Closes #624
- Fixes `<` handling in expressions by peeking the next character to check for spaces and numbers. It's not a perfect check but it should work for 90% of cases.

## Testing

Added tokenizer test to verify correct tokenization
Added WASM test to verify correct output


## Docs

Bug fix only