### PR TITLE
Fix `define:vars` when used with a `style` attribute

### DIFF
--- a/.changeset/tame-pillows-shake.md
+++ b/.changeset/tame-pillows-shake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix `define:vars` when used with a `style` attribute

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2537,6 +2537,38 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "define:vars on style tag with style shorthand attribute on element",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 {style}>testing</h1>",
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(style + $$definedVars, "style")} class="astro-YIEFZSDV">testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
+			name:   "define:vars on style tag with style empty attribute on element",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style>testing</h1>",
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute($$definedVars, "style")} class="astro-YVZW3G7H">testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
+			name:   "define:vars on style tag with style quoted attribute on element",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style='color: yellow;'>testing</h1>",
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${"color: yellow;"} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-RRT5RQ2H">testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
+			name:   "define:vars on style tag with style template literal attribute on element",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style=`color: ${color};`>testing</h1>",
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${` + BACKTICK + `color: ${color};` + BACKTICK + `} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-33XVGAES">testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
 			name:   "multiple define:vars on style",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><style define:vars={{color:'red'}}>h2{color:var(--color)}</style><h1>foo</h1><h2>bar</h2>",
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2540,7 +2540,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "define:vars on style tag with style shorthand attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 {style}>testing</h1>",
 			want: want{
-				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(style + $$definedVars, "style")} class="astro-YIEFZSDV">testing</h1>`,
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${style}; ${$$definedVars}` + BACKTICK + `, "style")} class="astro-YIEFZSDV">testing</h1>`,
 				definedVars: []string{"{color:'green'}"},
 			},
 		},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2548,7 +2548,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "define:vars on style tag with style expression attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style={myStyles}>testing</h1>",
 			want: want{
-				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${myStyles} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-ZWHEDDU6">testing</h1>`,
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${myStyles}; ${$$definedVars}` + BACKTICK + `, "style")} class="astro-ZWHEDDU6">testing</h1>`,
 				definedVars: []string{"{color:'green'}"},
 			},
 		},
@@ -2564,7 +2564,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "define:vars on style tag with style quoted attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style='color: yellow;'>testing</h1>",
 			want: want{
-				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${"color: yellow;"} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-RRT5RQ2H">testing</h1>`,
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${"color: yellow;"}; ${$$definedVars}` + BACKTICK + `, "style")} class="astro-RRT5RQ2H">testing</h1>`,
 				definedVars: []string{"{color:'green'}"},
 			},
 		},
@@ -2572,7 +2572,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "define:vars on style tag with style template literal attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style=`color: ${color};`>testing</h1>",
 			want: want{
-				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${` + BACKTICK + `color: ${color};` + BACKTICK + `} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-33XVGAES">testing</h1>`,
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${` + BACKTICK + `color: ${color};` + BACKTICK + `}; ${$$definedVars}` + BACKTICK + `, "style")} class="astro-33XVGAES">testing</h1>`,
 				definedVars: []string{"{color:'green'}"},
 			},
 		},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2545,7 +2545,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "define:vars on style tag with style shorthand attribute on element",
+			name:   "define:vars on style tag with style expression attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style={myStyles}>testing</h1>",
 			want: want{
 				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${myStyles} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-ZWHEDDU6">testing</h1>`,

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2545,6 +2545,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "define:vars on style tag with style shorthand attribute on element",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style={myStyles}>testing</h1>",
+			want: want{
+				code:        `${$$maybeRenderHead($$result)}<h1${$$addAttribute(` + BACKTICK + `${myStyles} ${$$definedVars}` + BACKTICK + `, "style")} class="astro-ZWHEDDU6">testing</h1>`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
 			name:   "define:vars on style tag with style empty attribute on element",
 			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1 style>testing</h1>",
 			want: want{

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -54,7 +54,7 @@ func injectDefineVars(n *astro.Node, values []string) {
 			switch attr.Type {
 			case astro.ShorthandAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf(`%s + %s`, attr.Key, definedVars)
+				attr.Val = fmt.Sprintf("`${%s}; ${%s}`", attr.Key, definedVars)
 				n.Attr[i] = attr
 				return
 			case astro.EmptyAttribute:

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -64,17 +64,17 @@ func injectDefineVars(n *astro.Node, values []string) {
 				return
 			case astro.QuotedAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf("`${\"%s\"} ${%s}`", attr.Val, definedVars)
+				attr.Val = fmt.Sprintf("`${\"%s\"}; ${%s}`", attr.Val, definedVars)
 				n.Attr[i] = attr
 				return
 			case astro.TemplateLiteralAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf("`${`%s`} ${%s}`", attr.Val, definedVars)
+				attr.Val = fmt.Sprintf("`${`%s`}; ${%s}`", attr.Val, definedVars)
 				n.Attr[i] = attr
 				return
 			case astro.ExpressionAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf("`${%s} ${%s}`", attr.Val, definedVars)
+				attr.Val = fmt.Sprintf("`${%s}; ${%s}`", attr.Val, definedVars)
 				n.Attr[i] = attr
 				return
 			}

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -62,14 +62,19 @@ func injectDefineVars(n *astro.Node, values []string) {
 				attr.Val = definedVars
 				n.Attr[i] = attr
 				return
-			case astro.QuotedAttribute, astro.TemplateLiteralAttribute:
+			case astro.QuotedAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf("`%s ${%s}`", attr.Key, definedVars)
+				attr.Val = fmt.Sprintf("`${\"%s\"} ${%s}`", attr.Val, definedVars)
+				n.Attr[i] = attr
+				return
+			case astro.TemplateLiteralAttribute:
+				attr.Type = astro.ExpressionAttribute
+				attr.Val = fmt.Sprintf("`${`%s`} ${%s}`", attr.Val, definedVars)
 				n.Attr[i] = attr
 				return
 			case astro.ExpressionAttribute:
 				attr.Type = astro.ExpressionAttribute
-				attr.Val = fmt.Sprintf("(%s) + %s`", attr.Val, definedVars)
+				attr.Val = fmt.Sprintf("`${%s} ${%s}`", attr.Val, definedVars)
 				n.Attr[i] = attr
 				return
 			}


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/compiler/issues/737

## Testing

Added test for when the `style` attribute is:
- A shorthand
- An expression
- Empty
- A template literal
- Quoted

## Docs

We might need to document semicolon usage depending of the resolution taken in [this comment](https://github.com/withastro/compiler/pull/741#pullrequestreview-1318082743)