### PR TITLE
Add raw attribute values to AST

### DIFF
--- a/.changeset/orange-kangaroos-dress.md
+++ b/.changeset/orange-kangaroos-dress.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+[AST] add raw attribute values to AST

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3014,7 +3014,7 @@ const c = '\''
 		{
 			name:   "Preserve namespaces",
 			source: `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><rect xlink:href="#id"></svg>`,
-			want:   []ASTNode{{Type: "element", Name: "svg", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xmlns", Value: "http://www.w3.org/2000/svg"}, {Type: "attribute", Kind: "quoted", Name: "xmlns:xlink", Value: "http://www.w3.org/1999/xlink"}}, Children: []ASTNode{{Type: "element", Name: "rect", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xlink:href", Value: "#id"}}}}}},
+			want:   []ASTNode{{Type: "element", Name: "svg", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xmlns", Value: "http://www.w3.org/2000/svg", Raw: `"http://www.w3.org/2000/svg"`}, {Type: "attribute", Kind: "quoted", Name: "xmlns:xlink", Value: "http://www.w3.org/1999/xlink", Raw: `"http://www.w3.org/1999/xlink"`}}, Children: []ASTNode{{Type: "element", Name: "rect", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "xlink:href", Value: "#id", Raw: `"#id"`}}}}}},
 		},
 		{
 			name:   "style before html",

--- a/packages/compiler/src/browser/utils.ts
+++ b/packages/compiler/src/browser/utils.ts
@@ -82,7 +82,7 @@ function serializeAttributes(node: TagLikeNode): string {
         break;
       }
       case 'quoted': {
-        output += `${attr.name}="${attr.value}"`;
+        output += `${attr.name}=${attr.raw}`;
         break;
       }
       case 'template-literal': {

--- a/packages/compiler/src/node/utils.ts
+++ b/packages/compiler/src/node/utils.ts
@@ -82,7 +82,7 @@ function serializeAttributes(node: TagLikeNode): string {
         break;
       }
       case 'quoted': {
-        output += `${attr.name}="${attr.value}"`;
+        output += `${attr.name}=${attr.raw}`;
         break;
       }
       case 'template-literal': {

--- a/packages/compiler/src/shared/ast.ts
+++ b/packages/compiler/src/shared/ast.ts
@@ -38,6 +38,7 @@ export interface AttributeNode extends BaseNode {
   kind: 'quoted' | 'empty' | 'expression' | 'spread' | 'shorthand' | 'template-literal';
   name: string;
   value: string;
+  raw?: string;
 }
 
 export interface TextNode extends ValueNode {

--- a/packages/compiler/test/parse/serialize.ts
+++ b/packages/compiler/test/parse/serialize.ts
@@ -50,4 +50,11 @@ test('self-close elements', async () => {
   assert.equal(selfClosedOutput, input, `Expected serialized output to equal ${input}`);
 });
 
+test('raw attributes', async () => {
+  const input = `<div name="value" single='quote' un=quote />`;
+  const { ast } = await parse(input);
+  const output = serialize(ast);
+  assert.equal(output, input, `Expected serialized output to equal ${input}`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Resolves #796
- In the AST, quoted attributes now contain their raw values
- This allows `serialize` to maintain the originally authored format of the attribute (double, single, or no quotes)

## Testing

Test added

## Docs

Need to update docs still!