### PR TITLE
fix: corner case that component in head expression will case `body` tag missing

### DIFF
--- a/.changeset/ninety-emus-swim.md
+++ b/.changeset/ninety-emus-swim.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+fix: corner case that component in head expression will case body tag missing

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2739,6 +2739,15 @@ func inExpressionIM(p *parser) bool {
 		return textIM(p)
 	case StartTagToken:
 		if p.isInsideHead() {
+			// Allow components in Head Expression
+			if isComponent(p.tok.Data) || isFragment(p.tok.Data) {
+				origIm := p.originalIM
+				p.originalIM = nil
+				ret := inLiteralIM(p)
+				p.im = inExpressionIM
+				p.originalIM = origIm
+				return ret
+			}
 			switch p.tok.DataAtom {
 			case a.Noframes, a.Style, a.Script, a.Title, a.Noscript, a.Base, a.Basefont, a.Bgsound, a.Link, a.Meta, a.Slot:
 				origIm := p.originalIM

--- a/packages/compiler/test/basic/body-after-head-component.ts
+++ b/packages/compiler/test/basic/body-after-head-component.ts
@@ -8,7 +8,7 @@ const isProd = true;
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <TestHead />
+    {isProd && <TestHead />}
     <title>document</title>
     {isProd && <slot />}
   </head>


### PR DESCRIPTION
## Changes

- The previous pr https://github.com/withastro/compiler/pull/671 has fixed the problem that `Slot` in `head` expression will cause `body` tag missing
- And I found that `Component` in `head` expression will cause the same problem. 
- Original Issue: https://github.com/withastro/astro/issues/5557 Minimal Reproducible Example: https://stackblitz.com/edit/github-uwb7te-xzq2mg?file=src%2Fcomponents%2FDocument.astro
- So, I think we should add `Component` Support in `inExpressionIM` function when it's in `head` tag.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added
## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
bug fix only