### PR TITLE
TSX: Map default export to 0:0

### DIFF
--- a/.changeset/perfect-ears-shave.md
+++ b/.changeset/perfect-ears-shave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Map default export to 0:0

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -143,6 +143,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		}
 		componentName := getTSXComponentName(p.opts.Filename)
 
+		p.addSourceMapping(loc.Loc{Start: 0})
 		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}", componentName, props.Statement, props.Ident, props.Generics))
 		return
 	}

--- a/packages/compiler/test/tsx-sourcemaps/export.ts
+++ b/packages/compiler/test/tsx-sourcemaps/export.ts
@@ -1,0 +1,18 @@
+import { convertToTSX } from '@astrojs/compiler';
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+const fixture = `<h1>Hello world!</h1>`;
+
+test('default export mapped to 0:0', async () => {
+  const input = fixture;
+  const { map } = await convertToTSX(input, { sourcemap: 'both', filename: 'index.astro' });
+  const tracer = new TraceMap(map);
+  const original = originalPositionFor(tracer, { line: 4, column: 0 });
+
+  assert.equal(original.column, 0);
+  assert.equal(original.line, 1);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Map the default export to 0:0 so things mapped to the default export at least go to 0:0 by default (ex: Go to Definition)

## Testing

Added a test

## Docs

N/A
