### PR TITLE
Implement scopedStyleStrategy

### DIFF
--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -111,16 +111,22 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 
 	preprocessStyle := options.Get("preprocessStyle")
 
+	scopedStyleStrategy := jsString(options.Get("scopedStyleStrategy"))
+	if scopedStyleStrategy == "" {
+		scopedStyleStrategy = "where"
+	}
+
 	return transform.TransformOptions{
-		Filename:           filename,
-		NormalizedFilename: normalizedFilename,
-		InternalURL:        internalURL,
-		SourceMap:          sourcemap,
-		AstroGlobalArgs:    astroGlobalArgs,
-		Compact:            compact,
-		ResolvePath:        resolvePathFn,
-		PreprocessStyle:    preprocessStyle,
-		ResultScopedSlot:   scopedSlot,
+		Filename:            filename,
+		NormalizedFilename:  normalizedFilename,
+		InternalURL:         internalURL,
+		SourceMap:           sourcemap,
+		AstroGlobalArgs:     astroGlobalArgs,
+		Compact:             compact,
+		ResolvePath:         resolvePathFn,
+		PreprocessStyle:     preprocessStyle,
+		ResultScopedSlot:    scopedSlot,
+		ScopedStyleStrategy: scopedStyleStrategy,
 	}
 }
 

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -41,10 +41,15 @@ func ScopeStyle(styles []*astro.Node, opts TransformOptions) bool {
 		if n.FirstChild == nil || strings.TrimSpace(n.FirstChild.Data) == "" {
 			continue
 		}
+		scopeStrategy := 1
+		if opts.ScopedStyleStrategy == "class" {
+			scopeStrategy = 2
+		}
+
 		// Use vendored version of esbuild internals to parse AST
 		tree := css_parser.Parse(logger.Log{AddMsg: func(msg logger.Msg) {}}, logger.Source{Contents: n.FirstChild.Data}, css_parser.Options{MinifySyntax: false, MinifyWhitespace: true})
 		// esbuild's internal `css_printer` has been modified to emit Astro scoped styles
-		result := css_printer.Print(tree, css_printer.Options{MinifyWhitespace: true, Scope: opts.Scope})
+		result := css_printer.Print(tree, css_printer.Options{MinifyWhitespace: true, Scope: opts.Scope, ScopeStrategy: scopeStrategy})
 		n.FirstChild.Data = string(result.CSS)
 	}
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -14,16 +14,17 @@ import (
 )
 
 type TransformOptions struct {
-	Scope              string
-	Filename           string
-	NormalizedFilename string
-	InternalURL        string
-	SourceMap          string
-	AstroGlobalArgs    string
-	Compact            bool
-	ResultScopedSlot   bool
-	ResolvePath        func(string) string
-	PreprocessStyle    interface{}
+	Scope               string
+	Filename            string
+	NormalizedFilename  string
+	InternalURL         string
+	SourceMap           string
+	AstroGlobalArgs     string
+	ScopedStyleStrategy string
+	Compact             bool
+	ResultScopedSlot    bool
+	ResolvePath         func(string) string
+	PreprocessStyle     interface{}
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {

--- a/lib/esbuild/css_printer/astro_features.go
+++ b/lib/esbuild/css_printer/astro_features.go
@@ -8,7 +8,13 @@ import (
 )
 
 func (p *printer) printScopedSelector() bool {
-	p.print(fmt.Sprintf(":where(.astro-%s)", p.options.Scope))
+	var str string
+	if p.options.ScopeStrategy == 1 {
+		str = fmt.Sprintf(":where(.astro-%s)", p.options.Scope)
+	} else {
+		str = fmt.Sprintf(".astro-%s", p.options.Scope)
+	}
+	p.print(str)
 	return true
 }
 

--- a/lib/esbuild/css_printer/css_printer.go
+++ b/lib/esbuild/css_printer/css_printer.go
@@ -37,6 +37,7 @@ type Options struct {
 	AddSourceMappings bool
 	LegalComments     config.LegalComments
 	Scope             string
+	ScopeStrategy     int
 }
 
 type PrintResult struct {

--- a/packages/compiler/shared/types.ts
+++ b/packages/compiler/shared/types.ts
@@ -50,6 +50,7 @@ export interface TransformOptions {
   astroGlobalArgs?: string;
   compact?: boolean;
   resultScopedSlot?: boolean;
+  scopedStyleStrategy?: 'where' | 'class';
   /**
    * @deprecated "as" has been removed and no longer has any effect!
    */


### PR DESCRIPTION
## Changes

- Implements compiler changes needed for https://github.com/withastro/roadmap/pull/543
- Mostly this is just threading a config option down to the CSS printer so that it doesn't include `:where` when the `class` option is provided.

## Testing

- New css printing test.

## Docs

N/A in the compiler, to be documented on the docs site.