### PR TITLE
Refactor file name options

### DIFF
--- a/.changeset/green-avocados-dance.md
+++ b/.changeset/green-avocados-dance.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Merge `sourcefile` and `moduleId` options as a single `filename` option. Add a new `normalizedFilename` option to generate stable hashes instead.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -52,7 +52,7 @@ func makeParseOptions(options js.Value) t.ParseOptions {
 		position = pos.Bool()
 	}
 
-	filename := jsString(options.Get("sourcefile"))
+	filename := jsString(options.Get("filename"))
 	if filename == "" {
 		filename = "<stdin>"
 	}
@@ -64,7 +64,7 @@ func makeParseOptions(options js.Value) t.ParseOptions {
 }
 
 func makeTransformOptions(options js.Value) transform.TransformOptions {
-	filename := jsString(options.Get("sourcefile"))
+	filename := jsString(options.Get("filename"))
 	if filename == "" {
 		filename = "<stdin>"
 	}
@@ -109,7 +109,6 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	return transform.TransformOptions{
 		Filename:           filename,
 		NormalizedFilename: normalizedFilename,
-		Scope:              astro.HashString(normalizedFilename),
 		InternalURL:        internalURL,
 		SourceMap:          sourcemap,
 		AstroGlobalArgs:    astroGlobalArgs,
@@ -253,6 +252,11 @@ func Transform() any {
 		source := jsString(args[0])
 
 		transformOptions := makeTransformOptions(js.Value(args[1]))
+		scopeStr := transformOptions.NormalizedFilename
+		if scopeStr == "<stdin>" {
+			scopeStr = source
+		}
+		transformOptions.Scope = astro.HashString(scopeStr)
 		h := handler.NewHandler(source, transformOptions.Filename)
 
 		styleError := []string{}

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -69,9 +69,9 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		filename = "<stdin>"
 	}
 
-	moduleId := jsString(options.Get("moduleId"))
-	if moduleId == "" {
-		moduleId = "<stdin>"
+	normalizedFilename := jsString(options.Get("normalizedFilename"))
+	if normalizedFilename == "" {
+		normalizedFilename = filename
 	}
 
 	internalURL := jsString(options.Get("internalURL"))
@@ -107,14 +107,15 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	preprocessStyle := options.Get("preprocessStyle")
 
 	return transform.TransformOptions{
-		Filename:        filename,
-		ModuleId:        moduleId,
-		InternalURL:     internalURL,
-		SourceMap:       sourcemap,
-		AstroGlobalArgs:   astroGlobalArgs,
-		Compact:         compact,
-		ResolvePath:     resolvePathFn,
-		PreprocessStyle: preprocessStyle,
+		Filename:           filename,
+		NormalizedFilename: normalizedFilename,
+		Scope:              astro.HashString(normalizedFilename),
+		InternalURL:        internalURL,
+		SourceMap:          sourcemap,
+		AstroGlobalArgs:    astroGlobalArgs,
+		Compact:            compact,
+		ResolvePath:        resolvePathFn,
+		PreprocessStyle:    preprocessStyle,
 	}
 }
 
@@ -252,7 +253,6 @@ func Transform() any {
 		source := jsString(args[0])
 
 		transformOptions := makeTransformOptions(js.Value(args[1]))
-		transformOptions.Scope = astro.HashFromSourceAndModuleId(source, transformOptions.ModuleId)
 		h := handler.NewHandler(source, transformOptions.Filename)
 
 		styleError := []string{}
@@ -269,11 +269,6 @@ func Transform() any {
 
 				// Hoist styles and scripts to the top-level
 				transform.ExtractStyles(doc)
-
-				if len(doc.Styles) > 0 {
-					newHash := astro.HashFromDoc(doc, transformOptions.ModuleId)
-					transformOptions.Scope = newHash
-				}
 
 				// Pre-process styles
 				// Important! These goroutines need to be spawned from this file or they don't work

--- a/internal/hash.go
+++ b/internal/hash.go
@@ -2,27 +2,14 @@ package astro
 
 import (
 	"encoding/base32"
-	"strings"
 
 	"github.com/withastro/compiler/internal/xxhash"
 )
 
-// This is used in `Transform` to ensure a stable hash when updating styles
-func HashFromDoc(doc *Node, moduleId string) string {
-	var b strings.Builder
-	PrintToSource(&b, doc)
-	source := strings.TrimSpace(b.String())
-	return HashFromSourceAndModuleId(source, moduleId)
-}
-
-func HashFromSourceAndModuleId(source, moduleId string) string {
+func HashString(str string) string {
 	h := xxhash.New()
 	//nolint
-	h.Write([]byte(moduleId + source))
+	h.Write([]byte(str))
 	hashBytes := h.Sum(nil)
 	return base32.StdEncoding.EncodeToString(hashBytes)[:8]
-}
-
-func HashFromSource(source string) string {
-	return HashFromSourceAndModuleId(source, "")
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -247,9 +247,9 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
 func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
 	componentName := getComponentName(opts.Filename)
 	p.addNilSourceMapping()
-	if len(opts.ModuleId) > 0 {
-		escapedModuleId := strings.ReplaceAll(opts.ModuleId, "'", "\\'")
-		p.println(fmt.Sprintf("}, '%s');", escapedModuleId))
+	if len(opts.Filename) > 0 {
+		escapedFilename := strings.ReplaceAll(opts.Filename, "'", "\\'")
+		p.println(fmt.Sprintf("}, '%s');", escapedFilename))
 	} else {
 		p.println("});")
 	}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -544,7 +544,8 @@ func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.Transfo
 	if patharg == "" {
 		patharg = "import.meta.url"
 	} else {
-		patharg = fmt.Sprintf("\"%s\"", patharg)
+		escapedPatharg := strings.ReplaceAll(patharg, "'", "\\'")
+		patharg = fmt.Sprintf("\"%s\"", escapedPatharg)
 	}
 	p.print(fmt.Sprintf("\nexport const $$metadata = %s(%s, { ", CREATE_METADATA, patharg))
 

--- a/internal/printer/printer_css_test.go
+++ b/internal/printer/printer_css_test.go
@@ -48,7 +48,7 @@ func TestPrinterCSS(t *testing.T) {
 				t.Error(err)
 			}
 
-			hash := astro.HashFromSource(code)
+			hash := astro.HashString(code)
 			transform.ExtractStyles(doc)
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}, handler.NewHandler(code, "/test.astro")) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintCSS(code, doc, transform.TransformOptions{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -45,11 +45,11 @@ var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
 // SPECIAL TEST FIXTURES
 var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[];:'\",.?")
 
-func suffixWithModuleId(moduleId string) string {
+func suffixWithFilename(filename string) string {
 
 	return fmt.Sprintf("%s;", BACKTICK) + fmt.Sprintf(`
 }, '%s');
-export default $$Component;`, moduleId)
+export default $$Component;`, filename)
 }
 
 type want struct {
@@ -72,7 +72,7 @@ type testcase struct {
 	name     string
 	source   string
 	only     bool
-	moduleId string
+	filename string
 	want     want
 }
 
@@ -2296,17 +2296,17 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:     "passes moduleId into createComponent if passed into the compiler options",
+			name:     "passes filename into createComponent if passed into the compiler options",
 			source:   `<div>test</div>`,
-			moduleId: "/projects/app/src/pages/page.astro",
+			filename: "/projects/app/src/pages/page.astro",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<div>test</div>`,
 			},
 		},
 		{
-			name:     "passes escaped moduleId into createComponent if it contains single quotes",
+			name:	    "passes escaped filename into createComponent if it contains single quotes",
 			source:   `<div>test</div>`,
-			moduleId: "/projects/app/src/pages/page-with-'-quotes.astro",
+			filename: "/projects/app/src/pages/page-with-'-quotes.astro",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<div>test</div>`,
 			},
@@ -2339,7 +2339,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
 				Scope:           "XXXX",
 				InternalURL:     "http://localhost:3000/",
-				ModuleId:        tt.moduleId,
+				Filename:        tt.filename,
 				AstroGlobalArgs: "'https://astro.build'",
 			}, h)
 			output := string(result.Output)
@@ -2445,9 +2445,9 @@ const items = ["Dog", "Cat", "Platipus"];
 				toMatch = strings.TrimRight(toMatch, ".")
 			}
 
-			if len(tt.moduleId) > 0 {
-				escapedModuleId := strings.ReplaceAll(tt.moduleId, "'", "\\'")
-				toMatch += suffixWithModuleId(escapedModuleId)
+			if len(tt.filename) > 0 {
+				escapedFilename := strings.ReplaceAll(tt.filename, "'", "\\'")
+				toMatch += suffixWithFilename(escapedFilename)
 			} else {
 				toMatch += SUFFIX
 			}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2333,7 +2333,7 @@ const items = ["Dog", "Cat", "Platipus"];
 				t.Error(err)
 			}
 
-			hash := astro.HashFromSource(code)
+			hash := astro.HashString(code)
 			transform.ExtractStyles(doc)
 			transform.Transform(doc, transform.TransformOptions{Scope: hash}, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
@@ -2418,7 +2418,12 @@ const items = ["Dog", "Cat", "Platipus"];
 			}
 			metadata += "] }"
 
-			toMatch += "\n\n" + fmt.Sprintf("export const %s = %s(import.meta.url, %s);\n\n", METADATA, CREATE_METADATA, metadata)
+			patharg := "import.meta.url"
+			if tt.filename != "" {
+				escapedFilename := strings.ReplaceAll(tt.filename, "'", "\\'")
+				patharg = fmt.Sprintf("\"%s\"", escapedFilename)
+			}
+			toMatch += "\n\n" + fmt.Sprintf("export const %s = %s(%s, %s);\n\n", METADATA, CREATE_METADATA, patharg, metadata)
 			toMatch += test_utils.Dedent(CREATE_ASTRO_CALL) + "\n"
 			if len(tt.want.getStaticPaths) > 0 {
 				toMatch += strings.TrimSpace(test_utils.Dedent(tt.want.getStaticPaths)) + "\n\n"
@@ -2448,6 +2453,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			if len(tt.filename) > 0 {
 				escapedFilename := strings.ReplaceAll(tt.filename, "'", "\\'")
 				toMatch += suffixWithFilename(escapedFilename)
+				toMatch = strings.Replace(toMatch, "$$Component", getComponentName((tt.filename)), -1)
 			} else {
 				toMatch += SUFFIX
 			}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2453,7 +2453,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			if len(tt.filename) > 0 {
 				escapedFilename := strings.ReplaceAll(tt.filename, "'", "\\'")
 				toMatch += suffixWithFilename(escapedFilename)
-				toMatch = strings.Replace(toMatch, "$$Component", getComponentName((tt.filename)), -1)
+				toMatch = strings.Replace(toMatch, "$$Component", getComponentName(tt.filename), -1)
 			} else {
 				toMatch += SUFFIX
 			}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -14,15 +14,15 @@ import (
 )
 
 type TransformOptions struct {
-	Scope           string
-	Filename        string
-	ModuleId        string
-	InternalURL     string
-	SourceMap       string
-	AstroGlobalArgs string
-	Compact         bool
-	ResolvePath     func(string) string
-	PreprocessStyle interface{}
+	Scope              string
+	Filename           string
+	NormalizedFilename string
+	InternalURL        string
+	SourceMap          string
+	AstroGlobalArgs    string
+	Compact            bool
+	ResolvePath        func(string) string
+	PreprocessStyle    interface{}
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -23,7 +23,7 @@ The Astro compiler can convert `.astro` syntax to a TypeScript Module whose defa
 import { transform } from '@astrojs/compiler';
 
 const result = await transform(source, {
-  sourcefile: '/Users/astro/Code/project/src/pages/index.astro',
+  filename: '/Users/astro/Code/project/src/pages/index.astro',
   sourcemap: 'both',
   internalURL: 'astro/runtime/server/index.js',
 });

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -44,7 +44,7 @@ export interface DiagnosticLocation {
 
 export interface TransformOptions {
   internalURL?: string;
-  sourcefile?: string;
+  filename?: string;
   normalizedFilename?: string;
   sourcemap?: boolean | 'inline' | 'external' | 'both';
   astroGlobalArgs?: string;

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -45,7 +45,7 @@ export interface DiagnosticLocation {
 export interface TransformOptions {
   internalURL?: string;
   sourcefile?: string;
-  moduleId?: string;
+  normalizedFilename?: string;
   sourcemap?: boolean | 'inline' | 'external' | 'both';
   astroGlobalArgs?: string;
   compact?: boolean;

--- a/packages/compiler/test/bad-styles/sass.ts
+++ b/packages/compiler/test/bad-styles/sass.ts
@@ -17,7 +17,7 @@ const FIXTURE = `
 
 test('it works', async () => {
   let result = await transform(FIXTURE, {
-    sourcefile: '/users/astro/apps/pacman/src/pages/index.astro',
+    filename: '/users/astro/apps/pacman/src/pages/index.astro',
     async preprocessStyle() {
       return {
         error: new Error('Unable to convert').message,

--- a/packages/compiler/test/basic/component-metadata/index.ts
+++ b/packages/compiler/test/basic/component-metadata/index.ts
@@ -30,7 +30,7 @@ import * as eight from '../components/eight.jsx';
 let result: TransformResult;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/users/astro/apps/pacman/src/pages/index.astro',
+    filename: '/users/astro/apps/pacman/src/pages/index.astro',
   });
 });
 

--- a/packages/compiler/test/basic/component-name.ts
+++ b/packages/compiler/test/basic/component-name.ts
@@ -7,7 +7,7 @@ const FIXTURE = `<div>Hello world!</div>`;
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/src/components/Cool.astro',
+    filename: '/src/components/Cool.astro',
   });
 });
 

--- a/packages/compiler/test/basic/null-chars.ts
+++ b/packages/compiler/test/basic/null-chars.ts
@@ -11,7 +11,7 @@ const FIXTURE = `
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/Users/matthew/dev/astro/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced.astro',
+    filename: '/Users/matthew/dev/astro/packages/astro/test/fixtures/astro-attrs/src/pages/namespaced.astro',
     sourcemap: 'both',
   });
 });

--- a/packages/compiler/test/client-directive/special-characters.ts
+++ b/packages/compiler/test/client-directive/special-characters.ts
@@ -28,7 +28,7 @@ import RemoteComponent from 'https://test.com/components/with-[wacky-brackets}()
 
 let result;
 test.before(async () => {
-  result = await transform(FIXTURE, { sourcefile: '/users/astro/apps/pacman/src/pages/index.astro' });
+  result = await transform(FIXTURE, { filename: '/users/astro/apps/pacman/src/pages/index.astro' });
 });
 
 test('does not panic', () => {

--- a/packages/compiler/test/css-order/astro-styles.ts
+++ b/packages/compiler/test/css-order/astro-styles.ts
@@ -11,7 +11,7 @@ const FIXTURE = `
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: 'test.astro',
+    filename: 'test.astro',
   });
 });
 

--- a/packages/compiler/test/css-order/imported-styles.ts
+++ b/packages/compiler/test/css-order/imported-styles.ts
@@ -14,7 +14,7 @@ import '../styles/global.css';
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: 'test.astro',
+    filename: 'test.astro',
   });
 });
 

--- a/packages/compiler/test/errors/client-only-unfound.ts
+++ b/packages/compiler/test/errors/client-only-unfound.ts
@@ -18,7 +18,7 @@ const { MyComponent } = components;
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/src/components/Cool.astro',
+    filename: '/src/components/Cool.astro',
   });
 });
 

--- a/packages/compiler/test/errors/define-vars.ts
+++ b/packages/compiler/test/errors/define-vars.ts
@@ -6,7 +6,7 @@ test('define:vars warning', async () => {
   const result = await transform(
     `<Fragment><slot /></Fragment>
 <style define:vars={{ color: 'red' }}></style>`,
-    { sourcefile: '/src/components/Foo.astro' }
+    { filename: '/src/components/Foo.astro' }
   );
   assert.ok(Array.isArray(result.diagnostics));
   assert.is(result.diagnostics.length, 1);
@@ -17,7 +17,7 @@ test('define:vars no warning', async () => {
   const result = await transform(
     `<div><slot /></div>
 <style define:vars={{ color: 'red' }}></style>`,
-    { sourcefile: '/src/components/Foo.astro' }
+    { filename: '/src/components/Foo.astro' }
   );
   assert.ok(Array.isArray(result.diagnostics));
   assert.is(result.diagnostics.length, 0);

--- a/packages/compiler/test/errors/fragment-shorthand.ts
+++ b/packages/compiler/test/errors/fragment-shorthand.ts
@@ -14,7 +14,7 @@ const FIXTURE = `<html>
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/src/components/fragment.astro',
+    filename: '/src/components/fragment.astro',
   });
 });
 

--- a/packages/compiler/test/errors/html-comment.ts
+++ b/packages/compiler/test/errors/html-comment.ts
@@ -16,7 +16,7 @@ const FIXTURE = `<html>
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/src/components/EOF.astro',
+    filename: '/src/components/EOF.astro',
   });
 });
 

--- a/packages/compiler/test/errors/invalid-spread.ts
+++ b/packages/compiler/test/errors/invalid-spread.ts
@@ -3,14 +3,14 @@ import * as assert from 'uvu/assert';
 import { transform } from '@astrojs/compiler';
 
 test('...spread has warning', async () => {
-  const result = await transform(`<Head ...seo />`, { sourcefile: '/src/components/Foo.astro' });
+  const result = await transform(`<Head ...seo />`, { filename: '/src/components/Foo.astro' });
   assert.ok(Array.isArray(result.diagnostics));
   assert.is(result.diagnostics.length, 1);
   assert.is(result.diagnostics[0].code, 2008);
 });
 
 test('{...spread} does not have warning', async () => {
-  const result = await transform(`<Head {...seo} />`, { sourcefile: '/src/components/Foo.astro' });
+  const result = await transform(`<Head {...seo} />`, { filename: '/src/components/Foo.astro' });
   assert.ok(Array.isArray(result.diagnostics));
   assert.is(result.diagnostics.length, 0);
 });

--- a/packages/compiler/test/errors/jsx-comment.ts
+++ b/packages/compiler/test/errors/jsx-comment.ts
@@ -16,7 +16,7 @@ const FIXTURE = `<html>
 let result;
 test.before(async () => {
   result = await transform(FIXTURE, {
-    sourcefile: '/src/components/EOF.astro',
+    filename: '/src/components/EOF.astro',
   });
 });
 

--- a/packages/compiler/test/scope/same-source.ts
+++ b/packages/compiler/test/scope/same-source.ts
@@ -27,13 +27,13 @@ function grabAstroScope(code: string) {
 
 test('Similar components have different scoped class names', async () => {
   let result = await transform(FIXTURE, {
-    moduleId: '/src/pages/index.astro',
+    normalizedFilename: '/src/pages/index.astro',
   });
   let scopeA = grabAstroScope(result.code);
   assert.ok(scopeA);
 
   result = await transform(FIXTURE, {
-    moduleId: '/src/pages/two.astro',
+    normalizedFilename: '/src/pages/two.astro',
   });
 
   let scopeB = grabAstroScope(result.code);

--- a/packages/compiler/test/styles/hash.ts
+++ b/packages/compiler/test/styles/hash.ts
@@ -37,11 +37,6 @@ test.before(async () => {
   scopes.push(a, b, c, d);
 });
 
-test('hash is stable when styles change', () => {
-  const [a, b] = scopes;
-  assert.equal(a, b, 'Expected scopes to be equal');
-});
-
 test('hash changes when content outside of style change', () => {
   const [, b, c] = scopes;
   assert.not.equal(b, c, 'Expected scopes to not be equal');

--- a/packages/compiler/test/table/components.ts
+++ b/packages/compiler/test/table/components.ts
@@ -21,7 +21,7 @@ const  MyTableRow = "tr";
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
   } catch (e) {
     error = 1;

--- a/packages/compiler/test/table/expressions.ts
+++ b/packages/compiler/test/table/expressions.ts
@@ -30,7 +30,7 @@ test('allows expressions in table', async () => {
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
     assert.match(code, '<tr>${num}</tr>');
   } catch (e) {
@@ -81,7 +81,7 @@ test('allows many expressions in table', async () => {
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
     assert.match(code, '<tr>${num}</tr>');
   } catch (e) {

--- a/packages/compiler/test/table/in-expression.ts
+++ b/packages/compiler/test/table/in-expression.ts
@@ -33,7 +33,7 @@ test('does not panic on table in expression', async () => {
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
   } catch (e) {
     error = 1;
@@ -59,7 +59,7 @@ test('does not generate invalid markup on table in expression', async () => {
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
   } catch (e) {
     error = 1;
@@ -85,7 +85,7 @@ test('does not generate invalid markup on multiple tables', async () => {
 
   let error = 0;
   try {
-    const { code } = await transform(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const { code } = await transform(input, { filename: 'index.astro', sourcemap: 'inline' });
     parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
   } catch (e) {
     error = 1;

--- a/packages/compiler/test/tsx-errors/eof.ts
+++ b/packages/compiler/test/tsx-errors/eof.ts
@@ -16,7 +16,7 @@ const FIXTURE = `<html>
 let result;
 test.before(async () => {
   result = await convertToTSX(FIXTURE, {
-    sourcefile: '/src/components/EOF.astro',
+    filename: '/src/components/EOF.astro',
   });
 });
 

--- a/packages/compiler/test/tsx-errors/fragment-shorthand.ts
+++ b/packages/compiler/test/tsx-errors/fragment-shorthand.ts
@@ -14,7 +14,7 @@ const FIXTURE = `<html>
 let result;
 test.before(async () => {
   result = await convertToTSX(FIXTURE, {
-    sourcefile: '/src/components/fragment.astro',
+    filename: '/src/components/fragment.astro',
   });
 });
 

--- a/packages/compiler/test/tsx-errors/unfinished-component.ts
+++ b/packages/compiler/test/tsx-errors/unfinished-component.ts
@@ -7,7 +7,7 @@ const FIXTURE = `<div class={`;
 let result;
 test.before(async () => {
   result = await convertToTSX(FIXTURE, {
-    sourcefile: '/src/components/unfinished.astro',
+    filename: '/src/components/unfinished.astro',
   });
 });
 

--- a/packages/compiler/test/tsx-sourcemaps/404.ts
+++ b/packages/compiler/test/tsx-sourcemaps/404.ts
@@ -5,6 +5,6 @@ import { convertToTSX } from '@astrojs/compiler';
 test('404 generates a valid identifier', async () => {
   const input = `<div {name} />`;
 
-  const output = await convertToTSX(input, { sourcefile: '404.astro', sourcemap: 'inline' });
+  const output = await convertToTSX(input, { filename: '404.astro', sourcemap: 'inline' });
   assert.match(output.code, `export default function __AstroComponent_`);
 });

--- a/packages/compiler/test/tsx-sourcemaps/complex-generics.ts
+++ b/packages/compiler/test/tsx-sourcemaps/complex-generics.ts
@@ -35,7 +35,7 @@ const { article } = Astro.props;
 test('does not panic on complex generics', async () => {
   let error = 0;
   try {
-    await convertToTSX(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
   } catch (e) {
     error = 1;
   }

--- a/packages/compiler/test/tsx-sourcemaps/template-windows.ts
+++ b/packages/compiler/test/tsx-sourcemaps/template-windows.ts
@@ -123,7 +123,7 @@ test('special attributes', async () => {
 
 test('whitespace', async () => {
   const input = `---\r\nimport A from "a";\r\n\timport B from "b";\r\n---\r\n`;
-  const { code } = await convertToTSX(input, { sourcemap: 'both', sourcefile: 'index.astro' });
+  const { code } = await convertToTSX(input, { sourcemap: 'both', filename: 'index.astro' });
   assert.match(code, '\t', 'output includes \\t');
 
   const B = await testTSXSourcemap(input, 'B');

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -8,7 +8,7 @@ const input = `<div class=\`></div>
 test('does not panic on unfinished template literal attribute', async () => {
   let error = 0;
   try {
-    const output = await convertToTSX(input, { sourcefile: 'index.astro', sourcemap: 'inline' });
+    const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
     assert.match(output.code, `class={\`\`}`);
   } catch (e) {
     error = 1;

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -42,7 +42,7 @@ let value = 'world';
 
 </Fragment>
 export default function Test__AstroComponent_(_props: Record<string, any>): any {}`;
-  const { code } = await convertToTSX(input, { sourcefile: '/Users/nmoo/test.astro', sourcemap: 'external' });
+  const { code } = await convertToTSX(input, { filename: '/Users/nmoo/test.astro', sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -128,7 +128,7 @@ type Props = {}
 
 </Fragment>
 export default function Test__AstroComponent_(_props: Props): any {}`;
-  const { code } = await convertToTSX(input, { sourcefile: '/Users/nmoo/test.astro', sourcemap: 'external' });
+  const { code } = await convertToTSX(input, { filename: '/Users/nmoo/test.astro', sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 

--- a/packages/compiler/test/utils.ts
+++ b/packages/compiler/test/utils.ts
@@ -47,7 +47,7 @@ export async function testTSXSourcemap(input: string, snippet: string) {
   const snippetLoc = getPositionFor(input, snippet);
   if (!snippetLoc) throw new Error(`Unable to find "${snippet}"`);
 
-  const { code, map } = await convertToTSX(input, { sourcemap: 'both', sourcefile: 'index.astro' });
+  const { code, map } = await convertToTSX(input, { sourcemap: 'both', filename: 'index.astro' });
   const tracer = new TraceMap(map);
 
   const generated = generatedPositionFor(tracer, { source: 'index.astro', line: snippetLoc.line, column: snippetLoc.column });
@@ -65,7 +65,7 @@ export async function testJSSourcemap(input: string, snippet: string) {
   const snippetLoc = getPositionFor(input, snippet);
   if (!snippetLoc) throw new Error(`Unable to find "${snippet}"`);
 
-  const { code, map } = await transform(input, { sourcemap: 'both', sourcefile: 'index.astro', experimentalStaticExtraction: true, resolvePath: (i: string) => i });
+  const { code, map } = await transform(input, { sourcemap: 'both', filename: 'index.astro', resolvePath: (i: string) => i });
   const tracer = new TraceMap(map);
 
   const generated = generatedPositionFor(tracer, { source: 'index.astro', line: snippetLoc.line, column: snippetLoc.column });


### PR DESCRIPTION
## Changes

- Merge `sourcefile` and `moduleId` options as a single `filename` option. (Possible since https://github.com/withastro/astro/pull/5811)
- Add a new `normalizedFilename` option to generate stable hashes instead.

---

The new scope hashes are derived like this:

1. If `normalizedFilename` is define, use it only to generate the hash.
2. Else use the entire source to generate the hash.

I don't think we need to combined both the file path and source to generate the hash, the `normalizedFilename` itself should be unique to generate off if it's define, which Astro core will always pass. The value would be like `/src/pages/index.astro` etc.

---

Should also pave the way for https://github.com/withastro/astro/issues/5136 once we are able to use the `normalizedFilename` option in core.



## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
- Updated the tests with the option name changes.
- Updated `printer_test` to also handle case where `filename` option is passed and used in the generated code.
- Remove "same file, same html but different style tag, but still same hash" test. I think the hash should derive from the source entirely (no excluding style) by default. This shouldn't affect us as if `normalizedFilename` is passed (which we will), the hash will derive from it instead.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
n/a