### PR TITLE
Apply `define:vars` to non-root elements

### DIFF
--- a/.changeset/flat-carpets-shout.md
+++ b/.changeset/flat-carpets-shout.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Apply `define:vars` to non-root elements

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2694,6 +2694,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "define:vars on non-root elements",
+			source: "<style define:vars={{color:'green'}}>h1{color:var(--color)}</style>{true ? <h1>foo</h1> : <h1>bar</h1>}",
+			want: want{
+				code:        `${true ? $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<h1 class="astro-34AO5S3B"${$$addAttribute($$definedVars, "style")}>foo</h1>` + BACKTICK + ` : $$render` + BACKTICK + `<h1 class="astro-34AO5S3B"${$$addAttribute($$definedVars, "style")}>bar</h1>` + BACKTICK + `}`,
+				definedVars: []string{"{color:'green'}"},
+			},
+		},
+		{
 			name: "define:vars on script with StaticExpression turned on",
 			// 1. An inline script with is:inline - right
 			// 2. A hoisted script - wrong, shown up in scripts.add

--- a/internal/transform/scope-html.go
+++ b/internal/transform/scope-html.go
@@ -17,7 +17,7 @@ func ScopeElement(n *astro.Node, opts TransformOptions) {
 func AddDefineVars(n *astro.Node, values []string) bool {
 	if n.Type == astro.ElementNode && !n.Component {
 		if _, noScope := NeverScopedElements[n.Data]; !noScope {
-			if IsTopLevel(n) {
+			if !IsImplicitNode(n) {
 				injectDefineVars(n, values)
 				return true
 			}


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/compiler/issues/797

Instead of not injecting `define:vars` style to non-root elements, I've changed to not inject for implicit nodes only. As when transforming nodes, the `html` and `body` seems to be added as well.

If not, it would cause a false negative warning at

https://github.com/withastro/compiler/blob/947c4dd8cceccc8aa97c03e35cd45a32e544c7b6/internal/transform/transform.go#L51-L64

Where the `html` and `body` always made `didAddDefinedVars` true

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
Added a new test in go

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
n/a. bug fix. The docs doesn't mention that `define:vars` can't be added to non-root elements.