### PR TITLE
fix: handle module IDs containing quotes

### DIFF
--- a/.changeset/sixty-dragons-perform.md
+++ b/.changeset/sixty-dragons-perform.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Handle module IDs containing quotes

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.go]
+indent_style = tab
+indent_size = 2
+trim_trailing_whitespace = true

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -228,7 +228,8 @@ func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
 	componentName := getComponentName(opts.Pathname)
 	p.addNilSourceMapping()
 	if len(opts.ModuleId) > 0 {
-		p.println(fmt.Sprintf("}, '%s');", opts.ModuleId))
+		escapedModuleId := strings.ReplaceAll(opts.ModuleId, "'", "\\'")
+		p.println(fmt.Sprintf("}, '%s');", escapedModuleId))
 	} else {
 		p.println("});")
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1095,7 +1095,7 @@ const someProps = {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-  
+
   ` + RENDER_HEAD_RESULT + `</head>
   <body class="astro-HMNNHVCQ">
     <main class="astro-HMNNHVCQ">
@@ -2332,6 +2332,14 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<div>test</div>`,
 			},
 		},
+		{
+			name:     "passes escaped moduleId into createComponent if it contains single quotes",
+			source:   `<div>test</div>`,
+			moduleId: "/projects/app/src/pages/page-with-'-quotes.astro",
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div>test</div>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2483,7 +2491,8 @@ const items = ["Dog", "Cat", "Platipus"];
 			}
 
 			if len(tt.moduleId) > 0 {
-				toMatch += suffixWithModuleId(tt.moduleId)
+				escapedModuleId := strings.ReplaceAll(tt.moduleId, "'", "\\'")
+				toMatch += suffixWithModuleId(escapedModuleId)
 			} else {
 				toMatch += SUFFIX
 			}


### PR DESCRIPTION
## Changes

* Escape single quotes in module identifiers

## Testing

* Added a test to the printer's tests

## Docs

* no docs updated

---

its possible you can have a file named `foo'bar.astro` which currently will trip up the compiler, since it'd produce something along the lines of `createComponent(..., 'foo'bar')` (ofc syntactically incorrect).

let me know if this is the wrong way to fix it and i'll update

i also added an `editorconfig`, let me know if its wrong. it'd be useful to have one in this repo so contributors automatically use the right indentation etc