### PR TITLE
Collapse all trailing text nodes

### DIFF
--- a/.changeset/twenty-eels-notice.md
+++ b/.changeset/twenty-eels-notice.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Collapse multiple trailing text nodes if present

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -184,8 +184,10 @@ func TrimTrailingSpace(doc *astro.Node) {
 		}
 	}
 
-	if n != nil && n.Type == astro.TextNode {
+	// Collapse all trailing text nodes
+	for n != nil && n.Type == astro.TextNode {
 		n.Data = strings.TrimRightFunc(n.Data, unicode.IsSpace)
+		n = n.PrevSibling
 	}
 }
 

--- a/packages/compiler/test/basic/trailing-spaces-ii.ts
+++ b/packages/compiler/test/basic/trailing-spaces-ii.ts
@@ -1,0 +1,35 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `---
+---
+
+<span class="spoiler">
+    <slot />
+</span>
+
+<style>
+span { color: red; }
+</style>
+<script>
+console.log("hello")
+</script>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('trailing space', () => {
+  assert.ok(result.code, 'Expected to compiler');
+  assert.match(
+    result.code,
+    `<span class="spoiler astro-BQATI2K5">
+    \${$$renderSlot($$result,$$slots["default"])}
+</span>\``
+  );
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Fixes issue reported on Discord
- We would previously only collapse _one_ trailing text node
- Now we collapse _all_ trailing text nodes

## Testing

Added fixture from reported repro

## Docs

N/A, bug fix only