### PR TITLE
[TSX] escape more invalid characters

### DIFF
--- a/.changeset/few-cats-happen.md
+++ b/.changeset/few-cats-happen.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+[TSX] escape additional invalid characters

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -178,7 +178,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 			p.print("}}\n")
 			p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start + len(n.Data)})
 			return
-		} else if strings.ContainsAny(n.Data, "{}") {
+		} else if strings.ContainsAny(n.Data, "{}<>'\"") {
 			p.addNilSourceMapping()
 			p.print("{`")
 			p.printTextWithSourcemap(escapeText(n.Data), n.Loc[0])

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -178,7 +178,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s>>`, props.Ident)
 			p.print("}}\n")
 			p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start + len(n.Data)})
 			return
-		} else if strings.ContainsAny(n.Data, "{}<>'\"") {
+		} else if strings.ContainsAny(n.Data, "{}<>'\"") && n.Data[0] != '<' {
 			p.addNilSourceMapping()
 			p.print("{`")
 			p.printTextWithSourcemap(escapeText(n.Data), n.Loc[0])


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/language-tools/issues/583
- Escapes more invalid characters in text nodes! Only thing not handled is if the initial character is `<` because that's probably an unclosed tag and we want to print it literally

## Testing

Existing tests pass

## Docs

N/A, bug fix only