### PR TITLE
Fix OSS-Fuzz #54632 (failed to scope input)

### DIFF
--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -95,6 +95,11 @@ func tests() []struct {
 			source: `<A { 0>`,
 			want:   `<A  0>={0>} class="astro-XXXXXX"></A>`,
 		},
+		{
+			name:   "incomplete props spread",
+			source: "<a {...>",
+			want:   "<a {...}></a>",
+		},
 	}
 
 }
@@ -150,11 +155,11 @@ func FuzzScopeHTML(f *testing.F) {
 		var b strings.Builder
 		astro.PrintToSource(&b, nodes[0])
 		got := b.String()
-		if !strings.Contains(got, "astro-XXXXXX") {
-			t.Errorf("HTML scoping failed to include the astro scope\n source: %q\n got: %q\n `nodes[0].Data: %q", source, got, nodes[0].Data)
-		}
 		if utf8.ValidString(source) && !utf8.ValidString(got) {
 			t.Errorf("HTML scoping produced invalid html string: %q", got)
+		}
+		if !strings.Contains(got, "astro-XXXXXX") {
+			t.Errorf("HTML scoping failed to include the astro scope\n source: %q\n got: %q\n `nodes[0].Data: %q", source, got, nodes[0].Data)
 		}
 	})
 }

--- a/internal/transform/scope-html_test.go
+++ b/internal/transform/scope-html_test.go
@@ -159,7 +159,7 @@ func FuzzScopeHTML(f *testing.F) {
 			t.Errorf("HTML scoping produced invalid html string: %q", got)
 		}
 		if !strings.Contains(got, "astro-XXXXXX") {
-			t.Errorf("HTML scoping failed to include the astro scope\n source: %q\n got: %q\n `nodes[0].Data: %q", source, got, nodes[0].Data)
+			t.Errorf("HTML scoping failed to include the astro scope\n source: %q\n got: %q\n `nodes[0]: %+v", source, got, nodes[0])
 		}
 	})
 }


### PR DESCRIPTION
## Changes

Currently trying to sort out how to fix this. I assume that it should throw an error w/ this input?

The real weirdness is that `astro.ParseFragmentWithOptions` parsed it fine?

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Adds failing input to `TestScopeHTML` from https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54636&q=label:Proj-astro-compiler

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
