### PR TITLE
fix: move declare const at the bottom of the file to make mapping easier downstream

### DIFF
--- a/.changeset/shaggy-jobs-deliver.md
+++ b/.changeset/shaggy-jobs-deliver.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Move `declare const` for Props type at the bottom of the file to make mapping easier downstream

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -98,14 +98,6 @@ func renderTsx(p *printer, n *Node) {
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		props := js_scanner.GetPropsType([]byte(p.sourcetext))
-		if props.Ident != "Record<string, any>" {
-			p.printf(`/**
- * Astro global available in all contexts in .astro files
- *
- * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
-*/
-declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
-		}
 		hasChildren := false
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			// This checks for the first node that comes *after* the frontmatter
@@ -143,7 +135,15 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 		}
 		componentName := getTSXComponentName(p.opts.Filename)
 
-		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}", componentName, props.Statement, props.Ident, props.Generics))
+		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}\n", componentName, props.Statement, props.Ident, props.Generics))
+		if props.Ident != "Record<string, any>" {
+			p.printf(`/**
+ * Astro global available in all contexts in .astro files
+ *
+ * [Astro documentation](https://docs.astro.build/reference/api-reference/#astro-global)
+*/
+declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
+		}
 		return
 	}
 

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -19,7 +19,7 @@ let value = 'world';
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -41,7 +41,7 @@ let value = 'world';
 <div></div>
 
 </Fragment>
-export default function Test__AstroComponent_(_props: Record<string, any>): any {}`;
+export default function Test__AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { filename: '/Users/nmoo/test.astro', sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -51,7 +51,7 @@ test('moves @attributes to spread', async () => {
   const output = `<Fragment>
 <div name="value" {...{"@click":(() => {})}}></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -71,7 +71,7 @@ console.log("hello")
 {hello}
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -91,7 +91,7 @@ const { hello } = Astro.props
 <div class={hello}></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -101,7 +101,7 @@ test('moves attributes with dots in them to spread', async () => {
   const output = `<Fragment>
 <div name="value" {...{"x-on:keyup.shift.enter":"alert('Astro')"}}></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -111,7 +111,7 @@ test('moves attributes that starts with : to spread', async () => {
   const output = `<Fragment>
 <div name="value" {...{":class":"hey"}}></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -121,7 +121,7 @@ test("Don't move attributes to spread unnecessarily", async () => {
   const output = `<Fragment>
 <div 丽dfds_fsfdsfs name="value"></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -131,7 +131,7 @@ test('preserves unclosed tags', async () => {
   const output = `<Fragment>
 <components.
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -141,7 +141,7 @@ test('template literal attribute', async () => {
   const output = `<Fragment>
 <div class={\`\${hello}\`}></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -158,7 +158,7 @@ const myMarkdown = await import('../content/post.md');
 <Fragment>
 <myMarkdown.
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -177,7 +177,7 @@ const myMarkdown = await import('../content/post.md');
 <myMarkdown.
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -187,7 +187,7 @@ test('spread object', async () => {
   const output = `<Fragment>
 <DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -199,7 +199,7 @@ test('spread object II', async () => {
 <MainLayout {...Astro.props}>
 </MainLayout>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });

--- a/packages/compiler/test/tsx/non-latin.ts
+++ b/packages/compiler/test/tsx/non-latin.ts
@@ -1,6 +1,6 @@
+import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler';
 
 // https://mathiasbynens.be/notes/javascript-identifiers
 const value = `
@@ -62,7 +62,7 @@ ${value}
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });

--- a/packages/compiler/test/tsx/props-and-staticPaths.ts
+++ b/packages/compiler/test/tsx/props-and-staticPaths.ts
@@ -1,6 +1,6 @@
+import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler';
 
 const PREFIX = `/**
  * Astro global available in all contexts in .astro files
@@ -19,7 +19,6 @@ export function getStaticProps() {
 
 <div></div>`;
   const output =
-    PREFIX +
     '\n' +
     `type Props = Record<string, never>;
 export function getStaticProps() {
@@ -29,7 +28,8 @@ export function getStaticProps() {
 "";<Fragment>
 <div></div>
 </Fragment>
-export default function __AstroComponent_(_props: Props): any {}`;
+export default function __AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -1,6 +1,6 @@
+import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler';
 
 const PREFIX = `/**
  * Astro global available in all contexts in .astro files
@@ -14,7 +14,7 @@ test('no props', async () => {
   const output = `<Fragment>
 <div></div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -27,7 +27,7 @@ function DoTheThing(Props) {}
 function DoTheThing(Props) {}
 
 
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -40,14 +40,15 @@ interface Props {}
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Props): any {}`;
+export default function __AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -60,14 +61,15 @@ import { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 import { Props } from './somewhere';
 
 <Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Props): any {}`;
+export default function __AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -80,14 +82,15 @@ import { MyComponent as Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 import { MyComponent as Props } from './somewhere';
 
 <Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Props): any {}`;
+export default function __AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -100,14 +103,15 @@ import type { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 import type { Props } from './somewhere';
 
 <Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_(_props: Props): any {}`;
+export default function __AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -120,14 +124,15 @@ type Props = {}
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 type Props = {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function Test__AstroComponent_(_props: Props): any {}`;
+export default function Test__AstroComponent_(_props: Props): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { filename: '/Users/nmoo/test.astro', sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -140,14 +145,15 @@ interface Props<T> {}
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props<T> {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_<T>(_props: Props<T>): any {}`;
+export default function __AstroComponent_<T>(_props: Props<T>): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -160,14 +166,15 @@ interface Props<T extends Other<{ [key: string]: any }>> {}
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props<T extends Other<{ [key: string]: any }>> {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_<T extends Other<{ [key: string]: any }>>(_props: Props<T>): any {}`;
+export default function __AstroComponent_<T extends Other<{ [key: string]: any }>>(_props: Props<T>): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -180,14 +187,15 @@ interface Props<T extends { [key: string]: any }, P extends string ? { [key: str
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never> {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never>(_props: Props<T, P>): any {}`;
+export default function __AstroComponent_<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never>(_props: Props<T, P>): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -200,14 +208,15 @@ interface Props<T extends Something<false> ? A : B, P extends string ? { [key: s
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never> {}
 
 "";<Fragment>
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never>(_props: Props<T, P>): any {}`;
+export default function __AstroComponent_<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never>(_props: Props<T, P>): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -222,7 +231,7 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 
 <div></div>
 `;
-  const output = `${PREFIX}
+  const output = `
 interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<Tag> {
   as?: Tag;
 }
@@ -231,7 +240,8 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 <div></div>
 
 </Fragment>
-export default function __AstroComponent_<Tag extends keyof JSX.IntrinsicElements>(_props: Props<Tag>): any {}`;
+export default function __AstroComponent_<Tag extends keyof JSX.IntrinsicElements>(_props: Props<Tag>): any {}
+${PREFIX}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -251,7 +261,7 @@ import SvelteOptionalProps from './SvelteOptionalProps.svelte';
 <SvelteOptionalProps />
 
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });

--- a/packages/compiler/test/tsx/raw.ts
+++ b/packages/compiler/test/tsx/raw.ts
@@ -1,13 +1,13 @@
+import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler';
 
 test('style is raw', async () => {
   const input = `<style>div { color: red; }</style>`;
   const output = `<Fragment>
 <style>{\`div { color: red; }\`}</style>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -17,7 +17,7 @@ test('is:raw is raw', async () => {
   const output = `<Fragment>
 <div is:raw>{\`A{B}C\`}</div>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });

--- a/packages/compiler/test/tsx/script.ts
+++ b/packages/compiler/test/tsx/script.ts
@@ -1,6 +1,6 @@
+import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler';
 
 test('script function', async () => {
   const input = `<script type="module">console.log({ test: \`literal\` })</script>`;
@@ -9,7 +9,7 @@ test('script function', async () => {
 {() => {console.log({ test: \`literal\` })}}
 </script>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -21,7 +21,7 @@ test('partytown function', async () => {
 {() => {console.log({ test: \`literal\` })}}
 </script>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
@@ -31,7 +31,7 @@ test('ld+json wrapping', async () => {
   const output = `<Fragment>
 <script type="application/ld+json">{\`{"a":"b"}\`}</script>
 </Fragment>
-export default function __AstroComponent_(_props: Record<string, any>): any {}`;
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });
   assert.snapshot(code, output, `expected code to match snapshot`);
 });


### PR DESCRIPTION
## Changes

By not shifting the start of the file, it allows consumer downstream to always assume that the frontmatter is the beginning of the file, this is especially useful for mapping code actions and completions that are supposed to add code to the frontmatter since we can know where the frontmatter starts and end in the virtual file by using the positions of it in the real file

Ultimately, it'd be better to solve this in another way (maybe provide the location of the frontmatter in the virtual file), but this changes makes things easier in the meantime

## Testing

Updated tests

## Docs

N/A
