### PR TITLE
fix(#714): skip `\r` in sourcemapping

### DIFF
--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -68,6 +68,9 @@ func (p *printer) printTextWithSourcemap(text string, l loc.Loc) {
 	lastPos := -1
 	for pos, c := range text {
 		diff := pos - lastPos
+		if (c == '\r' && len(text[pos:]) > 0 && text[pos + 1] == '\n') {
+			continue;
+		}
 		p.addSourceMapping(loc.Loc{Start: start})
 		p.print(string(c))
 		start += diff

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,10 @@
+import { convertToTSX } from './packages/compiler/node/index.js';
+import fs from 'node:fs';
+
+async function run() {
+    const file = fs.readFileSync('/Users/nmoo/Desktop/render.astro', 'utf8').replace(/\n/g, '\r\n');
+    const output = await convertToTSX(file, { sourcemap: 'inline' })
+    fs.writeFileSync('/Users/nmoo/Desktop/render.astro.js', output.code, 'utf8');
+}
+
+run();


### PR DESCRIPTION
## Changes

- Closes #714

## Testing

Tested manually

## Docs

Bug fix only