### PR TITLE
Fix parse error for multiline `export type` using Unions or Intersections

### DIFF
--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -110,6 +110,9 @@ outer:
 						foundIdent = true
 					}
 				} else if next == js.LineTerminatorToken || next == js.SemicolonToken {
+					if next == js.LineTerminatorToken && i < len(source) && (source[i] == '&' || source[i] == '|') {
+						continue
+					}
 					if (flags["function"] || flags["=>"] || flags["interface"]) && !flags["{"] {
 						continue
 					}

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -439,7 +439,14 @@ export type Props =
 
 export interface Foo {
 	bar: string;
-}`,
+}
+
+export type FooAndBar1 = 'Foo' &
+'Bar';
+export type FooAndBar2 = 'Foo'
+& 'Bar';
+export type FooOrBar = 'Foo'
+| 'Bar';`,
 			want: `export type Theme = 'light' | 'dark';
 export type Props =
 {
@@ -447,7 +454,13 @@ export type Props =
 }
 export interface Foo {
 	bar: string;
-}`,
+}
+export type FooAndBar1 = 'Foo' &
+'Bar';
+export type FooAndBar2 = 'Foo'
+& 'Bar';
+export type FooOrBar = 'Foo'
+| 'Bar';`,
 		},
 		{
 			name: "Picture",


### PR DESCRIPTION
## Changes
In TypeScript syntax, we can write Union types(`|`) or Intersection types (`&`) as multiline.
([TS Playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcBiEIEEB2ATAIQEMoBGOAXjgHIMJq4AyOAKGuKmoG4XRJYEyVHVyESAJko06DFs3YluvcNHhIU6TAHkoHKbUzUWAHxoduQA))

Currently, Astro compiler throws an error if `|` or `&` operator appears at the top of a line.
```bash
Unexpected "|"
40 |  type Bar = string;
41 |
42 |  // Compile error
   |                   ^
43 |  | Bar;
   |  ^
44 |
```

Repro: https://github.com/araya-playground/astro-playground/tree/repro%2Fcompile-union-type-error

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

I added test cases: 667bbe36989baa38640ca94dd933246bd2fd0cc2

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

This PR is fixing a bug.