### PR TITLE
Restart service on crashes when using `convertToTSX` and `parse` like for `transform`

### DIFF
--- a/.changeset/dry-knives-glow.md
+++ b/.changeset/dry-knives-glow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Handle crashes when using parse and convertToTSX by restarting the service

--- a/.changeset/dry-knives-glow.md
+++ b/.changeset/dry-knives-glow.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Handle crashes when using parse and convertToTSX by restarting the service
+Handle crashes when using `parse` and `convertToTSX` by restarting the service

--- a/packages/compiler/node/index.ts
+++ b/packages/compiler/node/index.ts
@@ -74,11 +74,22 @@ const startRunningService = async (): Promise<Service> => {
           throw err;
         }
       }),
-    parse: (input, options) => new Promise((resolve) => resolve(_service.parse(input, options || {}))).then((result: any) => ({ ...result, ast: JSON.parse(result.ast) })),
+    parse: (input, options) =>
+      new Promise((resolve) => resolve(_service.parse(input, options || {})))
+        .catch((error) => {
+          longLivedService = void 0;
+          throw error;
+        })
+        .then((result: any) => ({ ...result, ast: JSON.parse(result.ast) })),
     convertToTSX: (input, options) => {
-      return new Promise((resolve) => resolve(_service.convertToTSX(input, options || {}))).then((result: any) => {
-        return { ...result, map: JSON.parse(result.map) };
-      });
+      return new Promise((resolve) => resolve(_service.convertToTSX(input, options || {})))
+        .catch((error) => {
+          longLivedService = void 0;
+          throw error;
+        })
+        .then((result: any) => {
+          return { ...result, map: JSON.parse(result.map) };
+        });
     },
   };
 };

--- a/packages/compiler/node/sync.cts
+++ b/packages/compiler/node/sync.cts
@@ -46,12 +46,22 @@ export function startRunningService(): Service {
       }
     },
     parse: (input, options) => {
-      const result = _service.parse(input, options || {});
-      return { ...result, ast: JSON.parse(result.ast) };
+      try {
+        const result = _service.parse(input, options || {});
+        return { ...result, ast: JSON.parse(result.ast) };
+      } catch (err) {
+        longLivedService = void 0;
+        throw err;
+      }
     },
     convertToTSX: (input, options) => {
-      const result = _service.convertToTSX(input, options || {});
-      return { ...result, map: JSON.parse(result.map) };
+      try {
+        const result = _service.convertToTSX(input, options || {});
+        return { ...result, map: JSON.parse(result.map) };
+      } catch (err) {
+        longLivedService = void 0;
+        throw err;
+      }
     },
   };
 }


### PR DESCRIPTION
## Changes

Whenever `transform` panic, the compiler force a restart of the service to avoid the "Go Program already Exited" error. This PR adds that mechanism to `parse` and `convertToTSX` as well. Otherwise it crashes our entire language-server whenever the compiler fails to convert a file to TSX

## Testing

Tested manually, service isn't actually supposed to crash, ha!

## Docs

N/A
