### PR TITLE
Baseline `experimentalStaticExtraction` flag

### DIFF
--- a/.changeset/healthy-parents-smile.md
+++ b/.changeset/healthy-parents-smile.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Remove `experimentalStaticExtraction` option. It is now the default.

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -102,7 +102,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		p.printInternalImports(p.opts.InternalURL, &opts)
-		if opts.opts.StaticExtraction && n.FirstChild != nil && n.FirstChild.Type != FrontmatterNode {
+		if n.FirstChild != nil && n.FirstChild.Type != FrontmatterNode {
 			p.printCSSImports(opts.cssLen)
 		}
 
@@ -147,10 +147,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 				}
 
-				if opts.opts.StaticExtraction {
-					p.addNilSourceMapping()
-					p.printCSSImports(opts.cssLen)
-				}
+				p.addNilSourceMapping()
+				p.printCSSImports(opts.cssLen)
 
 				// 1. Component imports, if any exist.
 				p.addNilSourceMapping()
@@ -222,25 +220,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					if len(definedVars) > 0 {
 						p.printf("const $$definedVars = %s([%s]);\n", DEFINE_STYLE_VARS, strings.Join(definedVars, ","))
 					}
-					if !opts.opts.StaticExtraction {
-						p.println("const STYLES = [")
-						for _, style := range n.Parent.Styles {
-							p.printStyleOrScript(opts, style)
-						}
-						p.println("];")
-						p.addNilSourceMapping()
-						p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE);", RESULT))
-					}
-				}
-
-				if !opts.opts.StaticExtraction && len(n.Parent.Scripts) > 0 {
-					p.println("const SCRIPTS = [")
-					for _, script := range n.Parent.Scripts {
-						p.printStyleOrScript(opts, script)
-					}
-					p.println("];")
-					p.addNilSourceMapping()
-					p.println(fmt.Sprintf("for (const SCRIPT of SCRIPTS) %s.scripts.add(SCRIPT);", RESULT))
 				}
 
 				p.printReturnOpen()
@@ -274,24 +253,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			if len(definedVars) > 0 {
 				p.printf("const $$definedVars = %s([%s]);\n", DEFINE_STYLE_VARS, strings.Join(definedVars, ","))
 			}
-			if !opts.opts.StaticExtraction {
-				p.println("const STYLES = [")
-				for _, style := range n.Parent.Styles {
-					p.printStyleOrScript(opts, style)
-				}
-				p.println("];")
-				p.addNilSourceMapping()
-				p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE);", RESULT))
-			}
-		}
-		if !opts.opts.StaticExtraction && len(n.Parent.Scripts) > 0 {
-			p.println("const SCRIPTS = [")
-			for _, script := range n.Parent.Scripts {
-				p.printStyleOrScript(opts, script)
-			}
-			p.println("];")
-			p.addNilSourceMapping()
-			p.println(fmt.Sprintf("for (const SCRIPT of SCRIPTS) %s.scripts.add(SCRIPT);", RESULT))
 		}
 
 		p.printReturnOpen()

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -313,29 +313,6 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 	p.print("}")
 }
 
-func (p *printer) printStyleOrScript(opts RenderOptions, n *astro.Node) {
-	// If this is using the StaticExtraction option, only define:vars
-	// styles should be included in the STYLES array
-	transformOpts := opts.opts
-	if transformOpts.StaticExtraction {
-		return
-	}
-
-	p.addNilSourceMapping()
-	p.print("{props:")
-	p.printAttributesToObject(n)
-
-	if n.FirstChild != nil && strings.TrimSpace(n.FirstChild.Data) != "" {
-		p.print(",children:`")
-		p.addSourceMapping(n.Loc[0])
-		p.print(escapeText(strings.TrimSpace(n.FirstChild.Data)))
-		p.addNilSourceMapping()
-		p.print("`")
-	}
-
-	p.print("},\n")
-}
-
 func (p *printer) printAttribute(attr astro.Attribute, n *astro.Node) {
 	if attr.Key == "define:vars" || attr.Key == "set:text" || attr.Key == "set:html" || attr.Key == "is:raw" {
 		return

--- a/internal/printer/printer_css_test.go
+++ b/internal/printer/printer_css_test.go
@@ -10,8 +10,14 @@ import (
 	"github.com/withastro/compiler/internal/transform"
 )
 
+type testcase_css struct {
+	name   string
+	source string
+	want   string
+}
+
 func TestPrinterCSS(t *testing.T) {
-	tests := []testcase{
+	tests := []testcase_css{
 		{
 			name: "styles (no frontmatter)",
 			source: `<style>
@@ -27,18 +33,8 @@ func TestPrinterCSS(t *testing.T) {
 
 		<h1 class="title">Page Title</h1>
 		<p class="body">I’m a page</p>`,
-			want: want{
-				styles: []string{".title:where(.astro-DPOHFLYM){font-family:fantasy;font-size:28px}.body:where(.astro-DPOHFLYM){font-size:1em}"},
-			},
+			want: ".title:where(.astro-DPOHFLYM){font-family:fantasy;font-size:28px}.body:where(.astro-DPOHFLYM){font-size:1em}",
 		},
-	}
-
-	for _, tt := range tests {
-		if tt.only {
-			tests = make([]testcase, 0)
-			tests = append(tests, tt)
-			break
-		}
 	}
 
 	for _, tt := range tests {
@@ -66,12 +62,7 @@ func TestPrinterCSS(t *testing.T) {
 				output += string(bytes)
 			}
 
-			toMatch := ""
-			if len(tt.want.styles) > 0 {
-				for _, style := range tt.want.styles {
-					toMatch += style + ""
-				}
-			}
+			toMatch := tt.want
 
 			// compare to expected string, show diff if mismatch
 			if diff := test_utils.ANSIDiff(test_utils.Dedent(toMatch), test_utils.Dedent(output)); diff != "" {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -75,12 +75,11 @@ type metadata struct {
 }
 
 type testcase struct {
-	name             string
-	source           string
-	only             bool
-	staticExtraction bool
-	moduleId         string
-	want             want
+	name     string
+	source   string
+	only     bool
+	moduleId string
+	want     want
 }
 
 type jsonTestcase struct {
@@ -1178,17 +1177,15 @@ import Widget2 from '../components/Widget2.astro';`},
 			},
 		},
 		{
-			name:             "script define:vars I",
-			staticExtraction: true,
-			source:           `<script define:vars={{ value: 0 }}>console.log(value);</script>`,
+			name:   "script define:vars I",
+			source: `<script define:vars={{ value: 0 }}>console.log(value);</script>`,
 			want: want{
 				code: `<script>(function(){${$$defineScriptVars({ value: 0 })}console.log(value);})();</script>`,
 			},
 		},
 		{
-			name:             "script define:vars II",
-			staticExtraction: true,
-			source:           `<script define:vars={{ "dash-case": true }}>console.log(dashCase);</script>`,
+			name:   "script define:vars II",
+			source: `<script define:vars={{ "dash-case": true }}>console.log(dashCase);</script>`,
 			want: want{
 				code: `<script>(function(){${$$defineScriptVars({ "dash-case": true })}console.log(dashCase);})();</script>`,
 			},
@@ -2258,18 +2255,16 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:             "define:vars on style with StaticExtraction turned on",
-			source:           "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
-			staticExtraction: true,
+			name:   "define:vars on style",
+			source: "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			want: want{
 				code:        `${$$maybeRenderHead($$result)}<h1 class="astro-VFS5OEMV"${$$addAttribute($$definedVars, "style")}>testing</h1>`,
 				definedVars: []string{"{color:'green'}"},
 			},
 		},
 		{
-			name:             "multiple define:vars on style",
-			source:           "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><style define:vars={{color:'red'}}>h2{color:var(--color)}</style><h1>foo</h1><h2>bar</h2>",
-			staticExtraction: true,
+			name:   "multiple define:vars on style",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><style define:vars={{color:'red'}}>h2{color:var(--color)}</style><h1>foo</h1><h2>bar</h2>",
 			want: want{
 				code:        `${$$maybeRenderHead($$result)}<h1 class="astro-6OXBQCST"${$$addAttribute($$definedVars, "style")}>foo</h1><h2 class="astro-6OXBQCST"${$$addAttribute($$definedVars, "style")}>bar</h2>`,
 				definedVars: []string{"{color:'red'}", "{color:'green'}"},
@@ -2281,8 +2276,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			// 2. A hoisted script - wrong, shown up in scripts.add
 			// 3. A define:vars hoisted script
 			// 4. A define:vars inline script
-			source:           `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline define:vars={{foo:'bar'}}>var four = foo;</script>`,
-			staticExtraction: true,
+			source: `<script is:inline>var one = 'one';</script><script>var two = 'two';</script><script define:vars={{foo:'bar'}}>var three = foo;</script><script is:inline define:vars={{foo:'bar'}}>var four = foo;</script>`,
 			want: want{
 				code: `<script>var one = 'one';</script>${$$maybeRenderHead($$result)}<script>(function(){${$$defineScriptVars({foo:'bar'})}var three = foo;})();</script><script>(function(){${$$defineScriptVars({foo:'bar'})}var four = foo;})();</script>`,
 				metadata: metadata{
@@ -2293,8 +2287,7 @@ const items = ["Dog", "Cat", "Platipus"];
 		{
 			name: "define:vars on a module script with imports",
 			// Should not wrap with { } scope.
-			source:           `<script type="module" define:vars={{foo:'bar'}}>import 'foo';\nvar three = foo;</script>`,
-			staticExtraction: true,
+			source: `<script type="module" define:vars={{foo:'bar'}}>import 'foo';\nvar three = foo;</script>`,
 			want: want{
 				code: `<script type="module">${$$defineScriptVars({foo:'bar'})}import 'foo';\\nvar three = foo;</script>`,
 			},
@@ -2378,12 +2371,11 @@ const items = ["Dog", "Cat", "Platipus"];
 			transform.ExtractStyles(doc)
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
-				Scope:            "XXXX",
-				Site:             "https://astro.build",
-				InternalURL:      "http://localhost:3000/",
-				ModuleId:         tt.moduleId,
-				ProjectRoot:      ".",
-				StaticExtraction: tt.staticExtraction,
+				Scope:       "XXXX",
+				Site:        "https://astro.build",
+				InternalURL: "http://localhost:3000/",
+				ModuleId:    tt.moduleId,
+				ProjectRoot: ".",
 			}, h)
 			output := string(result.Output)
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -39,10 +39,6 @@ var RETURN = fmt.Sprintf("return %s%s", TEMPLATE_TAG, BACKTICK)
 var SUFFIX = fmt.Sprintf("%s;", BACKTICK) + `
 });
 export default $$Component;`
-var STYLE_PRELUDE = "const STYLES = [\n"
-var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE);\n"
-var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
-var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT);\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
 var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
 
@@ -59,8 +55,6 @@ export default $$Component;`, moduleId)
 type want struct {
 	frontmatter    []string
 	definedVars    []string
-	styles         []string
-	scripts        []string
 	getStaticPaths string
 	code           string
 	metadata
@@ -441,7 +435,6 @@ import type data from "test"
 				frontmatter: []string{
 					`import './styles.css';`,
 				},
-				styles: []string{},
 			},
 		},
 		{
@@ -508,7 +501,6 @@ import * as ns from '../components';
 </html>`,
 			want: want{
 				frontmatter: []string{`import * as ns from '../components';`},
-				styles:      []string{},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: '../components', assert: {} }`}},
 				code: `<html>
   <head>
@@ -781,7 +773,6 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 </div>`,
 			want: want{
 				frontmatter: []string{"", "const groups = [[0, 1, 2], [3, 4, 5]];"},
-				styles:      []string{},
 				code: fmt.Sprintf(`${$$maybeRenderHead($$result)}<div>
 	${groups.map(items => {
 		return %s<ul>${
@@ -971,7 +962,6 @@ const name = "world";
 		<h1 class="title">Page Title</h1>
 		<p class="body">I’m a page</p>`,
 			want: want{
-				styles: []string{"{props:{\"data-astro-id\":\"DPOHFLYM\"},children:`.title:where(.astro-DPOHFLYM){font-family:fantasy;font-size:28px}.body:where(.astro-DPOHFLYM){font-size:1em}`}"},
 				code: "\n\n\t\t" + `${$$maybeRenderHead($$result)}<h1 class="title astro-DPOHFLYM">Page Title</h1>
 		<p class="body astro-DPOHFLYM">I’m a page</p>`,
 			},
@@ -1095,7 +1085,6 @@ const someProps = {
 
 // Full Astro Component Syntax:
 // https://docs.astro.build/core-concepts/astro-components/`},
-				styles: []string{fmt.Sprintf(`{props:{"data-astro-id":"HMNNHVCQ"},children:%s:root{font-family:system-ui;padding:2em 0}.counter{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));place-items:center;font-size:2em;margin-top:2em}.children{display:grid;place-items:center;margin-bottom:2em}%s}`, BACKTICK, BACKTICK)},
 				metadata: metadata{
 					modules:             []string{`{ module: $$module1, specifier: '../components/Counter.jsx', assert: {} }`},
 					hydratedComponents:  []string{`Counter`},
@@ -1129,7 +1118,6 @@ import Widget2 from '../components/Widget2.astro';
 			want: want{
 				frontmatter: []string{`import Widget from '../components/Widget.astro';
 import Widget2 from '../components/Widget2.astro';`},
-				styles: []string{},
 				metadata: metadata{
 					modules: []string{
 						`{ module: $$module1, specifier: '../components/Widget.astro', assert: {} }`,
@@ -1148,8 +1136,6 @@ import Widget2 from '../components/Widget2.astro';`},
 <script type="module" hoist>console.log("Hello");</script>`,
 			want: want{
 				frontmatter: []string{""},
-				styles:      []string{},
-				scripts:     []string{fmt.Sprintf(`{props:{"type":"module","hoist":true},children:%sconsole.log("Hello");%s}`, BACKTICK, BACKTICK)},
 				metadata:    metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
 				code:        `${$$maybeRenderHead($$result)}`,
 			},
@@ -1161,8 +1147,6 @@ import Widget2 from '../components/Widget2.astro';`},
 								<script type="module" hoist>console.log("Hello");</script>
 							`,
 			want: want{
-				styles:   []string{},
-				scripts:  []string{"{props:{\"type\":\"module\",\"hoist\":true},children:`console.log(\"Hello\");`}"},
 				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sconsole.log("Hello");%s }`, BACKTICK, BACKTICK)}},
 				code: "${$$maybeRenderHead($$result)}<main>\n" +
 					"								${$$maybeRenderHead($$result)}\n" +
@@ -1194,7 +1178,6 @@ import Widget2 from '../components/Widget2.astro';`},
 			name:   "script before elements",
 			source: `<script>Here</script><div></div>`,
 			want: want{
-				scripts:  []string{"{props:{},children:`Here`}"},
 				metadata: metadata{hoisted: []string{fmt.Sprintf(`{ type: 'inline', value: %sHere%s }`, BACKTICK, BACKTICK)}},
 				code:     `${$$maybeRenderHead($$result)}<div></div>`,
 			},
@@ -1224,7 +1207,6 @@ const name = 'named';
 		</Component>`,
 			want: want{
 				frontmatter: []string{`import Component from 'test';`, `const name = 'named';`},
-				styles:      []string{},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
 				code:        `${$$renderComponent($$result,'Component',Component,{},{[name]: () => $$render` + "`" + `${$$maybeRenderHead($$result)}<div>Named</div>` + "`" + `,})}`,
 			},
@@ -1251,7 +1233,6 @@ import 'test';
 <my-element></my-element>`,
 			want: want{
 				frontmatter: []string{`import 'test';`},
-				styles:      []string{},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'test', assert: {} }`}},
 				code:        `${$$renderComponent($$result,'my-element','my-element',{})}`,
 			},
@@ -1361,8 +1342,7 @@ const canonicalURL = new URL('http://example.com');
 			want: want{
 				frontmatter: []string{"", `const image = './penguin.png';
 const canonicalURL = new URL('http://example.com');`},
-				styles: []string{},
-				code:   "${image && ($$render`<meta property=\"og:image\"${$$addAttribute(new URL(image, canonicalURL), \"content\")}>`)}",
+				code: "${image && ($$render`<meta property=\"og:image\"${$$addAttribute(new URL(image, canonicalURL), \"content\")}>`)}",
 			},
 		},
 		{
@@ -1383,8 +1363,7 @@ let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');
 	author: string;
 }
 let allPosts = Astro.fetchContent<MarkdownFrontmatter>('./post/*.md');`},
-				styles: []string{},
-				code:   "${$$maybeRenderHead($$result)}<div>testing</div>",
+				code: "${$$maybeRenderHead($$result)}<div>testing</div>",
 			},
 		},
 		{
@@ -1397,8 +1376,7 @@ const article2 = await import('../markdown/article2.md')
 `, want: want{
 				frontmatter: []string{"", `const markdownDocs = await Astro.glob('../markdown/*.md')
 const article2 = await import('../markdown/article2.md')`},
-				styles: []string{},
-				code:   "${$$maybeRenderHead($$result)}<div></div>",
+				code: "${$$maybeRenderHead($$result)}<div></div>",
 			},
 		},
 		{
@@ -1475,8 +1453,7 @@ const title = 'icon';
 			name:   "Empty script",
 			source: `<script hoist></script>`,
 			want: want{
-				scripts: []string{`{props:{"hoist":true}}`},
-				code:    `${$$maybeRenderHead($$result)}`,
+				code: `${$$maybeRenderHead($$result)}`,
 			},
 		},
 		{
@@ -1484,7 +1461,6 @@ const title = 'icon';
 			source: `<style define:vars={{ color: "Gainsboro" }}></style>`,
 			want: want{
 				definedVars: []string{`{ color: "Gainsboro" }`},
-				styles:      []string{`{props:{"define:vars":({ color: "Gainsboro" }),"data-astro-id":"7HAAVZPE"}}`},
 				code:        ``,
 			},
 		},
@@ -1603,11 +1579,6 @@ import { Container, Col, Row } from 'react-bootstrap';
 </head>
 <div />`,
 			want: want{
-				styles: []string{
-					"{props:{\"data-astro-id\":\"LASNTLJA\"},children:`div:where(.astro-LASNTLJA){color:blue}`}",
-					"{props:{\"is:scoped\":true,\"data-astro-id\":\"LASNTLJA\"},children:`div:where(.astro-LASNTLJA){color:green}`}",
-					"{props:{\"is:global\":true},children:`div { color: red }`}",
-				},
 				code: "<head>\n\n\n\n\n\n\n" + RENDER_HEAD_RESULT + "</head>\n<div class=\"astro-LASNTLJA\"></div>",
 			},
 		},
@@ -1636,9 +1607,6 @@ import { Container, Col, Row } from 'react-bootstrap';
 			name:   "spread with style but no explicit class",
 			source: `<style>div { color: red; }</style><div {...Astro.props} />`,
 			want: want{
-				styles: []string{
-					"{props:{\"data-astro-id\":\"TN53UTDL\"},children:`div:where(.astro-TN53UTDL){color:red}`}",
-				},
 				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,"Astro.props",{"class":"astro-XXXX"})}></div>`,
 			},
 		},
@@ -2027,8 +1995,7 @@ const items = ["Dog", "Cat", "Platipus"];
 </style><div class="container">My Text</div>`,
 
 			want: want{
-				styles: []string{fmt.Sprintf(`{props:{"data-astro-id":"SJ3WYE6H"},children:%s.container:where(.astro-SJ3WYE6H){padding:2rem}%s}`, BACKTICK, BACKTICK)},
-				code:   `${$$maybeRenderHead($$result)}<div class="container astro-SJ3WYE6H">My Text</div>`,
+				code: `${$$maybeRenderHead($$result)}<div class="container astro-SJ3WYE6H">My Text</div>`,
 			},
 		},
 		{
@@ -2326,7 +2293,6 @@ const items = ["Dog", "Cat", "Platipus"];
 			want: want{
 				code:     `${$$maybeRenderHead($$result)}`,
 				metadata: metadata{hoisted: []string{"{ type: 'inline', value: `console.log('hello world');` }"}},
-				scripts:  []string{"{props:{},children:`console.log('hello world');`}"},
 			},
 		},
 		{
@@ -2472,20 +2438,6 @@ const items = ["Dog", "Cat", "Platipus"];
 					toMatch += d
 				}
 				toMatch += "]);\n"
-			}
-			if len(tt.want.styles) > 0 {
-				toMatch = toMatch + STYLE_PRELUDE
-				for _, style := range tt.want.styles {
-					toMatch += style + ",\n"
-				}
-				toMatch += STYLE_SUFFIX
-			}
-			if len(tt.want.scripts) > 0 {
-				toMatch = toMatch + SCRIPT_PRELUDE
-				for _, script := range tt.want.scripts {
-					toMatch += script + ",\n"
-				}
-				toMatch += SCRIPT_SUFFIX
 			}
 			// code
 			toMatch += test_utils.Dedent(fmt.Sprintf("%s%s", RETURN, tt.want.code))

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -14,18 +14,17 @@ import (
 )
 
 type TransformOptions struct {
-	Scope            string
-	Filename         string
-	Pathname         string
-	ModuleId         string
-	InternalURL      string
-	SourceMap        string
-	Site             string
-	ProjectRoot      string
-	Compact          bool
-	ResolvePath      func(string) string
-	PreprocessStyle  interface{}
-	StaticExtraction bool
+	Scope           string
+	Filename        string
+	Pathname        string
+	ModuleId        string
+	InternalURL     string
+	SourceMap       string
+	Site            string
+	ProjectRoot     string
+	Compact         bool
+	ResolvePath     func(string) string
+	PreprocessStyle interface{}
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -301,15 +300,13 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 				}
 				if attr.Key == "src" {
 					if attr.Type == astro.ExpressionAttribute {
-						if opts.StaticExtraction {
-							shouldAdd = false
-							h.AppendWarning(&loc.ErrorWithRange{
-								Code:  loc.WARNING_UNSUPPORTED_EXPRESSION,
-								Text:  "<script> uses an expression for the src attribute and will be ignored.",
-								Hint:  fmt.Sprintf("Replace src={%s} with a string literal", attr.Val),
-								Range: loc.Range{Loc: n.Loc[0], Len: len(n.Data)},
-							})
-						}
+						shouldAdd = false
+						h.AppendWarning(&loc.ErrorWithRange{
+							Code:  loc.WARNING_UNSUPPORTED_EXPRESSION,
+							Text:  "<script> uses an expression for the src attribute and will be ignored.",
+							Hint:  fmt.Sprintf("Replace src={%s} with a string literal", attr.Val),
+							Range: loc.Range{Loc: n.Loc[0], Len: len(n.Data)},
+						})
 						break
 					}
 				}

--- a/packages/compiler/browser/utils.ts
+++ b/packages/compiler/browser/utils.ts
@@ -105,6 +105,8 @@ function serializeAttributes(node: TagLikeNode): string {
 export interface SerializeOptions {
   selfClose: boolean;
 }
+/** @deprecated Please use `SerializeOptions`  */
+export type SerializeOtions = SerializeOptions;
 
 export function serialize(root: Node, opts: SerializeOptions = { selfClose: true }): string {
   let output = '';

--- a/packages/compiler/node/utils.ts
+++ b/packages/compiler/node/utils.ts
@@ -105,6 +105,8 @@ function serializeAttributes(node: TagLikeNode): string {
 export interface SerializeOptions {
   selfClose: boolean;
 }
+/** @deprecated Please use `SerializeOptions`  */
+export type SerializeOtions = SerializeOptions;
 
 export function serialize(root: Node, opts: SerializeOptions = { selfClose: true }): string {
   let output = '';

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -57,7 +57,6 @@ export interface TransformOptions {
   projectRoot?: string;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
-  experimentalStaticExtraction?: boolean;
 }
 
 export type HoistedScript = { type: string } & (

--- a/packages/compiler/test/bad-styles/sass.ts
+++ b/packages/compiler/test/bad-styles/sass.ts
@@ -17,7 +17,6 @@ const FIXTURE = `
 
 test('it works', async () => {
   let result = await transform(FIXTURE, {
-    experimentalStaticExtraction: true,
     pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro',
     async preprocessStyle() {
       return {

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -31,7 +31,6 @@ let result: TransformResult;
 test.before(async () => {
   result = await transform(FIXTURE, {
     pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro',
-    experimentalStaticExtraction: true,
   });
 });
 

--- a/packages/compiler/test/client-directive/special-characters.ts
+++ b/packages/compiler/test/client-directive/special-characters.ts
@@ -28,7 +28,7 @@ import RemoteComponent from 'https://test.com/components/with-[wacky-brackets}()
 
 let result;
 test.before(async () => {
-  result = await transform(FIXTURE, { experimentalStaticExtraction: true, pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro' });
+  result = await transform(FIXTURE, { pathname: '/@fs/users/astro/apps/pacman/src/pages/index.astro' });
 });
 
 test('does not panic', () => {

--- a/packages/compiler/test/css-order/astro-styles.ts
+++ b/packages/compiler/test/css-order/astro-styles.ts
@@ -12,7 +12,6 @@ let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
     sourcefile: 'test.astro',
-    experimentalStaticExtraction: true,
   });
 });
 

--- a/packages/compiler/test/css-order/imported-styles.ts
+++ b/packages/compiler/test/css-order/imported-styles.ts
@@ -15,7 +15,6 @@ let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
     sourcefile: 'test.astro',
-    experimentalStaticExtraction: true,
   });
 });
 

--- a/packages/compiler/test/scope/same-source.ts
+++ b/packages/compiler/test/scope/same-source.ts
@@ -27,14 +27,12 @@ function grabAstroScope(code: string) {
 
 test('Similar components have different scoped class names', async () => {
   let result = await transform(FIXTURE, {
-    experimentalStaticExtraction: true,
     moduleId: '/src/pages/index.astro',
   });
   let scopeA = grabAstroScope(result.code);
   assert.ok(scopeA);
 
   result = await transform(FIXTURE, {
-    experimentalStaticExtraction: true,
     moduleId: '/src/pages/two.astro',
   });
 

--- a/packages/compiler/test/static-extraction/css.ts
+++ b/packages/compiler/test/static-extraction/css.ts
@@ -14,9 +14,7 @@ const FIXTURE = `
 
 let result;
 test.before(async () => {
-  result = await transform(FIXTURE, {
-    experimentalStaticExtraction: true,
-  });
+  result = await transform(FIXTURE);
 });
 
 test('extracts styles', () => {

--- a/packages/compiler/test/static-extraction/hoist-expression.ts
+++ b/packages/compiler/test/static-extraction/hoist-expression.ts
@@ -11,7 +11,7 @@ const url = 'foo';
 
 let result;
 test.before(async () => {
-  result = await transform(FIXTURE, { experimentalStaticExtraction: true });
+  result = await transform(FIXTURE);
 });
 
 test('logs warning with hoisted expression', () => {

--- a/packages/compiler/test/styles/define-vars.ts
+++ b/packages/compiler/test/styles/define-vars.ts
@@ -24,7 +24,6 @@ test.before(async () => {
   result = await transform(FIXTURE, {
     sourcemap: true,
     preprocessStyle,
-    experimentalStaticExtraction: true,
   });
 });
 

--- a/packages/compiler/test/styles/sass.ts
+++ b/packages/compiler/test/styles/sass.ts
@@ -37,11 +37,11 @@ test.before(async () => {
 });
 
 test('transforms scss one', () => {
-  assert.match(result.code, 'color:red', 'Expected "color:red" to be present.');
+  assert.match(result.css[result.css.length - 1], 'color:red', 'Expected "color:red" to be present.');
 });
 
 test('transforms scss two', () => {
-  assert.match(result.code, 'color:green', 'Expected "color:green" to be present.');
+  assert.match(result.css[0], 'color:green', 'Expected "color:green" to be present.');
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- Closes #688 
- Removes `experimentalStaticExtraction` flag and related legacy code.
- Uses `experimentalStaticExtraction` behavior as the default.

## Testing

Covered by existing tests, outdated tests updated

## Docs

CHANGELOG updated