### PR TITLE
Improve error recovery

### DIFF
--- a/.changeset/spicy-ways-sing.md
+++ b/.changeset/spicy-ways-sing.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Improve error recovery

--- a/.changeset/spicy-ways-sing.md
+++ b/.changeset/spicy-ways-sing.md
@@ -1,5 +1,5 @@
 ---
-'@astrojs/compiler': patch
+'@astrojs/compiler': minor
 ---
 
-Improve error recovery
+Improve error recovery when using the `transform` function. The compiler will now properly reject the promise with a useful message and stacktrace rather than print internal errors to stdout.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -268,14 +268,14 @@ func Transform() any {
 				var doc *astro.Node
 				defer func() {
 					if err := recover(); err != nil {
-						reject.Invoke(handler.ErrorToJSError(h, err.(error)))
+						reject.Invoke(wasm_utils.ErrorToJSError(h, err.(error)))
 						return
 					}
 				}()
 
 				doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h))
 				if err != nil {
-					reject.Invoke(handler.ErrorToJSError(h, err))
+					reject.Invoke(wasm_utils.ErrorToJSError(h, err))
 					return
 				}
 

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -267,8 +267,8 @@ func Transform() any {
 			go func() {
 				var doc *astro.Node
 				defer func() {
-					if err := recover().(error); err != nil {
-						reject.Invoke(handler.ErrorToJSError(h, err))
+					if err := recover(); err != nil {
+						reject.Invoke(handler.ErrorToJSError(h, err.(error)))
 						return
 					}
 				}()

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -260,15 +260,23 @@ func Transform() any {
 		h := handler.NewHandler(source, transformOptions.Filename)
 
 		styleError := []string{}
-		handler := js.FuncOf(func(this js.Value, args []js.Value) any {
+		promiseHandle := js.FuncOf(func(this js.Value, args []js.Value) any {
 			resolve := args[0]
+			reject := args[1]
 
 			go func() {
 				var doc *astro.Node
+				defer func() {
+					if err := recover().(error); err != nil {
+						reject.Invoke(handler.ErrorToJSError(h, err))
+						return
+					}
+				}()
 
 				doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h))
 				if err != nil {
-					fmt.Println(err)
+					reject.Invoke(handler.ErrorToJSError(h, err))
+					return
 				}
 
 				// Hoist styles and scripts to the top-level
@@ -403,11 +411,11 @@ func Transform() any {
 
 			return nil
 		})
-		defer handler.Release()
+		defer promiseHandle.Release()
 
 		// Create and return the Promise object
 		promiseConstructor := js.Global().Get("Promise")
-		return promiseConstructor.New(handler)
+		return promiseConstructor.New(promiseHandle)
 	})
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -2,13 +2,8 @@ package handler
 
 import (
 	"errors"
-	"fmt"
-	"regexp"
-	"runtime/debug"
 	"strings"
-	"syscall/js"
 
-	"github.com/norunners/vert"
 	"github.com/withastro/compiler/internal/loc"
 	"github.com/withastro/compiler/internal/sourcemap"
 )
@@ -21,15 +16,6 @@ type Handler struct {
 	warnings   []error
 	infos      []error
 	hints      []error
-}
-
-type JSError struct {
-	Message string `js:"message"`
-	Stack   string `js:"stack"`
-}
-
-func (err *JSError) Value() js.Value {
-	return vert.ValueOf(err).Value
 }
 
 func NewHandler(sourcetext string, filename string) *Handler {
@@ -125,38 +111,4 @@ func ErrorToMessage(h *Handler, severity loc.DiagnosticSeverity, err error) loc.
 	default:
 		return loc.DiagnosticMessage{Text: err.Error()}
 	}
-}
-
-var FN_NAME_RE = regexp.MustCompile(`(\w+)\([^)]+\)$`)
-
-func ErrorToJSError(h *Handler, err error) js.Value {
-	stack := string(debug.Stack())
-	message := strings.TrimSpace(err.Error())
-	if strings.Contains(message, ":") {
-		message = strings.TrimSpace(strings.Split(message, ":")[1])
-	}
-	hasFnName := false
-	message = fmt.Sprintf("UnknownCompilerError: %s", message)
-	cleanStack := message
-	for _, v := range strings.Split(stack, "\n") {
-		matches := FN_NAME_RE.FindAllString(v, -1)
-		if len(matches) > 0 {
-			name := strings.Split(matches[0], "(")[0]
-			if name == "panic" {
-				cleanStack = message
-				continue
-			}
-			cleanStack += fmt.Sprintf("\n    at %s", strings.Split(matches[0], "(")[0])
-			hasFnName = true
-		} else if hasFnName {
-			url := strings.Split(strings.Split(strings.TrimSpace(v), " ")[0], "/compiler/")[1]
-			cleanStack += fmt.Sprintf(" (@astrojs/compiler/%s)", url)
-			hasFnName = false
-		}
-	}
-	jsError := JSError{
-		Message: message,
-		Stack:   cleanStack,
-	}
-	return jsError.Value()
 }

--- a/internal_wasm/utils/utils.go
+++ b/internal_wasm/utils/utils.go
@@ -1,7 +1,6 @@
 package wasm_utils
 
 import (
-	"fmt"
 	"regexp"
 	"runtime/debug"
 	"strings"
@@ -71,31 +70,9 @@ var FN_NAME_RE = regexp.MustCompile(`(\w+)\([^)]+\)$`)
 func ErrorToJSError(h *handler.Handler, err error) js.Value {
 	stack := string(debug.Stack())
 	message := strings.TrimSpace(err.Error())
-	if strings.Contains(message, ":") {
-		message = strings.TrimSpace(strings.Split(message, ":")[1])
-	}
-	hasFnName := false
-	message = fmt.Sprintf("UnknownCompilerError: %s", message)
-	cleanStack := message
-	for _, v := range strings.Split(stack, "\n") {
-		matches := FN_NAME_RE.FindAllString(v, -1)
-		if len(matches) > 0 {
-			name := strings.Split(matches[0], "(")[0]
-			if name == "panic" {
-				cleanStack = message
-				continue
-			}
-			cleanStack += fmt.Sprintf("\n    at %s", strings.Split(matches[0], "(")[0])
-			hasFnName = true
-		} else if hasFnName {
-			url := strings.Split(strings.Split(strings.TrimSpace(v), " ")[0], "/compiler/")[1]
-			cleanStack += fmt.Sprintf(" (@astrojs/compiler/%s)", url)
-			hasFnName = false
-		}
-	}
 	jsError := JSError{
 		Message: message,
-		Stack:   cleanStack,
+		Stack:   stack,
 	}
 	return jsError.Value()
 }

--- a/internal_wasm/utils/utils.go
+++ b/internal_wasm/utils/utils.go
@@ -65,8 +65,6 @@ func (err *JSError) Value() js.Value {
 	return vert.ValueOf(err).Value
 }
 
-var FN_NAME_RE = regexp.MustCompile(`(\w+)\([^)]+\)$`)
-
 func ErrorToJSError(h *handler.Handler, err error) js.Value {
 	stack := string(debug.Stack())
 	message := strings.TrimSpace(err.Error())

--- a/internal_wasm/utils/utils.go
+++ b/internal_wasm/utils/utils.go
@@ -1,9 +1,15 @@
 package wasm_utils
 
 import (
+	"fmt"
+	"regexp"
+	"runtime/debug"
+	"strings"
 	"syscall/js"
 
+	"github.com/norunners/vert"
 	astro "github.com/withastro/compiler/internal"
+	"github.com/withastro/compiler/internal/handler"
 )
 
 // See https://stackoverflow.com/questions/68426700/how-to-wait-a-js-async-function-from-golang-wasm
@@ -49,4 +55,47 @@ func GetAttrs(n *astro.Node) js.Value {
 		}
 	}
 	return attrs
+}
+
+type JSError struct {
+	Message string `js:"message"`
+	Stack   string `js:"stack"`
+}
+
+func (err *JSError) Value() js.Value {
+	return vert.ValueOf(err).Value
+}
+
+var FN_NAME_RE = regexp.MustCompile(`(\w+)\([^)]+\)$`)
+
+func ErrorToJSError(h *handler.Handler, err error) js.Value {
+	stack := string(debug.Stack())
+	message := strings.TrimSpace(err.Error())
+	if strings.Contains(message, ":") {
+		message = strings.TrimSpace(strings.Split(message, ":")[1])
+	}
+	hasFnName := false
+	message = fmt.Sprintf("UnknownCompilerError: %s", message)
+	cleanStack := message
+	for _, v := range strings.Split(stack, "\n") {
+		matches := FN_NAME_RE.FindAllString(v, -1)
+		if len(matches) > 0 {
+			name := strings.Split(matches[0], "(")[0]
+			if name == "panic" {
+				cleanStack = message
+				continue
+			}
+			cleanStack += fmt.Sprintf("\n    at %s", strings.Split(matches[0], "(")[0])
+			hasFnName = true
+		} else if hasFnName {
+			url := strings.Split(strings.Split(strings.TrimSpace(v), " ")[0], "/compiler/")[1]
+			cleanStack += fmt.Sprintf(" (@astrojs/compiler/%s)", url)
+			hasFnName = false
+		}
+	}
+	jsError := JSError{
+		Message: message,
+		Stack:   cleanStack,
+	}
+	return jsError.Value()
 }

--- a/internal_wasm/utils/utils.go
+++ b/internal_wasm/utils/utils.go
@@ -1,7 +1,6 @@
 package wasm_utils
 
 import (
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"syscall/js"


### PR DESCRIPTION
## Changes

- This adds some logic to intercept and format `panic`s so that we actually reject the `transform` promise with the correct error instead of just printing the error to stdout.
- ~~Trims irrelevant info from the stacktrace and formats to more helpful internal file location.~~
- ~~Formats errors similarly to JS stacktraces so that they don't confuse users~~
- Related to https://github.com/withastro/astro/pull/5855

## Testing

Tested manually

| Before 	| After 	|
|:------:	|:-----:	|
| <img width="400" alt="old stacktrace" src="https://user-images.githubusercontent.com/7118177/212566271-007d1817-048a-4504-9d5d-7dcd41805de7.png"> | <img width="400" alt="new stacktrace" src="https://user-images.githubusercontent.com/7118177/212566263-dd1a7e99-b2c0-4943-92f2-acc94b996c7e.png"> |

## Docs

N/A, QoL improvement