### PR TITLE
fix(#814): improve Props import detection

### DIFF
--- a/.changeset/swift-crews-develop.md
+++ b/.changeset/swift-crews-develop.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix props detection when importing `Props` from another file (see [#814](https://github.com/withastro/compiler/issues/814))

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -310,6 +310,12 @@ outer:
 
 		if js.IsIdentifier(token) {
 			if isKeyword(value) {
+				// fix(#814): fix Props detection when using `{ Props as SomethingElse }`
+				if ident == "Props" && string(value) == "as" {
+					start = 0
+					ident = defaultPropType
+					idents = make([]string, 0)
+				}
 				i += len(value)
 				continue
 			}

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -266,4 +266,23 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('unrelated sibling prop', async () => {
+  const input = `---
+import type { Props as ComponentBProps } from './ComponentB.astro'
+---
+
+<div />
+`;
+  const output = `
+import type { Props as ComponentBProps } from './ComponentB.astro'
+
+"";<Fragment>
+<div />
+
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Resolves https://github.com/withastro/compiler/issues/814
- Improves `Prop` import detection to avoid falsely detecting `import { Props as SomethingElse }` statements

## Testing

Test added, this will also fix https://github.com/withastro/language-tools/issues/585 and remove the need for https://github.com/withastro/astro/pull/7550

## Docs

No, bug fix only