### PR TITLE
Capture closing frontmatter location on EOF

### DIFF
--- a/.changeset/eight-ducks-invent.md
+++ b/.changeset/eight-ducks-invent.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+[AST] Include end position for frontmatter node when it is the only item in the file

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2683,6 +2683,8 @@ func frontmatterIM(p *parser) bool {
 		p.oe.pop()
 		return true
 	default:
+		// Might be EOF, make sure to capture last location
+		p.addLoc()
 		p.im = p.originalIM
 		p.originalIM = nil
 		return false

--- a/packages/compiler/test/parse/position.ts
+++ b/packages/compiler/test/parse/position.ts
@@ -86,4 +86,18 @@ test('include correct start and end position for normal closing tag', async () =
   assert.equal(li.position.end, { line: 3, column: 10, offset: 35 }, `Expected serialized output to contain an end position`);
 });
 
+test('include start and end position if frontmatter is only thing in file (#802)', async () => {
+  const input = `---
+---`;
+  const { ast } = await parse(input);
+
+  const frontmatter = ast.children[0];
+  assert.is(frontmatter.type, 'frontmatter');
+  assert.ok(frontmatter.position.start, `Expected serialized output to contain a start position`);
+  assert.ok(frontmatter.position.end, `Expected serialized output to contain an end position`);
+
+  assert.equal(frontmatter.position.start, { line: 1, column: 1, offset: 0 }, `Expected serialized output to contain a start position`);
+  assert.equal(frontmatter.position.end, { line: 2, column: 4, offset: 7 }, `Expected serialized output to contain an end position`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Resolves #802
- Includes end position in AST even when frontmatter is the only node in the file

## Testing

Test added

## Docs

Bug fix only