### PR TITLE
Add `<noscript/>` to allowed head elements

### DIFF
--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -359,7 +359,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		// Before the first non-head element, inject $$maybeRender($$result)
 		// This is for pages that do not contain an explicit head element
 		switch n.DataAtom {
-		case atom.Html, atom.Head, atom.Base, atom.Basefont, atom.Bgsound, atom.Link, atom.Meta, atom.Noframes, atom.Script, atom.Style, atom.Template, atom.Title:
+		case atom.Html, atom.Head, atom.Base, atom.Basefont, atom.Bgsound, atom.Link, atom.Meta, atom.Noframes, atom.Noscript, atom.Script, atom.Style, atom.Template, atom.Title:
 			break
 		default:
 			if !*opts.printedMaybeHead {


### PR DESCRIPTION
## Changes

- Adds `<noscript>` to the allowed head elements
- This prevents injecting Astro assets too early in the head

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

unsure how to test, maybe a fixure like the one in https://discord.com/channels/830184174198718474/1078802894050054144?

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Bugfix, docs unneeded