### PR TITLE
fix: corner case with slot expression in head will cause body tag missing

### DIFF
--- a/.changeset/quick-radios-cheer.md
+++ b/.changeset/quick-radios-cheer.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+fix: corner case with slot expression in head will cause body tag missing

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2740,7 +2740,7 @@ func inExpressionIM(p *parser) bool {
 	case StartTagToken:
 		if p.isInsideHead() {
 			switch p.tok.DataAtom {
-			case a.Noframes, a.Style, a.Script, a.Title, a.Noscript, a.Base, a.Basefont, a.Bgsound, a.Link, a.Meta:
+			case a.Noframes, a.Style, a.Script, a.Title, a.Noscript, a.Base, a.Basefont, a.Bgsound, a.Link, a.Meta, a.Slot:
 				origIm := p.originalIM
 				p.originalIM = nil
 				ret := inHeadIM(p)

--- a/packages/compiler/test/basic/body-after-head-component.ts
+++ b/packages/compiler/test/basic/body-after-head-component.ts
@@ -2,14 +2,17 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { transform } from '@astrojs/compiler';
 
-const FIXTURE = `
+const FIXTURE = `---
+const isProd = true;
+---
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <TestHead />
     <title>document</title>
+    {isProd && <slot />}
   </head>
-  <body>
+  <body style="color: red;">
     <main>
        <h1>Welcome to <span class="text-gradient">Astro</span></h1>
     </main>
@@ -23,7 +26,7 @@ test.before(async () => {
 });
 
 test('has body in output', () => {
-  assert.match(result.code, '<body>', 'Expected output to contain body element!');
+  assert.match(result.code, '<body style="color: red;">', 'Expected output to contain body element!');
 });
 
 test.run();


### PR DESCRIPTION

## Changes

- Solve issue https://github.com/withastro/astro/issues/5557
- `Slot` in `head` tag will cause a situation that paser cannot exit from `inExpressionIM`

For file:
```js
---
const isProd = true;
---
<!DOCTYPE html>
<html lang="en">
  <head>
    <TestHead />
    <title>document</title>
    {isProd && <slot />}
  </head>
  <body style="color: red;">
    <main>
       <h1>Welcome to <span class="text-gradient">Astro</span></h1>
    </main>
  </body>
</html>
```

Before, compiler has the below output, it omits the `body` tag.
```js
const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
const Astro = $$result.createAstro($$Astro, $$props, $$slots);
Astro.self = $$stdin;
const isProd = true;
return $$render`<html lang="en">
  <head>
    ${$$renderComponent($$result,'TestHead',TestHead,{})}
    <title>document</title>
    ${isProd && $$render`${$$renderSlot($$result,$$slots["default"])}`}
  ${$$renderHead($$result)}</head>
  
    <main>
       <h1>Welcome to <span class="text-gradient">Astro</span></h1>
    </main>
  

</html>`;
}, '<stdin>');
```

After this pr, it will like this:
```js
const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
const Astro = $$result.createAstro($$Astro, $$props, $$slots);
Astro.self = $$stdin;
const isProd = true;
return $$render`<html lang="en">
  <head>
    ${$$renderComponent($$result,'TestHead',TestHead,{})}
    <title>document</title>
    ${isProd && $$render`${$$renderSlot($$result,$$slots["default"])}`}
  ${$$renderHead($$result)}</head>
  <body style="color: red;">
    <main>
       <h1>Welcome to <span class="text-gradient">Astro</span></h1>
    </main>
  </body></html>`;
}, '<stdin>');
```

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Adding test

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only.