### PR TITLE
Fix `compressHTML` edge case

### DIFF
--- a/.changeset/good-trains-matter.md
+++ b/.changeset/good-trains-matter.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix `compressHTML` edge case when both leading and trailing whitespace is present

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -284,34 +284,37 @@ func collapseWhitespace(doc *astro.Node) {
 				return
 			}
 			originalLen := len(n.Data)
-			hasNewline := false
+			hasLeftNewline := false
 			n.Data = strings.TrimLeftFunc(n.Data, func(r rune) bool {
 				if r == '\n' {
-					hasNewline = true
+					hasLeftNewline = true
 				}
 				return unicode.IsSpace(r)
 			})
 			if originalLen != len(n.Data) {
-				if hasNewline {
+				if hasLeftNewline {
 					n.Data = "\n" + n.Data
 				} else {
 					n.Data = " " + n.Data
 				}
 			}
-			hasNewline = false
+			hasRightNewline := false
 			originalLen = len(n.Data)
 			n.Data = strings.TrimRightFunc(n.Data, func(r rune) bool {
 				if r == '\n' {
-					hasNewline = true
+					hasRightNewline = true
 				}
 				return unicode.IsSpace(r)
 			})
 			if originalLen != len(n.Data) {
-				if hasNewline {
+				if hasRightNewline {
 					n.Data = n.Data + "\n"
 				} else {
 					n.Data = n.Data + " "
 				}
+			}
+			if hasLeftNewline && hasRightNewline {
+				n.Data = strings.TrimSpace(n.Data)
 			}
 		}
 	})

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -355,7 +355,7 @@ func TestCompactTransform(t *testing.T) {
 		{
 			name:   "collapse surrounding newlines",
 			source: "<div>\n\n\tC O O L\n\n\t</div>",
-			want:   "<div>\nC O O L\n</div>",
+			want:   "<div>C O O L</div>",
 		},
 		{
 			name:   "expression trim first",

--- a/packages/compiler/test/compact/minify.ts
+++ b/packages/compiler/test/compact/minify.ts
@@ -148,81 +148,12 @@ test('space normalization around text', async () => {
       assert.match(await minify(input), output);
     })
   );
-  // await Promise.all([
-  //   ' a <? b ?> c ',
-  //   '<!-- d --> a <? b ?> c ',
-  //   ' <!-- d -->a <? b ?> c ',
-  //   ' a<!-- d --> <? b ?> c ',
-  //   ' a <!-- d --><? b ?> c ',
-  //   ' a <? b ?><!-- d --> c ',
-  //   ' a <? b ?> <!-- d -->c ',
-  //   ' a <? b ?> c<!-- d --> ',
-  //   ' a <? b ?> c <!-- d -->'
-  // ].map(async (input) => {
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     conservativeCollapse: true
-  //   })).toBe(input, input);
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     removeComments: true
-  //   })).toBe('a <? b ?> c', input);
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     conservativeCollapse: true,
-  //     removeComments: true
-  //   })).toBe(' a <? b ?> c ', input);
-  //   input = '<p>' + input + '</p>';
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     conservativeCollapse: true
-  //   })).toBe(input, input);
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     removeComments: true
-  //   })).toBe('<p>a <? b ?> c</p>', input);
-  //   expect(await minify(input, {
-  //     collapseWhitespace: true,
-  //     conservativeCollapse: true,
-  //     removeComments: true
-  //   })).toBe('<p> a <? b ?> c </p>', input);
-  // }));
-  // input = '<li><i></i> <b></b> foo</li>';
-  // output = '<li><i></i> <b></b> foo</li>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<li><i> </i> <b></b> foo</li>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<li> <i></i> <b></b> foo</li>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<li><i></i> <b> </b> foo</li>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<li> <i> </i> <b> </b> foo</li>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<div> <a href="#"> <span> <b> foo </b> <i> bar </i> </span> </a> </div>';
-  // output = '<div><a href="#"><span><b>foo </b><i>bar</i></span></a></div>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<head> <!-- a --> <!-- b --><link> </head>';
-  // output = '<head><!-- a --><!-- b --><link></head>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<head> <!-- a --> <!-- b --> <!-- c --><link> </head>';
-  // output = '<head><!-- a --><!-- b --><!-- c --><link></head>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<p> foo\u00A0bar\nbaz  \u00A0\nmoo\t</p>';
-  // output = '<p>foo\u00A0bar baz \u00A0 moo</p>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<label> foo </label>\n' +
-  //   '<input>\n' +
-  //   '<object> bar </object>\n' +
-  //   '<select> baz </select>\n' +
-  //   '<textarea> moo </textarea>\n';
-  // output = '<label>foo</label> <input> <object>bar</object> <select>baz</select> <textarea> moo </textarea>';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
-  // input = '<pre>\n' +
-  //   'foo\n' +
-  //   '<br>\n' +
-  //   'bar\n' +
-  //   '</pre>\n' +
-  //   'baz\n';
-  // output = '<pre>\nfoo\n<br>\nbar\n</pre>baz';
-  // expect(await minify(input, { collapseWhitespace: true })).toBe(output);
+});
+
+test('surrounded by newlines #7401', async () => {
+  const input = '<span>foo</span>\n\t\tbar\n\t\t<span>baz</span>';
+  const output = '<span>foo</span>bar<span>baz</span>';
+  const result = await minify(input);
+
+  assert.match(result, output);
 });


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/7401
- We were preserving newlines, even if both _leading_ and _trailing_ newlines were present. Newlines should only be preserved if they are not symmetrical.

## Testing

New test added

## Docs

N/a, bug fix only