### PR TITLE
Fix ignored `form` elements after a `form` element containing an expression

### DIFF
--- a/.changeset/tame-tables-taste.md
+++ b/.changeset/tame-tables-taste.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix ignored `form` elements after a `form` element that contains an expression

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1751,6 +1751,9 @@ func textIM(p *parser) bool {
 	case EndTagToken:
 		p.addLoc()
 		p.oe.pop()
+		if p.tok.DataAtom == a.Form {
+			p.form = nil
+		}
 		return true
 	case EndExpressionToken:
 		p.addLoc()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1987,6 +1987,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "Expression in form followed by another sibling form",
+			source: "<form>{data.formLabelA}</form><form><button></button></form>",
+			want: want{
+				code: "${$$maybeRenderHead($$result)}<form>${data.formLabelA}</form><form><button></button></form>",
+			},
+		},
+		{
 			name:   "slot inside of Base",
 			source: `<Base title="Home"><div>Hello</div></Base>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1987,10 +1987,10 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "Expression in form followed by another sibling form",
-			source: "<form>{data.formLabelA}</form><form><button></button></form>",
+			name:   "Expression in form followed by other sibling forms",
+			source: "<form><p>No expression here. So the next form will render.</p></form><form><h3>{data.formLabelA}</h3></form><form><h3>{data.formLabelB}</h3></form><form><p>No expression here, but the last form before me had an expression, so my form didn't render.</p></form><form><h3>{data.formLabelC}</h3></form><div><p>Here is some in-between content</p></div><form><h3>{data.formLabelD}</h3></form>",
 			want: want{
-				code: "${$$maybeRenderHead($$result)}<form>${data.formLabelA}</form><form><button></button></form>",
+				code: "${$$maybeRenderHead($$result)}<form><p>No expression here. So the next form will render.</p></form><form><h3>${data.formLabelA}</h3></form><form><h3>${data.formLabelB}</h3></form><form><p>No expression here, but the last form before me had an expression, so my form didn't render.</p></form><form><h3>${data.formLabelC}</h3></form><div><p>Here is some in-between content</p></div><form><h3>${data.formLabelD}</h3></form>",
 			},
 		},
 		{

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -142,7 +142,7 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartTagToken, TextToken, EndTagToken, StartTagToken, EndTagToken, StartTagToken, EndTagToken, EndTagToken},
 		},
 		{
-			"Successive form elements with expressions inside theme",
+			"form element with expression follwed by another form",
 			`<form>{data.formLabelA}</form><form><button></button></form>`,
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, StartTagToken, StartTagToken, EndTagToken, EndTagToken},
 		},

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -142,6 +142,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartTagToken, TextToken, EndTagToken, StartTagToken, EndTagToken, StartTagToken, EndTagToken, EndTagToken},
 		},
 		{
+			"Successive form elements with expressions inside theme",
+			`<form>{data.formLabelA}</form><form><button></button></form>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, StartTagToken, StartTagToken, EndTagToken, EndTagToken},
+		},
+		{
 			"text",
 			"test",
 			[]TokenType{TextToken},


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/compiler/issues/743

The form pointer element wasn't reset when going from `inExpressionIM` to `textIM` at the end of an expression inside a form element, which caused the following `form` elements to be ignored.

## Testing

- Added a tokenizer test for a sanity check
- Added a printer test

## Docs

bug fix only