### PR TITLE
chore: set github action timeout to 3min / job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   test:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +27,7 @@ jobs:
         run: go test -v ./internal/...
 
   test-wasm:
+    timeout-minutes: 3
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]
@@ -62,6 +64,7 @@ jobs:
         run: pnpm test:ci
 
   lint:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -71,6 +74,7 @@ jobs:
           version: latest
 
   lint-js:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           go-version: 1.19
 
       - name: Test
-        run: go test -v ./internal/...
+        run: go test -v -timeout 30s ./internal/...
 
   test-wasm:
     timeout-minutes: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: go test -v -timeout 30s ./internal/...
 
   test-wasm:
-    timeout-minutes: 3
+    timeout-minutes: 10
     strategy:
       matrix:
         OS: [ubuntu-latest, windows-latest]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   release:
+    timeout-minutes: 3
     name: Changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -10,6 +10,7 @@ defaults:
 
 jobs:
   snapshot-release:
+    timeout-minutes: 3
     name: Create a snapshot release of a pull request
     if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && startsWith(github.event.comment.body, '!preview') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION


## Changes

- All jobs consistently complete in under 3min - this should bring the generous default down to something that we can detect. CI sorta PR!

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
