### PR TITLE
Add join-base directive

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2332,6 +2332,13 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<div>test</div>`,
 			},
 		},
+		{
+			name:   "join-base: directive transforms to Astro.joinBase call",
+			source: `<img join-base:src="/images/penguin.png" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<img${$$addAttribute(Astro.joinBase('/images/penguin.png'), "src")}>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -35,6 +35,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 	walk(doc, func(n *astro.Node) {
 		ExtractScript(doc, n, &opts, h)
 		AddComponentProps(doc, n, &opts)
+		TransformJoinBase(n)
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
@@ -391,6 +392,21 @@ func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 
 				break
 			}
+		}
+	}
+}
+
+func TransformJoinBase(n *astro.Node) {
+	key := "join-base:"
+	for i, attr := range n.Attr {
+		if strings.HasPrefix(attr.Key, key) {
+			attrName := attr.Key[len(key):]
+			newAttr := astro.Attribute{
+				Key:  attrName,
+				Val:  fmt.Sprintf("Astro.joinBase('%s')", attr.Val),
+				Type: astro.ExpressionAttribute,
+			}
+			n.Attr[i] = newAttr
 		}
 	}
 }


### PR DESCRIPTION
Note that this is **just an experiment** and is not ready to be merged. If successful it will turn into an RFC.

## Changes

- Adds a new directive `join-base` that can be used on any element to join a path to your base configuration. For example:

```astro
<img join-base:src="/images/penguin.png" />
```

Will get transformed to this HTML assuming your `base` config is `"/docs/"`:

```html
<img src="/docs/images/penguin.png" />
```

## Testing

- Test case added

## Docs

