### PR TITLE
Allow script/style before html

### DIFF
--- a/.changeset/orange-bottles-bow.md
+++ b/.changeset/orange-bottles-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Allow `script` and `style` before HTML

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -675,7 +675,7 @@ func beforeHTMLIM(p *parser) bool {
 			p.addElement()
 			p.im = beforeHeadIM
 			return true
-		case a.Script, a.Style:
+		case a.Script:
 			p.addElement()
 			if p.originalIM == nil {
 				p.setOriginalIM()
@@ -704,7 +704,7 @@ func beforeHTMLIM(p *parser) bool {
 		}
 	case EndTagToken:
 		switch p.tok.DataAtom {
-		case a.Script, a.Style:
+		case a.Script:
 			p.oe.pop()
 			return true
 		case a.Head, a.Body, a.Html, a.Br:

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -670,9 +670,22 @@ func beforeHTMLIM(p *parser) bool {
 			return true
 		}
 	case StartTagToken:
-		if p.tok.DataAtom == a.Html {
+		switch p.tok.DataAtom {
+		case a.Html:
 			p.addElement()
 			p.im = beforeHeadIM
+			return true
+		case a.Script, a.Style:
+			p.addElement()
+			if p.originalIM == nil {
+				p.setOriginalIM()
+			}
+			p.im = textIM
+			if p.hasSelfClosingToken {
+				p.addLoc()
+				p.oe.pop()
+				p.acknowledgeSelfClosingTag()
+			}
 			return true
 		}
 		if isComponent(p.tok.Data) {
@@ -691,6 +704,9 @@ func beforeHTMLIM(p *parser) bool {
 		}
 	case EndTagToken:
 		switch p.tok.DataAtom {
+		case a.Script, a.Style:
+			p.oe.pop()
+			return true
 		case a.Head, a.Body, a.Html, a.Br:
 			p.parseImpliedToken(StartTagToken, a.Html, a.Html.String())
 			return false

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -682,7 +682,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 // Section 12.1.2, "Elements", gives this list of void elements. Void elements
 // are those that can't have any contents.
-//nolint
+// nolint
 var voidElements = map[string]bool{
 	"area":   true,
 	"base":   true,

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -68,8 +68,10 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 			renderHeadNode := &astro.Node{
 				Type: astro.RenderHeadNode,
 			}
-			script.Parent.InsertBefore(renderHeadNode, script)
-			addedHeadRenderingInsertion = true
+			if script.Parent.Type != astro.DocumentNode {
+				script.Parent.InsertBefore(renderHeadNode, script)
+				addedHeadRenderingInsertion = true
+			}
 		}
 
 		script.Parent.RemoveChild(script)

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -68,10 +68,8 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 			renderHeadNode := &astro.Node{
 				Type: astro.RenderHeadNode,
 			}
-			if script.Parent.Type != astro.DocumentNode {
-				script.Parent.InsertBefore(renderHeadNode, script)
-				addedHeadRenderingInsertion = true
-			}
+			script.Parent.InsertBefore(renderHeadNode, script)
+			addedHeadRenderingInsertion = true
 		}
 
 		script.Parent.RemoveChild(script)

--- a/packages/compiler/test/basic/script-before-html.ts
+++ b/packages/compiler/test/basic/script-before-html.ts
@@ -1,0 +1,41 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<script>
+  // anything ...
+</script>
+
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Astro strips html lang tag</title>
+  </head>
+  <body>
+    <main>
+      <slot />
+    </main>
+  </body>
+</html>
+
+<style lang="scss" is:global>
+html {
+  scroll-behavior: smooth;
+}
+</style>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('includes html element', () => {
+  assert.ok(result.code.includes('<html lang="de">'), 'Expected compile result to include html element!');
+});
+
+test.run();

--- a/packages/compiler/test/basic/script-before-html.ts
+++ b/packages/compiler/test/basic/script-before-html.ts
@@ -7,6 +7,7 @@ const FIXTURE = `
   // anything ...
 </script>
 
+<!DOCTYPE html>
 <html lang="de">
   <head>
     <meta charset="UTF-8" />


### PR DESCRIPTION
## Changes

- Allows `script` nodes before the `html` node.
- Closes https://github.com/withastro/compiler/issues/660
- This was an edge case in our parser that was causing the actual `html` node to be ignored

## Testing

Wasm test added

## Docs

Bug fix only
