### PR TITLE
Maintain whitespace before tag close

### DIFF
--- a/.changeset/seven-moons-design.md
+++ b/.changeset/seven-moons-design.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+[TSX] maintain trailing whitespace before an element is closed, fixing TypeScript completion in some cases

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -264,6 +264,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	p.print("<")
 	p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start})
 	p.print(n.Data)
+	p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start + len(n.Data)})
 
 	invalidTSXAttributes := make([]Attribute, 0)
 	endLoc := n.Loc[0].Start + len(n.Data)
@@ -422,6 +423,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	isSelfClosing := false
 	hasLeadingSpace := false
 	tmpLoc := endLoc
+	leadingSpaceLoc := endLoc
 	if len(p.sourcetext) > tmpLoc {
 		for i := 0; i < len(p.sourcetext[tmpLoc:]); i++ {
 			c := p.sourcetext[endLoc : endLoc+1][0]
@@ -434,6 +436,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 				break
 			} else if unicode.IsSpace(rune(c)) {
 				hasLeadingSpace = true
+				leadingSpaceLoc = endLoc
 				endLoc++
 			} else {
 				endLoc++
@@ -444,8 +447,9 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 	}
 
 	if hasLeadingSpace {
-		p.addSourceMapping(loc.Loc{Start: endLoc - 1})
+		p.addSourceMapping(loc.Loc{Start: leadingSpaceLoc})
 		p.print(" ")
+		p.addSourceMapping(loc.Loc{Start: leadingSpaceLoc + 1})
 	}
 
 	if voidElements[n.Data] && n.FirstChild == nil {

--- a/packages/compiler/test/tsx-sourcemaps/tags.ts
+++ b/packages/compiler/test/tsx-sourcemaps/tags.ts
@@ -1,5 +1,7 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { convertToTSX } from '@astrojs/compiler';
+import { generatedPositionFor, TraceMap } from '@jridgewell/trace-mapping';
 import { testTSXSourcemap } from '../utils';
 
 test('tag close', async () => {
@@ -11,6 +13,19 @@ test('tag close', async () => {
     column: 6,
     source: 'index.astro',
     name: null,
+  });
+});
+
+test('tag with spaces', async () => {
+  const input = `<Button      ></Button>`;
+  const { map } = await convertToTSX(input, { sourcemap: 'both', filename: 'index.astro' });
+  const tracer = new TraceMap(map);
+
+  const generated = generatedPositionFor(tracer, { source: 'index.astro', line: 1, column: 14 });
+
+  assert.equal(generated, {
+    line: 2,
+    column: 9,
   });
 });
 

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -214,4 +214,24 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('preserves spaces in tag', async () => {
+  const input = '<Button ></Button>';
+  const output = `<Fragment>
+<Button ></Button>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test('preserves spaces after attributes in tag', async () => {
+  const input = '<Button a="b" ></Button>';
+  const output = `<Fragment>
+<Button a="b" ></Button>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
 test.run();

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -234,4 +234,14 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('preserves spaces in tag', async () => {
+  const input = '<Button      >';
+  const output = `<Fragment>
+<Button ></Button>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- Resolves #801
- Maintains trailing whitespace in TSX output, which fixes TS completions in some cases

## Testing

Two tests added

## Docs

N/A, bug fix only