### PR TITLE
Implement head bubbling

### DIFF
--- a/.changeset/fast-bears-do.md
+++ b/.changeset/fast-bears-do.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Implements opt-in head bubbling

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -96,6 +96,11 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		scopedSlot = true
 	}
 
+	implicitHeadInjection := true
+	if !options.Get("implicitHeadInjection").IsUndefined() {
+		implicitHeadInjection = jsBool(options.Get("implicitHeadInjection"))
+	}
+
 	var resolvePath any = options.Get("resolvePath")
 	var resolvePathFn func(string) string
 	if resolvePath.(js.Value).Type() == js.TypeFunction {
@@ -112,15 +117,16 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	preprocessStyle := options.Get("preprocessStyle")
 
 	return transform.TransformOptions{
-		Filename:           filename,
-		NormalizedFilename: normalizedFilename,
-		InternalURL:        internalURL,
-		SourceMap:          sourcemap,
-		AstroGlobalArgs:    astroGlobalArgs,
-		Compact:            compact,
-		ResolvePath:        resolvePathFn,
-		PreprocessStyle:    preprocessStyle,
-		ResultScopedSlot:   scopedSlot,
+		Filename:              filename,
+		NormalizedFilename:    normalizedFilename,
+		InternalURL:           internalURL,
+		SourceMap:             sourcemap,
+		AstroGlobalArgs:       astroGlobalArgs,
+		Compact:               compact,
+		ResolvePath:           resolvePathFn,
+		PreprocessStyle:       preprocessStyle,
+		ResultScopedSlot:      scopedSlot,
+		ImplicitHeadInjection: implicitHeadInjection,
 	}
 }
 

--- a/internal/node.go
+++ b/internal/node.go
@@ -93,6 +93,7 @@ type Node struct {
 	ClientOnlyComponentNodes []*Node
 	ClientOnlyComponents     []*HydratedComponentMetadata
 	HydrationDirectives      map[string]bool
+	HeadNode                 *Node
 
 	Type      NodeType
 	DataAtom  atom.Atom

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -222,8 +222,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 				}
 
-				p.printReturnOpen(n)
-				renderHeadBubbling(p, c, opts)
+				p.printReturnOpen(n.Parent)
+				renderHeadBubbling(p, n.Parent, opts)
 			} else {
 				render1(p, c, RenderOptions{
 					isRoot:           false,

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -726,14 +726,18 @@ func renderHeadBubbling(p *printer, n *Node, opts RenderOptions) {
 
 	// Head argument
 	p.printTemplateLiteralOpen()
-	render1(p, headNode, RenderOptions{
-		isRoot:           false,
-		isExpression:     true,
-		depth:            depth + 1,
-		opts:             opts.opts,
-		cssLen:           opts.cssLen,
-		printedMaybeHead: opts.printedMaybeHead,
-	})
+
+	// Loop over children, don't print actual `<head>` element here.
+	for c := headNode.FirstChild; c != nil; c = c.NextSibling {
+		render1(p, c, RenderOptions{
+			isRoot:           false,
+			isExpression:     true,
+			depth:            depth + 1,
+			opts:             opts.opts,
+			cssLen:           opts.cssLen,
+			printedMaybeHead: opts.printedMaybeHead,
+		})
+	}
 	p.printTemplateLiteralClose()
 	p.print(",")
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -256,7 +256,6 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			}
 		}
 
-		fmt.Printf("DOWN HERE %v\n", n.Parent)
 		p.printReturnOpen(n.Parent)
 		renderHeadBubbling(p, n.Parent, opts)
 	}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -117,8 +117,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			})
 		}
 
-		p.printReturnClose()
-		p.printFuncSuffix(opts.opts)
+		p.printReturnClose(n)
+		p.printFuncSuffix(opts.opts, n)
 		return
 	}
 
@@ -222,7 +222,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 				}
 
-				p.printReturnOpen()
+				p.printReturnOpen(n)
+				renderHeadBubbling(p, c, opts)
 			} else {
 				render1(p, c, RenderOptions{
 					isRoot:           false,
@@ -255,7 +256,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			}
 		}
 
-		p.printReturnOpen()
+		fmt.Printf("DOWN HERE %v\n", n.Parent)
+		p.printReturnOpen(n.Parent)
+		renderHeadBubbling(p, n.Parent, opts)
 	}
 	switch n.Type {
 	case TextNode:
@@ -711,6 +714,31 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		p.addSourceMapping(loc.Loc{Start: start})
 		p.print(`>`)
 	}
+}
+
+func renderHeadBubbling(p *printer, n *Node, opts RenderOptions) {
+	if !containsHeadBubbling(n) {
+		return
+	}
+
+	depth := opts.depth
+	headNode := n.HeadNode
+
+	// Head argument
+	p.printTemplateLiteralOpen()
+	render1(p, headNode, RenderOptions{
+		isRoot:           false,
+		isExpression:     true,
+		depth:            depth + 1,
+		opts:             opts.opts,
+		cssLen:           opts.cssLen,
+		printedMaybeHead: opts.printedMaybeHead,
+	})
+	p.printTemplateLiteralClose()
+	p.print(",")
+
+	// Content argument
+	p.printTemplateLiteralOpen()
 }
 
 // Section 12.1.2, "Elements", gives this list of void elements. Void elements

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1570,6 +1570,20 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
+			name: "Head bubbling",
+			only: true,
+			source: `<head>
+				<meta property="og:title" content="Some title" />
+				<meta property="og:description" content="Some content" /></head>
+				<div>
+					<h1>Testing</h1>
+				</div>
+			`,
+			want: want{
+				code: "<head></head>\n<div class=\"astro-LASNTLJA\"></div>",
+			},
+		},
+		{
 			name: "Mixed style siblings",
 			source: `<head>
 	<style is:global>div { color: red }</style>
@@ -2464,6 +2478,8 @@ const items = ["Dog", "Cat", "Platipus"];
 			} else {
 				toMatch += SUFFIX
 			}
+
+			fmt.Println(output)
 
 			// compare to expected string, show diff if mismatch
 			if diff := test_utils.ANSIDiff(test_utils.RemoveNewlines(test_utils.Dedent(toMatch)), test_utils.RemoveNewlines(test_utils.Dedent(output))); diff != "" {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1583,8 +1583,28 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
+			name: "Head bubbling with frontmatter",
+			source: `---
+			const title = 'Blog Post';
+			const description = 'Some description';
+			---
+
+			<head>
+				<meta property="og:title" content={title} />
+				<meta property="og:description" content={description} /></head>
+			</head>
+
+			<article>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas eget commodo lacus. Sed hendrerit vel tortor in viverra. Praesent a lectus ex. Cras hendrerit ligula in sapien euismod maximus. Duis vel consectetur nibh, sed tempus est. Nullam sit amet iaculis nisl. Suspendisse efficitur libero eu magna varius faucibus a a nulla. Aliquam pretium diam ut bibendum convallis. Nullam vel mi nunc. Duis rutrum odio a magna posuere, in semper nisl dictum. Proin malesuada arcu in mi finibus, eget blandit urna varius. Ut pulvinar malesuada euismod.</p>
+				<p>Suspendisse sed erat neque. Donec est ante, venenatis ut urna a, efficitur finibus leo. Cras ut pellentesque mi. Sed non nunc tincidunt, euismod erat eu, fringilla augue. Nunc in sem a nisi luctus lacinia ut interdum turpis. Pellentesque at bibendum nunc. Etiam id felis in erat egestas ultrices. Proin cursus nulla et ligula elementum iaculis. Aenean volutpat ullamcorper purus, vitae elementum urna interdum at. Aenean ex elit, porta vitae dictum ac, mattis at justo. Aenean non augue tincidunt tellus aliquam condimentum. Nullam eu ante sed turpis lobortis iaculis.</p>
+			</article>
+			`,
+			want: want{
+				code: "<head></head>\n<div class=\"astro-LASNTLJA\"></div>",
+			},
+		},
+		{
 			name: "No head bubbling if head nested inside of HTML",
-			only: true,
 			source: `<html><head>
 				<meta property="og:title" content="Some title" />
 				<meta property="og:description" content="Some content" /></head>

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1570,14 +1570,28 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
-			name: "Head bubbling",
-			only: true,
+			name: "Head bubbling for top-level head tags",
 			source: `<head>
 				<meta property="og:title" content="Some title" />
 				<meta property="og:description" content="Some content" /></head>
 				<div>
 					<h1>Testing</h1>
 				</div>
+			`,
+			want: want{
+				code: "<head></head>\n<div class=\"astro-LASNTLJA\"></div>",
+			},
+		},
+		{
+			name: "No head bubbling if head nested inside of HTML",
+			only: true,
+			source: `<html><head>
+				<meta property="og:title" content="Some title" />
+				<meta property="og:description" content="Some content" /></head>
+				<div>
+					<h1>Testing</h1>
+				</div>
+				</html>
 			`,
 			want: want{
 				code: "<head></head>\n<div class=\"astro-LASNTLJA\"></div>",

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -326,9 +326,19 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 	}
 }
 
+func isHTMLNode(n *astro.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Type == astro.ElementNode && n.DataAtom == a.Html {
+		return !IsImplicitNode(n)
+	}
+	return false
+}
+
 func ExtractHead(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *handler.Handler) bool {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Head {
-		if n.Parent == nil || (n.Parent.Type != astro.ElementNode || n.Parent.DataAtom != a.Html) {
+		if n.Parent == nil || !isHTMLNode(n.Parent) {
 			doc.HeadNode = n
 			n.Parent.RemoveChild(n)
 			return true

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -328,7 +328,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 
 func ExtractHead(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *handler.Handler) bool {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Head {
-		if n.Parent != nil || (n.Parent.Type != astro.ElementNode || n.Parent.DataAtom != a.Html) {
+		if n.Parent == nil || (n.Parent.Type != astro.ElementNode || n.Parent.DataAtom != a.Html) {
 			doc.HeadNode = n
 			n.Parent.RemoveChild(n)
 			return true

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -50,6 +50,7 @@ export interface TransformOptions {
   astroGlobalArgs?: string;
   compact?: boolean;
   resultScopedSlot?: boolean;
+  implicitHeadInjection?: boolean;
   /**
    * @deprecated "as" has been removed and no longer has any effect!
    */


### PR DESCRIPTION
> Note that this is just a draft, for experimental purposes. Not read to merge.

## Changes

- Adds support for head bubbling. If we find a `<head>` tag that is not a child of `<html>` it is treated as needing to bubbling up to the page level. In this case it uses `$$createHeadAndContent` to provide different streams for the head and the content parts.

## Testing

- New test added
- Other tests updated (WIP)

## Docs

Not yet