### PR TITLE
Fix CONTRIBUTING.md link in readme

### DIFF
--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -63,4 +63,4 @@ A `devcontainer` configuration is available for use with VSCode's [Remote Develo
 
 ## Contributing
 
-[CONTRIBUTING.md](./CONTRIBUTING.md)
+[CONTRIBUTING.md](/CONTRIBUTING.md)


### PR DESCRIPTION
## Changes

The link for CONTRIBUTING.md was using relative path and pointing to a non-existent file when opened inside packages/compiler.

## Testing

n/a

## Docs

link fix only