### PR TITLE
fix(windows): Fix crash when transforming files with Windows-style line endings

### DIFF
--- a/.changeset/silly-countries-act.md
+++ b/.changeset/silly-countries-act.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix crash when transforming files with Windows line endings

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -69,7 +69,7 @@ func (p *printer) printTextWithSourcemap(text string, l loc.Loc) {
 	for pos, c := range text {
 		diff := pos - lastPos
 		// Handle Windows-specific "\r\n" newlines
-		if c == '\r' && len(text[pos:]) > 0 && text[pos + 1] == '\n' {
+		if c == '\r' && len(text[pos:]) > 1 && text[pos+1] == '\n' {
 			start += diff
 			lastPos = pos
 			continue

--- a/packages/compiler/test/js-sourcemaps/windows-linereturns.ts
+++ b/packages/compiler/test/js-sourcemaps/windows-linereturns.ts
@@ -1,0 +1,12 @@
+import { transform } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+test('Windows line returns', async () => {
+  const result = await transform(
+    `<div class="px-10">\r\n{\r\n() => {\r\nif (style == Style.Ordered) {\r\nreturn items.map((item: string, index: number) => (\r\n// index + 1 is needed to start with 1 not 0\r\n<p>\r\n{index + 1}\r\n<Fragment set:html={item} />\r\n</p>\r\n));\r\n} else {\r\nreturn items.map((item: string) => (\r\n<Fragment set:html={item} />\r\n));\r\n}\r\n}\r\n}\r\n</div>`,
+    { sourcemap: 'both', filename: 'index.astro', resolvePath: (i: string) => i }
+  );
+  assert.ok(result.code, 'Expected to compile');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

There's some specific cases where the length check wasn't enough and the compiler would crash. It was strangely hard to reproduce because in tests, the compiler would sometimes just hang and not fully crash and the test would be considered "pending" infinitely, super weird.

I'm also totally unsure why the current Windows tests don't catch this, very weird

Fix https://github.com/withastro/compiler/issues/786

## Testing

Added a test

## Docs

N/A
