### PR TITLE
Add teardown API

### DIFF
--- a/.changeset/weak-seals-serve.md
+++ b/.changeset/weak-seals-serve.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': minor
 ---
 
-Add teardown API to free up memory after using the compiler
+Add teardown API to remove WASM instance after using the compiler

--- a/.changeset/weak-seals-serve.md
+++ b/.changeset/weak-seals-serve.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Add teardown API to free up memory after using the compiler

--- a/packages/compiler/browser/index.ts
+++ b/packages/compiler/browser/index.ts
@@ -17,6 +17,12 @@ interface Service {
 let initializePromise: Promise<Service> | undefined;
 let longLivedService: Service | undefined;
 
+export const teardown: typeof types.teardown = () => {
+  initializePromise = undefined;
+  longLivedService = undefined;
+  (globalThis as any)['@astrojs/compiler'] = undefined;
+};
+
 export const initialize: typeof types.initialize = async (options) => {
   let wasmURL = options.wasmURL;
   if (!wasmURL) throw new Error('Must provide the "wasmURL" option');

--- a/packages/compiler/node/index.ts
+++ b/packages/compiler/node/index.ts
@@ -29,6 +29,11 @@ interface Service {
 
 let longLivedService: Promise<Service> | undefined;
 
+export const teardown: typeof types.teardown = () => {
+  longLivedService = undefined;
+  (globalThis as any)['@astrojs/compiler'] = undefined;
+};
+
 let getService = (): Promise<Service> => {
   if (!longLivedService) {
     longLivedService = startRunningService().catch((err) => {

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -131,7 +131,16 @@ export declare function convertToTSX(input: string, options?: ConvertToTSXOption
 // Works in browser: yes ("options" is required)
 export declare function initialize(options: InitializeOptions): Promise<void>;
 
-// Clears internal cache to release memory usage
+/**
+ * When calling the core compiler APIs, e.g. `transform`, `parse`, etc, they
+ * would automatically instantiate a WASM instance to process the input. When
+ * done, you can call this to manually teardown the WASM instance.
+ *
+ * If the APIs are called again, they will automatically instantiate a new WASM
+ * instance. In browsers, you have to call `initialize()` again before using the APIs.
+ *
+ * Note: Calling teardown is optional and exists mostly as an optimization only.
+ */
 export declare function teardown(): void;
 
 export interface InitializeOptions {

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -131,6 +131,9 @@ export declare function convertToTSX(input: string, options?: ConvertToTSXOption
 // Works in browser: yes ("options" is required)
 export declare function initialize(options: InitializeOptions): Promise<void>;
 
+// Clears internal cache to release memory usage
+export declare function teardown(): void;
+
 export interface InitializeOptions {
   // The URL of the "astro.wasm" file. This must be provided when running
   // astro in the browser.

--- a/packages/compiler/test/teardown/parse.ts
+++ b/packages/compiler/test/teardown/parse.ts
@@ -8,6 +8,7 @@ test('parse still works after teardown', async () => {
   const ast1 = await parse(FIXTURE);
   assert.ok(ast1);
   teardown();
+  // Make sure `parse` creates a new WASM instance after teardown removed the previous one
   const ast2 = await parse(FIXTURE);
   assert.ok(ast2);
 });

--- a/packages/compiler/test/teardown/parse.ts
+++ b/packages/compiler/test/teardown/parse.ts
@@ -1,0 +1,15 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { parse, teardown } from '@astrojs/compiler';
+
+const FIXTURE = `<div>hello</div>`;
+
+test('parse still works after teardown', async () => {
+  const ast1 = await parse(FIXTURE);
+  assert.ok(ast1);
+  teardown();
+  const ast2 = await parse(FIXTURE);
+  assert.ok(ast2);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Allow calling `teardown()` to free up memory. It's fine to continue calling `parse` or `transform` again, just that the previous cache would be gone.

It would be great to not need to call this, but the "caching" seems to be in the [Go class in wasm_exec.ts](https://github.com/withastro/compiler/blob/db033b6d88096abd439d2f8995323ad106255997/packages/compiler/node/wasm_exec.ts#L51), and they are cached in `_values` specifically, presumably at

https://github.com/withastro/compiler/blob/db033b6d88096abd439d2f8995323ad106255997/packages/compiler/node/wasm_exec.ts#L116

I'm not familiar with what it's doing so I figured to leave it be for now.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a simple teardown test, and make sure other APIs still work after tearing down.

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
n/a