### PR TITLE
Add test for self-closing tags before expressions

### DIFF
--- a/.changeset/purple-olives-punch.md
+++ b/.changeset/purple-olives-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix regression related to self-closing tags

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2750,6 +2750,14 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'Layout',Layout,{})}`,
 			},
 		},
+		{
+			name:     "complex recursive component",
+			source:   `{(<Fragment><Fragment set:html={` + BACKTICK + `<${Node.tag} ${stringifyAttributes(Node.attributes)}>` + BACKTICK + `} />{Node.children.map((child) => (<Astro.self node={child} />))}<Fragment set:html={` + BACKTICK + `</${Node.tag}>` + BACKTICK + `} /></Fragment>)}`,
+			filename: "/projects/app/src/components/RenderNode.astro",
+			want: want{
+				code: `${($$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `<${Node.tag} ${stringifyAttributes(Node.attributes)}>` + BACKTICK + `)}` + BACKTICK + `,})}${Node.children.map((child) => ($$render` + BACKTICK + `${$$renderComponent($$result,'Astro.self',Astro.self,{"node":(child)})}` + BACKTICK + `))}${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `</${Node.tag}>` + BACKTICK + `)}` + BACKTICK + `,})}` + BACKTICK + `,})})` + BACKTICK + `}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/token.go
+++ b/internal/token.go
@@ -1626,6 +1626,7 @@ func (z *Tokenizer) trackExpressionElementStack() {
 	} else if z.tt == SelfClosingTagToken {
 		stack := z.expressionElementStack[i]
 		if len(stack) == 0 {
+			// Only switch out of this mode if we're not in an active stack
 			z.openBraceIsExpressionStart = false
 		}
 	}

--- a/internal/token.go
+++ b/internal/token.go
@@ -1624,7 +1624,10 @@ func (z *Tokenizer) trackExpressionElementStack() {
 			}
 		}
 	} else if z.tt == SelfClosingTagToken {
-		z.openBraceIsExpressionStart = false
+		stack := z.expressionElementStack[i]
+		if len(stack) == 0 {
+			z.openBraceIsExpressionStart = false
+		}
 	}
 }
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -727,6 +727,13 @@ func TestExpressions(t *testing.T) {
 			[]TokenType{StartExpressionToken, TextToken, TextToken, TextToken, StartTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, EndExpressionToken},
 		},
 		{
+			"nested one level with self-closing tag before expression",
+			`{() => {
+				return <div><div />{value}</div>
+			}}`,
+			[]TokenType{StartExpressionToken, TextToken, TextToken, TextToken, StartTagToken, SelfClosingTagToken, StartExpressionToken, TextToken, EndExpressionToken, EndTagToken, TextToken, TextToken, EndExpressionToken},
+		},
+		{
 			"nested two levels",
 			`{() => {
 				return <div>{() => {


### PR DESCRIPTION
## Changes

Add test for tokenizer evaluating nested expressions after self-closing tags.
See #755 for related bug.

Closes https://github.com/withastro/astro/issues/6589

## Testing

`go test`
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Just added test.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
