### PR TITLE
fix: quoted `set` directives to not inlined as text node

### DIFF
--- a/.changeset/tall-mails-impress.md
+++ b/.changeset/tall-mails-impress.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Compile `set:html` and `set:text` quoted and templated literal attributes as strings
+Compile `set:html` and `set:text` quoted and template literal attributes as strings

--- a/.changeset/tall-mails-impress.md
+++ b/.changeset/tall-mails-impress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Compile `set:html` and `set:text` quoted and templated literal attributes as strings

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2125,14 +2125,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html with quoted attribute",
 			source: `<article set:html="content" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
 			},
 		},
 		{
-			name:   "set:html with template literal attribute",
+			name:   "set:html with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html with template literal attribute with variable",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
 			},
 		},
 		{
@@ -2150,17 +2157,45 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "set:text with template literal attribute ",
+			name:   "set:text with template literal attribute without variable",
 			source: `<article set:text=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
+			name:   "set:text with template literal attribute with variable",
+			source: `<article set:text=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
+			}},
+		{
 			name:   "set:html on Component",
-			source: "<Component set:html={content} />",
+			source: `<Component set:html={content} />`,
 			want: want{
 				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + "`${$$unescapeHTML(content)}`," + `})}`,
+			},
+		},
+		{
+			name:   "set:html on Component with quoted attribute",
+			source: `<Component set:html="content" />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML("content")}` + BACKTICK + `,})}`,
+			},
+		},
+		// on component with template literal attribute
+		{
+			name:   "set:html on Component with template literal attribute without variable",
+			source: `<Component set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}` + BACKTICK + `,})}`,
+			},
+		},
+		{
+			name:   "set:html on Component with template literal attribute with variable",
+			source: `<Component set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -2171,10 +2206,54 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:text on Component with quoted attribute",
+			source: `<Component set:text="content" />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `content` + BACKTICK + `,})}`,
+			},
+		},
+		// on component with template literal attribute
+		{
+			name:   "set:text on Component with template literal attribute without variable",
+			source: `<Component set:text=` + BACKTICK + `content` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `content` + BACKTICK + `}` + BACKTICK + `,})}`,
+			},
+		},
+		{
+			name:   "set:text on Component with template literal attribute with variable",
+			source: `<Component set:text=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `${content}` + BACKTICK + `}` + BACKTICK + `,})}`,
+			},
+		},
+		{
 			name:   "set:html on custom-element",
 			source: "<custom-element set:html={content} />",
 			want: want{
 				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + "`${$$unescapeHTML(content)}`," + `})}`,
+			},
+		},
+		{
+			name:   "set:html on custom-element with quoted attribute",
+			source: `<custom-element set:html="content" />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML("content")}` + BACKTICK + `,})}`,
+			},
+		},
+		// on custom element with template literal attribute
+		{
+			name:   "set:html on custom-element with template literal attribute without variable",
+			source: `<custom-element set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}` + BACKTICK + `,})}`,
+			},
+		},
+		{
+			name:   "set:html on custom-element with template literal attribute with variable",
+			source: `<custom-element set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -2185,10 +2264,53 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:text on custom-element with quoted attribute",
+			source: `<custom-element set:text="content" />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `content` + BACKTICK + `,})}`,
+			},
+		},
+		{
+			name:   "set:text on custom-element with template literal attribute without variable",
+			source: `<custom-element set:text=` + BACKTICK + `content` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `content` + BACKTICK + `}` + BACKTICK + `,})}`,
+			},
+		},
+		{
+			name:   "set:text on custom-element with template literal attribute with variable",
+			source: `<custom-element set:text=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `${content}` + BACKTICK + `}` + BACKTICK + `,})}`,
+			},
+		},
+		{
 			name:   "set:html on self-closing tag",
 			source: "<article set:html={content} />",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
+			},
+		},
+		{
+			name:   "set:html on self-closing tag with quoted attribute",
+			source: `<article set:html="content" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		// on self-closing tag with template literal attribute
+		{
+			name:   "set:html on self-closing tag with template literal attribute without variable",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html on self-closing tag with template literal attribute with variable",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
 			},
 		},
 		{
@@ -2198,11 +2320,57 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(content)}</article>`,
 			},
 		},
+		// with other attributes and quoted attribute
+		{
+			name:   "set:html with quoted attribute and other attributes",
+			source: `<article set:html="content" cool="true" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		// with other attributes and template literal attribute
+		{
+			name:   "set:html with template literal attribute without variable and other attributes",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` cool="true" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html with template literal attribute with variable and other attributes",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` cool="true" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+			},
+		},
 		{
 			name:   "set:html on empty tag",
 			source: "<article set:html={content}></article>",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
+			},
+		},
+		// on empty tag with quoted attribute
+		{
+			name:   "set:html on empty tag with quoted attribute",
+			source: `<article set:html="content"></article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		// on empty tag with template literal attribute
+		{
+			name:   "set:html on empty tag with template literal attribute without variable",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `></article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html on empty tag with template literal attribute with variable",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `></article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
 			},
 		},
 		{
@@ -2213,11 +2381,34 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
+		//
 		{
 			name:   "set:html on tag with children",
 			source: "<article set:html={content}>!!!</article>",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
+			},
+		},
+		// on tag with children and quoted attribute
+		{
+			name:   "set:html on tag with children and quoted attribute",
+			source: `<article set:html="content">!!!</article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		{
+			name:   "set:html on tag with children and template literal attribute without variable",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `>!!!</article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html on tag with children and template literal attribute with variable",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `>!!!</article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
 			},
 		},
 		{
@@ -2228,10 +2419,52 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:html on tag with empty whitespace and quoted attribute",
+			source: `<article set:html="content">   </article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		{
+			name:   "set:html on tag with empty whitespace and template literal attribute without variable",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `>   </article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
+			name:   "set:html on tag with empty whitespace and template literal attribute with variable",
+			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `>   </article>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+			},
+		},
+		{
 			name:   "set:html on script",
 			source: "<script set:html={content} />",
 			want: want{
 				code: `<script>${$$unescapeHTML(content)}</script>`,
+			},
+		},
+		{
+			name:   "set:html on script with quoted attribute",
+			source: `<script set:html="alert(1)" />`,
+			want: want{
+				code: `<script>${$$unescapeHTML("alert(1)")}</script>`,
+			},
+		},
+		{
+			name:   "set:html on script with template literal attribute without variable",
+			source: `<script set:html=` + BACKTICK + `alert(1)` + BACKTICK + ` />`,
+			want: want{
+				code: `<script>${$$unescapeHTML(` + BACKTICK + `alert(1)` + BACKTICK + `)}</script>`,
+			},
+		},
+		{
+			name:   "set:html on script with template literal attribute with variable",
+			source: `<script set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `<script>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</script>`,
 			},
 		},
 		{
@@ -2242,10 +2475,52 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:html on style with quoted attribute",
+			source: `<style set:html="h1{color:green;}" />`,
+			want: want{
+				code: `<style>${$$unescapeHTML("h1{color:green;}")}</style>`,
+			},
+		},
+		{
+			name:   "set:html on style with template literal attribute without variable",
+			source: `<style set:html=` + BACKTICK + `h1{color:green;}` + BACKTICK + ` />`,
+			want: want{
+				code: `<style>${$$unescapeHTML(` + BACKTICK + `h1{color:green;}` + BACKTICK + `)}</style>`,
+			},
+		},
+		{
+			name:   "set:html on style with template literal attribute with variable",
+			source: `<style set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `<style>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</style>`,
+			},
+		},
+		{
 			name:   "set:html on Fragment",
 			source: "<Fragment set:html={\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\"} />",
 			want: want{
 				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\")}`,})}",
+			},
+		},
+		{
+			name:   "set:html on Fragment with quoted attribute",
+			source: "<Fragment set:html=\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\" />",
+			want: want{
+				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(\"<p><i>This should NOT be italic</i></p>\")}`,})}",
+			},
+		},
+		{
+			name:   "set:html on Fragment with template literal attribute without variable",
+			source: "<Fragment set:html=`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>` />",
+			want: want{
+				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(`<p><i>This should NOT be italic</i></p>`)}`,})}",
+			},
+		},
+		{
+			name:   "set:html on Fragment with template literal attribute with variable",
+			source: `<Fragment set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2122,10 +2122,24 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "set:html with quoted value",
+			source: `<article set:html="content" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+			},
+		},
+		{
 			name:   "set:text",
 			source: "<article set:text={content} />",
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>${content}</article>`,
+			},
+		},
+		{
+			name:   "set:text with quoted value",
+			source: `<article set:text="content" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2125,7 +2125,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html with quoted value",
 			source: `<article set:html="content" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
 			},
 		},
 		{
@@ -2139,7 +2139,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:text with quoted value",
 			source: `<article set:text="content" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2122,8 +2122,15 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "set:html with quoted value",
+			name:   "set:html with quoted attribute",
 			source: `<article set:html="content" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
+			},
+		},
+		{
+			name:   "set:html with template literal attribute",
+			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
 			},
@@ -2136,8 +2143,15 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "set:text with quoted value",
+			name:   "set:text with quoted attribute",
 			source: `<article set:text="content" />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
+			},
+		},
+		{
+			name:   "set:text with template literal attribute ",
+			source: `<article set:text=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<article>content</article>`,
 			},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2183,7 +2183,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${"content"}` + BACKTICK + `,})}`,
 			},
 		},
-		// on component with template literal attribute
 		{
 			name:   "set:html on Component with template literal attribute without variable",
 			source: `<Component set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
@@ -2212,7 +2211,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `content` + BACKTICK + `,})}`,
 			},
 		},
-		// on component with template literal attribute
 		{
 			name:   "set:text on Component with template literal attribute without variable",
 			source: `<Component set:text=` + BACKTICK + `content` + BACKTICK + ` />`,
@@ -2241,7 +2239,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${"content"}` + BACKTICK + `,})}`,
 			},
 		},
-		// on custom element with template literal attribute
 		{
 			name:   "set:html on custom-element with template literal attribute without variable",
 			source: `<custom-element set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
@@ -2298,7 +2295,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
-		// on self-closing tag with template literal attribute
 		{
 			name:   "set:html on self-closing tag with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
@@ -2320,7 +2316,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(content)}</article>`,
 			},
 		},
-		// with other attributes and quoted attribute
 		{
 			name:   "set:html with quoted attribute and other attributes",
 			source: `<article set:html="content" cool="true" />`,
@@ -2328,7 +2323,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article cool="true">${"content"}</article>`,
 			},
 		},
-		// with other attributes and template literal attribute
 		{
 			name:   "set:html with template literal attribute without variable and other attributes",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` cool="true" />`,
@@ -2350,7 +2344,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
-		// on empty tag with quoted attribute
 		{
 			name:   "set:html on empty tag with quoted attribute",
 			source: `<article set:html="content"></article>`,
@@ -2358,7 +2351,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
-		// on empty tag with template literal attribute
 		{
 			name:   "set:html on empty tag with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `></article>`,
@@ -2389,7 +2381,6 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(content)}</article>`,
 			},
 		},
-		// on tag with children and quoted attribute
 		{
 			name:   "set:html on tag with children and quoted attribute",
 			source: `<article set:html="content">!!!</article>`,

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2125,21 +2125,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html with quoted attribute",
 			source: `<article set:html="content" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		{
 			name:   "set:html with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html with template literal attribute with variable",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2180,7 +2180,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on Component with quoted attribute",
 			source: `<Component set:html="content" />`,
 			want: want{
-				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML("content")}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${"content"}` + BACKTICK + `,})}`,
 			},
 		},
 		// on component with template literal attribute
@@ -2188,14 +2188,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on Component with template literal attribute without variable",
 			source: `<Component set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `content` + BACKTICK + `}` + BACKTICK + `,})}`,
 			},
 		},
 		{
 			name:   "set:html on Component with template literal attribute with variable",
 			source: `<Component set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `${content}` + BACKTICK + `}` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -2238,7 +2238,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on custom-element with quoted attribute",
 			source: `<custom-element set:html="content" />`,
 			want: want{
-				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML("content")}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${"content"}` + BACKTICK + `,})}`,
 			},
 		},
 		// on custom element with template literal attribute
@@ -2246,14 +2246,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on custom-element with template literal attribute without variable",
 			source: `<custom-element set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `content` + BACKTICK + `}` + BACKTICK + `,})}`,
 			},
 		},
 		{
 			name:   "set:html on custom-element with template literal attribute with variable",
 			source: `<custom-element set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'custom-element','custom-element',{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `${content}` + BACKTICK + `}` + BACKTICK + `,})}`,
 			},
 		},
 		{
@@ -2295,7 +2295,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on self-closing tag with quoted attribute",
 			source: `<article set:html="content" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		// on self-closing tag with template literal attribute
@@ -2303,14 +2303,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on self-closing tag with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html on self-closing tag with template literal attribute with variable",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2325,7 +2325,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html with quoted attribute and other attributes",
 			source: `<article set:html="content" cool="true" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${"content"}</article>`,
 			},
 		},
 		// with other attributes and template literal attribute
@@ -2333,14 +2333,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html with template literal attribute without variable and other attributes",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + ` cool="true" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html with template literal attribute with variable and other attributes",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + ` cool="true" />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article cool="true">${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article cool="true">${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2355,7 +2355,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on empty tag with quoted attribute",
 			source: `<article set:html="content"></article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		// on empty tag with template literal attribute
@@ -2363,14 +2363,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on empty tag with template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `></article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html on empty tag with template literal attribute with variable",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `></article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2394,21 +2394,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on tag with children and quoted attribute",
 			source: `<article set:html="content">!!!</article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with children and template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `>!!!</article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with children and template literal attribute with variable",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `>!!!</article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2422,21 +2422,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on tag with empty whitespace and quoted attribute",
 			source: `<article set:html="content">   </article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML("content")}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${"content"}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with empty whitespace and template literal attribute without variable",
 			source: `<article set:html=` + BACKTICK + `content` + BACKTICK + `>   </article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `content` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `content` + BACKTICK + `}</article>`,
 			},
 		},
 		{
 			name:   "set:html on tag with empty whitespace and template literal attribute with variable",
 			source: `<article set:html=` + BACKTICK + `${content}` + BACKTICK + `>   </article>`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<article>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</article>`,
+				code: `${$$maybeRenderHead($$result)}<article>${` + BACKTICK + `${content}` + BACKTICK + `}</article>`,
 			},
 		},
 		{
@@ -2450,21 +2450,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on script with quoted attribute",
 			source: `<script set:html="alert(1)" />`,
 			want: want{
-				code: `<script>${$$unescapeHTML("alert(1)")}</script>`,
+				code: `<script>${"alert(1)"}</script>`,
 			},
 		},
 		{
 			name:   "set:html on script with template literal attribute without variable",
 			source: `<script set:html=` + BACKTICK + `alert(1)` + BACKTICK + ` />`,
 			want: want{
-				code: `<script>${$$unescapeHTML(` + BACKTICK + `alert(1)` + BACKTICK + `)}</script>`,
+				code: `<script>${` + BACKTICK + `alert(1)` + BACKTICK + `}</script>`,
 			},
 		},
 		{
 			name:   "set:html on script with template literal attribute with variable",
 			source: `<script set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `<script>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</script>`,
+				code: `<script>${` + BACKTICK + `${content}` + BACKTICK + `}</script>`,
 			},
 		},
 		{
@@ -2478,21 +2478,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on style with quoted attribute",
 			source: `<style set:html="h1{color:green;}" />`,
 			want: want{
-				code: `<style>${$$unescapeHTML("h1{color:green;}")}</style>`,
+				code: `<style>${"h1{color:green;}"}</style>`,
 			},
 		},
 		{
 			name:   "set:html on style with template literal attribute without variable",
 			source: `<style set:html=` + BACKTICK + `h1{color:green;}` + BACKTICK + ` />`,
 			want: want{
-				code: `<style>${$$unescapeHTML(` + BACKTICK + `h1{color:green;}` + BACKTICK + `)}</style>`,
+				code: `<style>${` + BACKTICK + `h1{color:green;}` + BACKTICK + `}</style>`,
 			},
 		},
 		{
 			name:   "set:html on style with template literal attribute with variable",
 			source: `<style set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `<style>${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}</style>`,
+				code: `<style>${` + BACKTICK + `${content}` + BACKTICK + `}</style>`,
 			},
 		},
 		{
@@ -2506,21 +2506,21 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "set:html on Fragment with quoted attribute",
 			source: "<Fragment set:html=\"<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>\" />",
 			want: want{
-				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(\"<p><i>This should NOT be italic</i></p>\")}`,})}",
+				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${\"<p><i>This should NOT be italic</i></p>\"}`,})}",
 			},
 		},
 		{
 			name:   "set:html on Fragment with template literal attribute without variable",
 			source: "<Fragment set:html=`<p>&#x3C;i>This should NOT be italic&#x3C;/i></p>` />",
 			want: want{
-				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${$$unescapeHTML(`<p><i>This should NOT be italic</i></p>`)}`,})}",
+				code: "${$$renderComponent($$result,'Fragment',Fragment,{},{\"default\": () => $$render`${`<p><i>This should NOT be italic</i></p>`}`,})}",
 			},
 		},
 		{
 			name:   "set:html on Fragment with template literal attribute with variable",
 			source: `<Fragment set:html=` + BACKTICK + `${content}` + BACKTICK + ` />`,
 			want: want{
-				code: `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `${content}` + BACKTICK + `)}` + BACKTICK + `,})}`,
+				code: `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${` + BACKTICK + `${content}` + BACKTICK + `}` + BACKTICK + `,})}`,
 			},
 		},
 		{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -125,22 +125,45 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 		for i, n := range nodes {
 			directive := directives[i]
 			n.RemoveAttribute(directive.Key)
-			expr := &astro.Node{
-				Type:       astro.ElementNode,
-				Data:       "astro:expression",
-				Expression: true,
+			var expr *astro.Node
+			var textNode *astro.Node
+			var isExpression bool
+			var isLiteral bool
+			switch directive.Type {
+			case astro.ExpressionAttribute:
+				isExpression = true
+				expr = &astro.Node{
+					Type:       astro.ElementNode,
+					Data:       "astro:expression",
+					Expression: true,
+				}
+			case astro.QuotedAttribute, astro.TemplateLiteralAttribute:
+				isLiteral = true
 			}
+
 			l := make([]loc.Loc, 1)
 			l = append(l, directive.ValLoc)
 			data := directive.Val
-			if directive.Key == "set:html" {
+			if directive.Key == "set:html" && isExpression {
 				data = fmt.Sprintf("$$unescapeHTML(%s)", data)
 			}
-			expr.AppendChild(&astro.Node{
-				Type: astro.TextNode,
-				Data: data,
-				Loc:  l,
-			})
+
+			var addedNode *astro.Node
+			if isExpression {
+				expr.AppendChild(&astro.Node{
+					Type: astro.TextNode,
+					Data: data,
+					Loc:  l,
+				})
+				addedNode = expr
+			} else if isLiteral {
+				textNode = &astro.Node{
+					Type: astro.TextNode,
+					Data: directive.Val,
+					Loc:  l,
+				}
+				addedNode = textNode
+			}
 
 			shouldWarn := false
 			// Remove all existing children
@@ -158,7 +181,7 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 					Hint:  "Remove the child nodes to suppress this warning.",
 				})
 			}
-			n.AppendChild(expr)
+			n.AppendChild(addedNode)
 		}
 	}
 }

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -127,33 +127,29 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 			n.RemoveAttribute(directive.Key)
 
 			var nodeToAppend *astro.Node
-			var isTemplateLiteral bool
-			var isQuoted bool
-			var isExpression bool
+			var shouldWrapInQuotes,
+				isTemplateLiteralAttribute,
+				isQuotedAttribute,
+				isExpressionAttribute,
+				shouldWrapInTemplateLiteral,
+				shouldAddExpression bool
 
 			switch directive.Type {
 			case astro.QuotedAttribute:
-				isQuoted = true
+				isQuotedAttribute = true
 			case astro.TemplateLiteralAttribute:
-				isTemplateLiteral = true
+				isTemplateLiteralAttribute = true
 			case astro.ExpressionAttribute:
-				isExpression = true
+				isExpressionAttribute = true
 			}
 
-			// should be wrapped in quotes
-			var shouldWrapInQuotes bool
-			if directive.Key == "set:html" && isQuoted {
+			if directive.Key == "set:html" && isQuotedAttribute {
 				shouldWrapInQuotes = true
 			}
-			// should be wrapped in template literal
-			var shouldWrapInTemplateLiteral bool
-			if (directive.Key == "set:html" || directive.Key == "set:text") && isTemplateLiteral {
+			if isTemplateLiteralAttribute {
 				shouldWrapInTemplateLiteral = true
 			}
-
-			// should be expression
-			var shouldAddExpression bool
-			if directive.Key == "set:html" || (directive.Key == "set:text" && isTemplateLiteral) || isExpression {
+			if directive.Key == "set:html" || (directive.Key == "set:text" && isTemplateLiteralAttribute) || isExpressionAttribute {
 				shouldAddExpression = true
 			}
 
@@ -169,7 +165,7 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 				data = fmt.Sprintf("`%s`", data)
 			}
 
-			if directive.Key == "set:html" && isExpression {
+			if directive.Key == "set:html" && isExpressionAttribute {
 				data = fmt.Sprintf("$$unescapeHTML(%s)", data)
 			}
 			if shouldAddExpression {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -129,12 +129,15 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 			var nodeToAppend *astro.Node
 			var isTemplateLiteral bool
 			var isQuoted bool
+			var isExpression bool
 
 			switch directive.Type {
 			case astro.QuotedAttribute:
 				isQuoted = true
 			case astro.TemplateLiteralAttribute:
 				isTemplateLiteral = true
+			case astro.ExpressionAttribute:
+				isExpression = true
 			}
 
 			// should be wrapped in quotes
@@ -149,9 +152,9 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 			}
 
 			// should be expression
-			var shouldBeExpression bool
-			if directive.Key == "set:html" || (directive.Key == "set:text" && isTemplateLiteral) || directive.Type == astro.ExpressionAttribute {
-				shouldBeExpression = true
+			var shouldAddExpression bool
+			if directive.Key == "set:html" || (directive.Key == "set:text" && isTemplateLiteral) || isExpression {
+				shouldAddExpression = true
 			}
 
 			l := make([]loc.Loc, 1)
@@ -166,10 +169,10 @@ func NormalizeSetDirectives(doc *astro.Node, h *handler.Handler) {
 				data = fmt.Sprintf("`%s`", data)
 			}
 
-			if directive.Key == "set:html" {
+			if directive.Key == "set:html" && isExpression {
 				data = fmt.Sprintf("$$unescapeHTML(%s)", data)
 			}
-			if shouldBeExpression {
+			if shouldAddExpression {
 				nodeToAppend = &astro.Node{
 					Type:       astro.ElementNode,
 					Data:       "astro:expression",


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/compiler/issues/735

Makes a text node the value of `set:html` and `set:text` directives when using quoted or template literal attributes

## Testing

Added tests to check if `set` directives using quoted or template literal attributes compile to text nodes

## Docs

bug fix only
