### PR TITLE
Fix export hoisting with inline TypeScript types

### DIFF
--- a/.changeset/flat-peaches-design.md
+++ b/.changeset/flat-peaches-design.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix getStaticPaths export when used with a TypeScript type ([#4929](https://github.com/withastro/astro/issues/4929))

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -116,6 +116,10 @@ outer:
 					if flags["&"] || flags["="] {
 						continue
 					}
+					if pairs['('] > 0 {
+						continue
+					}
+
 					foundSemicolonOrLineTerminator = true
 				} else if js.IsPunctuator(next) {
 					if nextValue[0] == '{' || nextValue[0] == '(' || nextValue[0] == '[' {

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -330,6 +330,26 @@ const { a } = Astro.props;`,
 }`,
 		},
 		{
+			name: "getStaticPaths with TypeScript type",
+			source: `import { fn } from "package";
+
+export async function getStaticPaths({
+	paginate
+}: {
+	paginate: any
+}) {
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export async function getStaticPaths({
+	paginate
+}: {
+	paginate: any
+}) {
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
 			name: "export interface",
 			source: `import { a } from "a";
 export interface Props {

--- a/packages/compiler/test/basic/get-static-paths.ts
+++ b/packages/compiler/test/basic/get-static-paths.ts
@@ -84,4 +84,27 @@ const { MdxContent, frontmatter, url, file } = Astro.props;
   assert.match(result.code, '\nconst $$stdin = ', 'Expected getStaticPaths hoisting to maintain newlines');
 });
 
+test('getStaticPaths with types', async () => {
+  const FIXTURE = `---
+export async function getStaticPaths({
+  paginate,
+}: {
+  paginate: PaginateFunction;
+}) {
+  const allPages = (
+    await getCollection(
+      "blog"
+    )
+  );
+  return paginate(allPages, { pageSize: 10 });
+}
+---
+
+<div></div>
+`;
+  const result = await transform(FIXTURE);
+  assert.match(result.code, `{\n  paginate: PaginateFunction;\n}) {`, 'Expected output to contain getStaticPaths output');
+});
+
+
 test.run();

--- a/packages/compiler/test/basic/get-static-paths.ts
+++ b/packages/compiler/test/basic/get-static-paths.ts
@@ -106,5 +106,4 @@ export async function getStaticPaths({
   assert.match(result.code, `{\n  paginate: PaginateFunction;\n}) {`, 'Expected output to contain getStaticPaths output');
 });
 
-
 test.run();


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/astro/issues/4929
- Fixes edge case with `getStaticPaths` export hoisting

## Testing

Test added

## Docs

Bug fix only