### PR TITLE
fix: merge class and class:list values

### DIFF
--- a/.changeset/yellow-cheetahs-drop.md
+++ b/.changeset/yellow-cheetahs-drop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Correctly apply style when `class` and `class:list` are both used

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1603,10 +1603,24 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
-			name:   "class and class list",
+			name:   "class and class list simple array",
 			source: `<div class="two" class:list={['one', 'variable']} />`,
 			want: want{
 				code: `${$$maybeRenderHead($$result)}<div class="two"${$$addAttribute(['two', ['one', 'variable']], "class:list")}></div>`,
+			},
+		},
+		{
+			name:   "class and class list object",
+			source: `<div class="two three" class:list={['hello goodbye', { hello: true, world: true }]} />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div class="two three"${$$addAttribute(['two three', ['hello goodbye', { hello: true, world: true }]], "class:list")}></div>`,
+			},
+		},
+		{
+			name:   "class and class list set",
+			source: `<div class="two three" class:list={[ new Set([hello: true, world: true]) ]} />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div class="two three"${$$addAttribute(['two three', [ new Set([hello: true, world: true]) ]], "class:list")}></div>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1618,9 +1618,9 @@ import { Container, Col, Row } from 'react-bootstrap';
 		},
 		{
 			name:   "class and class list set",
-			source: `<div class="two three" class:list={[ new Set([hello: true, world: true]) ]} />`,
+			source: `<div class="two three" class:list={[ new Set([{hello: true, world: true}]) ]} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['two three', [ new Set([hello: true, world: true]) ]], "class:list")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['two three', [ new Set([{hello: true, world: true}]) ]], "class:list")}></div>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1606,21 +1606,21 @@ import { Container, Col, Row } from 'react-bootstrap';
 			name:   "class and class list simple array",
 			source: `<div class="two" class:list={['one', 'variable']} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div class="two"${$$addAttribute(['two', ['one', 'variable']], "class:list")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['two', ['one', 'variable']], "class:list")}></div>`,
 			},
 		},
 		{
 			name:   "class and class list object",
 			source: `<div class="two three" class:list={['hello goodbye', { hello: true, world: true }]} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div class="two three"${$$addAttribute(['two three', ['hello goodbye', { hello: true, world: true }]], "class:list")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['two three', ['hello goodbye', { hello: true, world: true }]], "class:list")}></div>`,
 			},
 		},
 		{
 			name:   "class and class list set",
 			source: `<div class="two three" class:list={[ new Set([hello: true, world: true]) ]} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div class="two three"${$$addAttribute(['two three', [ new Set([hello: true, world: true]) ]], "class:list")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['two three', [ new Set([hello: true, world: true]) ]], "class:list")}></div>`,
 			},
 		},
 		{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1596,6 +1596,20 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
+			name:   "class list",
+			source: `<div class:list={['one', 'variable']} />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute(['one', 'variable'], "class:list")}></div>`,
+			},
+		},
+		{
+			name:   "class and class list",
+			source: `<div class="two" class:list={['one', 'variable']} />`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div class="two"${$$addAttribute(['two', ['one', 'variable']], "class:list")}></div>`,
+			},
+		},
+		{
 			name:   "spread without style or class",
 			source: `<div {...Astro.props} />`,
 			want: want{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -42,6 +42,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 				didAddDefinedVars = didAdd
 			}
 		}
+		mergeClassList(doc, n, &opts)
 	})
 	if len(definedVars) > 0 && !didAddDefinedVars {
 		for _, style := range doc.Styles {
@@ -452,4 +453,23 @@ func walk(doc *astro.Node, cb func(*astro.Node)) {
 		}
 	}
 	f(doc)
+}
+
+// This function merges the values of `class=""` and `class:list=""` in `class:list`
+func mergeClassList(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
+	var classListAttrValue string
+	var classListAttrIndex int
+	var classAttrValue string
+	for i, a := range n.Attr {
+		if a.Key == "class:list" {
+			classListAttrValue = a.Val
+			classListAttrIndex = i
+		}
+		if a.Key == "class" {
+			classAttrValue = a.Val
+		}
+	}
+	if classListAttrIndex > 0 {
+		n.Attr[classListAttrIndex].Val = fmt.Sprintf("['%s', %s]", classAttrValue, classListAttrValue)
+	}
 }


### PR DESCRIPTION
## Changes

Closes https://github.com/withastro/compiler/issues/747

I applied a transformation where if we have `class` and `class:list`, we take value from `class` and merge it with `class:list`

So if we have something like this

```jsx
<p class="one" class:list={["two", "three"]}>
```

It will be result into something like this:

```jsx
<p class="one" class:list={["one", ["two", "three"]]}>
```

I checked we if we support arrays in an array inside `class:list`, and we do!
## Testing

I added a test case to cover the transformation

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
