### PR TITLE
Add metadata for head propagation

### DIFF
--- a/.changeset/honest-hats-wash.md
+++ b/.changeset/honest-hats-wash.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Add ContainsHead flag for metadata

--- a/internal/node.go
+++ b/internal/node.go
@@ -93,6 +93,7 @@ type Node struct {
 	ClientOnlyComponentNodes []*Node
 	ClientOnlyComponents     []*HydratedComponentMetadata
 	HydrationDirectives      map[string]bool
+	ContainsHead             bool
 
 	Type      NodeType
 	DataAtom  atom.Atom

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -43,6 +43,9 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 			}
 		}
 		mergeClassList(doc, n, &opts)
+		if n.DataAtom == a.Head {
+			doc.ContainsHead = true
+		}
 	})
 	if len(definedVars) > 0 && !didAddDefinedVars {
 		for _, style := range doc.Styles {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -43,7 +43,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 			}
 		}
 		mergeClassList(doc, n, &opts)
-		if n.DataAtom == a.Head {
+		if n.DataAtom == a.Head && !IsImplicitNode(n) {
 			doc.ContainsHead = true
 		}
 	})

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prerelease": "pnpm run build:compiler",
     "release": "changeset publish",
     "test": "tsx node_modules/uvu/bin.js packages test -i utils -i stress",
+    "test:only": "tsx node_modules/uvu/bin.js packages",
     "test:stress": "tsx packages/compiler/test/stress/index.ts",
     "test:ci": "pnpm run test && pnpm run test:stress"
   },

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -88,6 +88,7 @@ export interface TransformResult {
   scripts: HoistedScript[];
   hydratedComponents: HydratedComponent[];
   clientOnlyComponents: HydratedComponent[];
+  containsHead: boolean;
 }
 
 export interface SourceMap {

--- a/packages/compiler/test/head-metadata/with-head.ts
+++ b/packages/compiler/test/head-metadata/with-head.ts
@@ -1,0 +1,27 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<html>
+  <head>
+    <title>Testing</title>
+  </head>
+  <body>
+    <h1>Testing</h1>
+  </body>
+</html>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    filename: 'test.astro',
+  });
+});
+
+test('containsHead is true', () => {
+  assert.equal(result.containsHead, true);
+});
+
+test.run();

--- a/packages/compiler/test/head-metadata/without-head.ts
+++ b/packages/compiler/test/head-metadata/without-head.ts
@@ -1,0 +1,20 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<slot />
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    filename: 'test.astro',
+  });
+});
+
+test('containsHead is false', () => {
+  assert.equal(result.containsHead, false);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Adds metadata on whether the tree includes a head. This is used on the Astro side to know if the implicit head injection algorithm can be ignored. It should be in most cases.

## Testing

- Added wasm tests

## Docs

N/A, bug fix