### PR TITLE
Adds congrats workflow

### DIFF
--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -1,0 +1,14 @@
+name: Congratsbot
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  congrats:
+    if: ${{ github.repository_owner == 'withastro' }}
+    uses: withastro/automation/.github/workflows/congratsbot.yml@main
+    with:
+      EMOJIS: '⚙️,🔩,🔧,🛠️,🧰,🗜️,🦺,<:lgtm:1121889033602215966>'
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_CONGRATS }}


### PR DESCRIPTION
## Changes

- Adds our Discord congrats bot to this repo
- Doesn’t do any filtering based on commit names (in other repos we ignore `[ci] format` but looks like that’s not a thing here)
- Uses a toolbox of emoji:
   <img width="224" alt="image" src="https://github.com/withastro/compiler/assets/357379/62463a31-7be8-4f17-a323-f6558006285b">

- [x] Needs someone to add a `DISCORD_WEBHOOK_CONGRATS` secret to this repo (I can provide the value, so it posts to `#dev` on Discord)

## Testing

Same workflow we use in other repos.

## Docs

N/A