### PR TITLE
Pass through result to slot

### DIFF
--- a/.changeset/pink-maps-sip.md
+++ b/.changeset/pink-maps-sip.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Allow passing through result to slot call

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -91,6 +91,11 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		compact = true
 	}
 
+	scopedSlot := false
+	if jsBool(options.Get("resultScopedSlot")) {
+		scopedSlot = true
+	}
+
 	var resolvePath any = options.Get("resolvePath")
 	var resolvePathFn func(string) string
 	if resolvePath.(js.Value).Type() == js.TypeFunction {
@@ -115,6 +120,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		Compact:            compact,
 		ResolvePath:        resolvePathFn,
 		PreprocessStyle:    preprocessStyle,
+		ResultScopedSlot:   scopedSlot,
 	}
 }
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -604,7 +604,14 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				if len(slottedKeys) > 0 {
 					for _, slotProp := range slottedKeys {
 						children := slottedChildren[slotProp]
-						p.print(fmt.Sprintf(`%s: ($$result) => `, slotProp))
+
+						// If selected, pass through result object on the Astro side
+						if opts.opts.ResultScopedSlot {
+							p.print(fmt.Sprintf(`%s: ($$result) => `, slotProp))
+						} else {
+							p.print(fmt.Sprintf(`%s: () => `, slotProp))
+						}
+
 						p.printTemplateLiteralOpen()
 						for _, child := range children {
 							render1(p, child, RenderOptions{

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -604,7 +604,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				if len(slottedKeys) > 0 {
 					for _, slotProp := range slottedKeys {
 						children := slottedChildren[slotProp]
-						p.print(fmt.Sprintf(`%s: () => `, slotProp))
+						p.print(fmt.Sprintf(`%s: ($$result) => `, slotProp))
 						p.printTemplateLiteralOpen()
 						for _, child := range children {
 							render1(p, child, RenderOptions{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -21,6 +21,7 @@ type TransformOptions struct {
 	SourceMap          string
 	AstroGlobalArgs    string
 	Compact            bool
+	ResultScopedSlot   bool
 	ResolvePath        func(string) string
 	PreprocessStyle    interface{}
 }

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -49,6 +49,7 @@ export interface TransformOptions {
   sourcemap?: boolean | 'inline' | 'external' | 'both';
   astroGlobalArgs?: string;
   compact?: boolean;
+  resultScopedSlot?: boolean;
   /**
    * @deprecated "as" has been removed and no longer has any effect!
    */

--- a/packages/compiler/test/slot-result/result.ts
+++ b/packages/compiler/test/slot-result/result.ts
@@ -1,0 +1,26 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+import Parent from './Parent.astro';
+---
+<Parent>
+  <div></div>
+</Parent>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    resolvePath: async (s) => s,
+    resultScopedSlot: true,
+  });
+});
+
+test('resultScopedSlot: includes the result object in the call to the slot', () => {
+  assert.match(result.code, new RegExp(`\\(\\$\\$result\\) =>`));
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Adds the `resultScopedSlot` option. Using this option causes the slot to receive the `$$result` object. This is so that we can provide scoped result objects within the context of slots. This is used so that if head injection occurs we can conditionally on render head contents when we should; for example not to render head contents when a JSX component using an Astro component, but itself is used within a layout.
- Ideally we can remove this option in the future if we remove implicit head injection in a major version.

## Testing

- Test for the option added

## Docs

N/A