### PR TITLE
fix: move declare const at the bottom of the file to make mapping easier downstream

### DIFF
--- a/.changeset/shaggy-jobs-deliver.md
+++ b/.changeset/shaggy-jobs-deliver.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Move `declare const` for Props type at the bottom of the file to make mapping easier downstream

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -98,14 +98,6 @@ func renderTsx(p *printer, n *Node) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		props := js_scanner.GetPropsType([]byte(p.sourcetext))
-		if props.Ident != "Record<string, any>" {
-			p.printf(`/**
- * Astro global available in all contexts in .astro files
- *
- * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
-*/
-declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
-		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			// This checks for the first node that comes *after* the frontmatter
@@ -143,7 +135,15 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		}
 		componentName := getTSXComponentName(p.opts.Filename)
 
-		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}", componentName, props.Statement, props.Ident, props.Generics))
+		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}\n", componentName, props.Statement, props.Ident, props.Generics))
+		if props.Ident != "Record<string, any>" {
+			p.printf(`/**
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
+*/
+declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Changes

By not shifting the start of the file, it allows consumer downstream to always assume that the frontmatter is the beginning of the file, this is especially useful for mapping code actions and completions that are supposed to add code to the frontmatter since we can know where the frontmatter starts and end in the virtual file by using the positions of it in the real file

Ultimately, it'd be better to solve this in another way (maybe provide the location of the frontmatter in the virtual file), but this changes makes things easier in the meantime

## Testing

Updated tests

## Docs

N/A
