### PR TITLE
Remove site and projectRoot options

### DIFF
--- a/.changeset/friendly-clouds-occur.md
+++ b/.changeset/friendly-clouds-occur.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Remove `site` and `projectRoot` options in favour of the `injectGlobals` option

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -89,15 +89,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		sourcemap = "both"
 	}
 
-	site := jsString(options.Get("site"))
-	if site == "" {
-		site = ""
-	}
-
-	projectRoot := jsString(options.Get("projectRoot"))
-	if projectRoot == "" {
-		projectRoot = "."
-	}
+	injectGlobals := jsString(options.Get("injectGlobals"))
 
 	compact := false
 	if jsBool(options.Get("compact")) {
@@ -125,8 +117,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		ModuleId:        moduleId,
 		InternalURL:     internalURL,
 		SourceMap:       sourcemap,
-		Site:            site,
-		ProjectRoot:     projectRoot,
+		InjectGlobals:   injectGlobals,
 		Compact:         compact,
 		ResolvePath:     resolvePathFn,
 		PreprocessStyle: preprocessStyle,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -418,7 +418,7 @@ func (p *printer) printTopLevelAstro(opts transform.TransformOptions) {
 		patharg = fmt.Sprintf("\"%s\"", patharg)
 	}
 
-	p.println(fmt.Sprintf("const $$Astro = %s(%s, '%s', '%s');\nconst Astro = $$Astro;", CREATE_ASTRO, patharg, p.opts.Site, p.opts.ProjectRoot))
+	p.println(fmt.Sprintf("const $$Astro = %s(%s);\nconst Astro = $$Astro;", CREATE_ASTRO, opts.InjectGlobals))
 }
 
 func remove(slice []*astro.Node, node *astro.Node) []*astro.Node {

--- a/internal/printer/printer_css_test.go
+++ b/internal/printer/printer_css_test.go
@@ -53,9 +53,7 @@ func TestPrinterCSS(t *testing.T) {
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}, handler.NewHandler(code, "/test.astro")) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintCSS(code, doc, transform.TransformOptions{
 				Scope:       "astro-XXXX",
-				Site:        "https://astro.build",
 				InternalURL: "http://localhost:3000/",
-				ProjectRoot: ".",
 			})
 			output := ""
 			for _, bytes := range result.Output {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -39,7 +39,7 @@ var RETURN = fmt.Sprintf("return %s%s", TEMPLATE_TAG, BACKTICK)
 var SUFFIX = fmt.Sprintf("%s;", BACKTICK) + `
 });
 export default $$Component;`
-var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build', '.');\nconst Astro = $$Astro;"
+var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro('https://astro.build');\nconst Astro = $$Astro;"
 var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
 
 // SPECIAL TEST FIXTURES
@@ -2337,11 +2337,10 @@ const items = ["Dog", "Cat", "Platipus"];
 			transform.ExtractStyles(doc)
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
-				Scope:       "XXXX",
-				Site:        "https://astro.build",
-				InternalURL: "http://localhost:3000/",
-				ModuleId:    tt.moduleId,
-				ProjectRoot: ".",
+				Scope:         "XXXX",
+				InternalURL:   "http://localhost:3000/",
+				ModuleId:      tt.moduleId,
+				InjectGlobals: "'https://astro.build'",
 			}, h)
 			output := string(result.Output)
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -20,8 +20,7 @@ type TransformOptions struct {
 	ModuleId        string
 	InternalURL     string
 	SourceMap       string
-	Site            string
-	ProjectRoot     string
+	InjectGlobals   string
 	Compact         bool
 	ResolvePath     func(string) string
 	PreprocessStyle interface{}

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -23,7 +23,6 @@ The Astro compiler can convert `.astro` syntax to a TypeScript Module whose defa
 import { transform } from '@astrojs/compiler';
 
 const result = await transform(source, {
-  site: 'https://mysite.dev',
   sourcefile: '/Users/astro/Code/project/src/pages/index.astro',
   sourcemap: 'both',
   internalURL: 'astro/runtime/server/index.js',

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -44,17 +44,16 @@ export interface DiagnosticLocation {
 
 export interface TransformOptions {
   internalURL?: string;
-  site?: string;
   sourcefile?: string;
   pathname?: string;
   moduleId?: string;
   sourcemap?: boolean | 'inline' | 'external' | 'both';
+  injectGlobals?: string
   compact?: boolean;
   /**
    * @deprecated "as" has been removed and no longer has any effect!
    */
   as?: 'document' | 'fragment';
-  projectRoot?: string;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
 }


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/compiler/issues/692

Remove `site` and `projectRoot` options, in favour of `injectGlobals` option which is more generic, e.g.

```js
transform(source, {
  injectGlobals: JSON.stringify(astroConfig.site)
})
```

The compiler would output `$$createAstro("https://astro.build")`. This allows us to pass params dynamically to `createAstro` without leaking business logic that gets added to, e.g. `Astro.site`.

Further discussion on discord: https://discord.com/channels/830184174198718474/1060212452756815954/1060564993768169542

Note this change goes in hand to this Astro code: https://github.com/withastro/astro/blob/6a95790b45114e2e9fae65f513c6c9381ccdf376/packages/astro/src/runtime/server/astro-global.ts#L19-L32

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Updated the test to cover this new option.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
n/a