### PR TITLE
Preserve whitespace in text surrounded by newlines

### DIFF
--- a/.changeset/soft-eggs-exercise.md
+++ b/.changeset/soft-eggs-exercise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Do not remove surrounding whitespace from text surrounded by newlines when `compressHTML` is enabled

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -355,7 +355,7 @@ func TestCompactTransform(t *testing.T) {
 		{
 			name:   "collapse surrounding newlines",
 			source: "<div>\n\n\tC O O L\n\n\t</div>",
-			want:   "<div>C O O L</div>",
+			want:   "<div>\nC O O L\n</div>",
 		},
 		{
 			name:   "expression trim first",

--- a/packages/compiler/test/compact/minify.ts
+++ b/packages/compiler/test/compact/minify.ts
@@ -20,7 +20,7 @@ test('preservation', async () => {
 
 test('collapsing', async () => {
   assert.match(await minify(`<span> inline </span>`), '$$render`<span> inline </span>`');
-  assert.match(await minify(`<span>\n inline \t{\t expression \t}</span>`), '$$render`<span> inline ${expression}</span>`');
+  assert.match(await minify(`<span>\n inline \t{\t expression \t}</span>`), '$$render`<span>\ninline ${expression}</span>`');
   assert.match(await minify(`<span> inline { expression }</span>`), '$$render`<span> inline ${expression}</span>`');
 });
 
@@ -150,9 +150,17 @@ test('space normalization around text', async () => {
   );
 });
 
-test('surrounded by newlines #7401', async () => {
+test('surrounded by newlines (astro#7401)', async () => {
   const input = '<span>foo</span>\n\t\tbar\n\t\t<span>baz</span>';
-  const output = '<span>foo</span>bar<span>baz</span>';
+  const output = '<span>foo</span>\nbar\n<span>baz</span>';
+  const result = await minify(input);
+
+  assert.match(result, output);
+});
+
+test('separated by newlines (#815)', async () => {
+  const input = '<p>\n\ta\n\t<span>b</span>\n\tc\n</p>';
+  const output = '<p>\na\n<span>b</span>\nc\n</p>';
   const result = await minify(input);
 
   assert.match(result, output);

--- a/packages/compiler/test/compact/minify.ts
+++ b/packages/compiler/test/compact/minify.ts
@@ -14,14 +14,14 @@ test('basic', async () => {
 
 test('preservation', async () => {
   assert.match(await minify(`<pre>  !  </pre>`), '$$render`<pre>  !  </pre>`');
-  assert.ok(await minify(`<div is:raw>  !  </div>`), '$$render`<div>  !  </div>`');
-  assert.ok(await minify(`<Markdown>  !  </Markdown>`), '$$render`  !  `');
+  assert.match(await minify(`<div is:raw>  !  </div>`), '$$render`<div>  !  </div>`');
+  assert.match(await minify(`<Markdown is:raw>  !  </Markdown>`), '$$render`  !  `');
 });
 
 test('collapsing', async () => {
-  assert.ok(await minify(`<span> inline </span>`), '$$render`<span> inline </span>`');
-  assert.ok(await minify(`<span>\n inline \t{\t expression \t}</span>`), '$$render`<span> inline ${ expression } </span>`');
-  assert.ok(await minify(`<span> inline { expression }</span>`), '$$render`<span> inline ${ expression }</span>`');
+  assert.match(await minify(`<span> inline </span>`), '$$render`<span> inline </span>`');
+  assert.match(await minify(`<span>\n inline \t{\t expression \t}</span>`), '$$render`<span> inline ${expression}</span>`');
+  assert.match(await minify(`<span> inline { expression }</span>`), '$$render`<span> inline ${expression}</span>`');
 });
 
 test('space normalization between attributes', async () => {


### PR DESCRIPTION
## Changes

Closes #815. This issue came about as withastro/astro#7401 reported the previous whitespace-preserving behavior as incorrect, leading to #809. See [my comment](https://github.com/withastro/astro/issues/7401#issuecomment-1619327198) for why the behavior introduced by that PR is incorrect.

TLDR: revert #809 (& more)

## Testing

I added a new test based on #815 and fixed a few problems with old tests.

## Docs

Documentation not changed as this is purely a bugfix.
