### PR TITLE
test(#493): add test fixture for self closing tags in switch statement scope

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -840,6 +840,13 @@ const groups = [[0, 1, 2], [3, 4, 5]];
 			},
 		},
 		{
+			name:   "nested expressions VIII",
+			source: `<div>{ items.map(({ type, ...data }) => { switch (type) { case 'card': { return ( <Card {...data} /> ); } case 'paragraph': { return ( <p>{data.body}</p>);}}})}</div>`,
+			want: want{
+				code: "${$$maybeRenderHead($$result)}<div>${ items.map(({ type, ...data }) => { switch (type) { case 'card': { return ( $$render`${$$renderComponent($$result,'Card',Card,{...(data)})}` ); } case 'paragraph': { return ( $$render`<p>${data.body}</p>`);}}})}</div>",
+			},
+		},
+		{
 			name: "expressions with JS comments",
 			source: `---
 const items = ['red', 'yellow', 'blue'];

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -248,6 +248,11 @@ func TestBasic(t *testing.T) {
 			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, SelfClosingTagToken, TextToken, TextToken, TextToken, TextToken, SelfClosingTagToken, TextToken, TextToken, TextToken, TextToken, SelfClosingTagToken, TextToken, TextToken, StartTagToken, TextToken, EndTagToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
 		},
 		{
+			"expression with switch returning a mix of self-closing tags and elements",
+			`<div>{items.map(({ type, ...data }) => { switch (type) { case 'card': { return (<Card {...data} />);}case 'paragraph': { return (<p>{data.body}</p>);}}})}</div>`,
+			[]TokenType{StartTagToken, StartExpressionToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, TextToken, SelfClosingTagToken, TextToken, TextToken, TextToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, TextToken, TextToken, EndExpressionToken, EndTagToken},
+		},
+		{
 			"expression with < operators",
 			`<div>{() => {
 				if (value < 0.25) {


### PR DESCRIPTION
## Changes

https://github.com/withastro/compiler/pull/740 seems to have fixed https://github.com/withastro/compiler/issues/493.
This PR adds a test to close that issue.
No changeset needed.

## Testing

Added a tokenizer and a printer test

## Docs

Adds test only!
