### PR TITLE
Support for view transition directives

### DIFF
--- a/.changeset/young-turkeys-wave.md
+++ b/.changeset/young-turkeys-wave.md
@@ -1,0 +1,7 @@
+---
+'@astrojs/compiler': minor
+---
+
+Support for view transition directives
+
+This adds support for `transition:animate` and `transition:name` which get passed into the new `renderTransition` runtime function.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -95,6 +95,10 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	if jsBool(options.Get("resultScopedSlot")) {
 		scopedSlot = true
 	}
+	experimentalTransitions := false
+	if jsBool(options.Get("experimentalTransitions")) {
+		experimentalTransitions = true
+	}
 
 	var resolvePath any = options.Get("resolvePath")
 	var resolvePathFn func(string) string
@@ -117,16 +121,17 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	}
 
 	return transform.TransformOptions{
-		Filename:            filename,
-		NormalizedFilename:  normalizedFilename,
-		InternalURL:         internalURL,
-		SourceMap:           sourcemap,
-		AstroGlobalArgs:     astroGlobalArgs,
-		Compact:             compact,
-		ResolvePath:         resolvePathFn,
-		PreprocessStyle:     preprocessStyle,
-		ResultScopedSlot:    scopedSlot,
-		ScopedStyleStrategy: scopedStyleStrategy,
+		Filename:                filename,
+		NormalizedFilename:      normalizedFilename,
+		InternalURL:             internalURL,
+		SourceMap:               sourcemap,
+		AstroGlobalArgs:         astroGlobalArgs,
+		Compact:                 compact,
+		ResolvePath:             resolvePathFn,
+		PreprocessStyle:         preprocessStyle,
+		ResultScopedSlot:        scopedSlot,
+		ScopedStyleStrategy:     scopedStyleStrategy,
+		ExperimentalTransitions: experimentalTransitions,
 	}
 }
 

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -99,6 +99,10 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	if jsBool(options.Get("experimentalTransitions")) {
 		experimentalTransitions = true
 	}
+	transitionsAnimationURL := jsString(options.Get("transitionsAnimationURL"))
+	if transitionsAnimationURL == "" {
+		transitionsAnimationURL = "astro/components/viewtransitions.css"
+	}
 
 	var resolvePath any = options.Get("resolvePath")
 	var resolvePathFn func(string) string
@@ -132,6 +136,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		ResultScopedSlot:        scopedSlot,
 		ScopedStyleStrategy:     scopedStyleStrategy,
 		ExperimentalTransitions: experimentalTransitions,
+		TransitionsAnimationURL: transitionsAnimationURL,
 	}
 }
 

--- a/internal/node.go
+++ b/internal/node.go
@@ -79,10 +79,12 @@ type HydratedComponentMetadata struct {
 // Similarly, "math" is short for "http://www.w3.org/1998/Math/MathML", and
 // "svg" is short for "http://www.w3.org/2000/svg".
 type Node struct {
-	Fragment      bool
-	CustomElement bool
-	Component     bool
-	Expression    bool
+	Fragment        bool
+	CustomElement   bool
+	Component       bool
+	Expression      bool
+	Transition      bool
+	TransitionScope string
 
 	Parent, FirstChild, LastChild, PrevSibling, NextSibling *Node
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -446,7 +446,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 			n.Attr = append(n.Attr, astro.Attribute{
 				Key:  "data-astro-transition-scope",
-				Val:  fmt.Sprintf(`${%s(%s, "%s", "%s", "%s")}`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationName, transitionName),
+				Val:  fmt.Sprintf(`%s(%s, "%s", "%s", "%s")`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationName, transitionName),
 				Type: astro.ExpressionAttribute,
 			})
 		}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -133,7 +133,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		}
 
 		p.printReturnClose()
-		p.printFuncSuffix(opts.opts)
+		p.printFuncSuffix(opts.opts, n)
 		return
 	}
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -111,7 +111,7 @@ func emptyTextNodeWithoutSiblings(n *Node) bool {
 func render1(p *printer, n *Node, opts RenderOptions) {
 	depth := opts.depth
 
-	if n.Transition {
+	if opts.opts.ExperimentalTransitions && n.Transition {
 		p.needsTransitionCSS = true
 	}
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -110,6 +110,10 @@ func emptyTextNodeWithoutSiblings(n *Node) bool {
 func render1(p *printer, n *Node, opts RenderOptions) {
 	depth := opts.depth
 
+	if n.Transition {
+		p.needsTransitionCSS = true
+	}
+
 	// Root of the document, print all children
 	if n.Type == DocumentNode {
 		p.printInternalImports(p.opts.InternalURL, &opts)
@@ -692,6 +696,16 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				}
 				p.printTemplateLiteralClose()
 			default:
+				if transform.HasAttr(n, "transition:animate") {
+					transitionName := ""
+					if transform.HasAttr(n, "transition:name") {
+						transitionName = transform.GetAttr(n, "transition:name").Val
+					}
+
+					val := transform.GetAttr(n, "transition:animate").Val
+					p.print(fmt.Sprintf(`${%s(%s, "%s", "%s", "%s")}`, RENDER_TRANSITION, RESULT, n.TransitionScope, val, transitionName))
+				}
+
 				for c := n.FirstChild; c != nil; c = c.NextSibling {
 					render1(p, c, RenderOptions{
 						isRoot:           false,

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -118,8 +118,10 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.print("defineStyleVars as " + DEFINE_STYLE_VARS + ",\n  ")
 	p.addNilSourceMapping()
 	p.print("defineScriptVars as " + DEFINE_SCRIPT_VARS + ",\n  ")
-	p.addNilSourceMapping()
-	p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
+	if opts.opts.ExperimentalTransitions {
+		p.addNilSourceMapping()
+		p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
+	}
 
 	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -28,6 +28,7 @@ type printer struct {
 	hasFuncPrelude     bool
 	hasInternalImports bool
 	hasCSSImports      bool
+	needsTransitionCSS bool
 }
 
 var TEMPLATE_TAG = "$$render"
@@ -40,6 +41,7 @@ var UNESCAPE_HTML = "$$unescapeHTML"
 var RENDER_SLOT = "$$renderSlot"
 var MERGE_SLOTS = "$$mergeSlots"
 var ADD_ATTRIBUTE = "$$addAttribute"
+var RENDER_TRANSITION = "$$renderTransition"
 var SPREAD_ATTRIBUTES = "$$spreadAttributes"
 var DEFINE_STYLE_VARS = "$$defineStyleVars"
 var DEFINE_SCRIPT_VARS = "$$defineScriptVars"
@@ -116,6 +118,8 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.print("defineStyleVars as " + DEFINE_STYLE_VARS + ",\n  ")
 	p.addNilSourceMapping()
 	p.print("defineScriptVars as " + DEFINE_SCRIPT_VARS + ",\n  ")
+	p.addNilSourceMapping()
+	p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
 
 	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {
@@ -140,6 +144,10 @@ func (p *printer) printCSSImports(cssLen int) {
 		// import '/src/pages/index.astro?astro&type=style&index=0&lang.css';
 		p.print(fmt.Sprintf("import \"%s?astro&type=style&index=%v&lang.css\";", p.opts.Filename, i))
 		i++
+	}
+	if p.needsTransitionCSS {
+		p.addNilSourceMapping()
+		p.print(`import "astro/components/viewtransitions.css";`)
 	}
 	p.print("\n")
 	p.hasCSSImports = true
@@ -323,7 +331,7 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 }
 
 func (p *printer) printAttribute(attr astro.Attribute, n *astro.Node) {
-	if attr.Key == "define:vars" || attr.Key == "set:text" || attr.Key == "set:html" || attr.Key == "is:raw" {
+	if attr.Key == "define:vars" || attr.Key == "set:text" || attr.Key == "set:html" || attr.Key == "is:raw" || attr.Key == "transition:animate" || attr.Key == "transition:name" {
 		return
 	}
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -258,15 +258,19 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
 	p.hasFuncPrelude = true
 }
 
-func (p *printer) printFuncSuffix(opts transform.TransformOptions) {
+func (p *printer) printFuncSuffix(opts transform.TransformOptions, n *astro.Node) {
 	componentName := getComponentName(opts.Filename)
 	p.addNilSourceMapping()
+	filenameArg := "undefined"
+	propagationArg := "undefined"
 	if len(opts.Filename) > 0 {
 		escapedFilename := strings.ReplaceAll(opts.Filename, "'", "\\'")
-		p.println(fmt.Sprintf("}, '%s');", escapedFilename))
-	} else {
-		p.println("});")
+		filenameArg = fmt.Sprintf("'%s'", escapedFilename)
 	}
+	if n.Transition {
+		propagationArg = "'self'"
+	}
+	p.println(fmt.Sprintf("}, %s, %s);", filenameArg, propagationArg))
 	p.println(fmt.Sprintf("export default %s;", componentName))
 }
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -149,7 +149,7 @@ func (p *printer) printCSSImports(cssLen int) {
 	}
 	if p.needsTransitionCSS {
 		p.addNilSourceMapping()
-		p.print(`import "astro/components/viewtransitions.css";`)
+		p.print(fmt.Sprintf(`import "%s";`, p.opts.TransitionsAnimationURL))
 	}
 	p.print("\n")
 	p.hasCSSImports = true

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -30,6 +30,7 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"spreadAttributes as " + SPREAD_ATTRIBUTES,
 	"defineStyleVars as " + DEFINE_STYLE_VARS,
 	"defineScriptVars as " + DEFINE_SCRIPT_VARS,
+	"renderTransition as " + RENDER_TRANSITION,
 	"createMetadata as " + CREATE_METADATA,
 }, ",\n  "), "http://localhost:3000/")
 var PRELUDE = fmt.Sprintf(`const $$Component = %s(async ($$result, $$props, %s) => {
@@ -37,7 +38,7 @@ const Astro = $$result.createAstro($$Astro, $$props, %s);
 Astro.self = $$Component;%s`, CREATE_COMPONENT, SLOTS, SLOTS, "\n\n")
 var RETURN = fmt.Sprintf("return %s%s", TEMPLATE_TAG, BACKTICK)
 var SUFFIX = fmt.Sprintf("%s;", BACKTICK) + `
-});
+}, undefined, undefined);
 export default $$Component;`
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro('https://astro.build');\nconst Astro = $$Astro;"
 var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
@@ -48,7 +49,7 @@ var NON_WHITESPACE_CHARS = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS
 func suffixWithFilename(filename string) string {
 
 	return fmt.Sprintf("%s;", BACKTICK) + fmt.Sprintf(`
-}, '%s');
+}, '%s', undefined);
 export default $$Component;`, filename)
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -30,7 +30,6 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"spreadAttributes as " + SPREAD_ATTRIBUTES,
 	"defineStyleVars as " + DEFINE_STYLE_VARS,
 	"defineScriptVars as " + DEFINE_SCRIPT_VARS,
-	"renderTransition as " + RENDER_TRANSITION,
 	"createMetadata as " + CREATE_METADATA,
 }, ",\n  "), "http://localhost:3000/")
 var PRELUDE = fmt.Sprintf(`const $$Component = %s(async ($$result, $$props, %s) => {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -27,6 +27,7 @@ type TransformOptions struct {
 	Compact                 bool
 	ResultScopedSlot        bool
 	ExperimentalTransitions bool
+	TransitionsAnimationURL string
 	ResolvePath             func(string) string
 	PreprocessStyle         interface{}
 }

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -17,17 +17,18 @@ const TRANSITION_ANIMATE = "transition:animate"
 const TRANSITION_NAME = "transition:name"
 
 type TransformOptions struct {
-	Scope               string
-	Filename            string
-	NormalizedFilename  string
-	InternalURL         string
-	SourceMap           string
-	AstroGlobalArgs     string
-	ScopedStyleStrategy string
-	Compact             bool
-	ResultScopedSlot    bool
-	ResolvePath         func(string) string
-	PreprocessStyle     interface{}
+	Scope                   string
+	Filename                string
+	NormalizedFilename      string
+	InternalURL             string
+	SourceMap               string
+	AstroGlobalArgs         string
+	ScopedStyleStrategy     string
+	Compact                 bool
+	ResultScopedSlot        bool
+	ExperimentalTransitions bool
+	ResolvePath             func(string) string
+	PreprocessStyle         interface{}
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -42,7 +43,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
-		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) {
+		if opts.ExperimentalTransitions && (HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME)) {
 			doc.Transition = true
 			n.TransitionScope = astro.HashString(fmt.Sprintf("%s-%v", opts.Scope, i))
 		}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -13,7 +13,8 @@ import (
 	a "golang.org/x/net/html/atom"
 )
 
-const ANIMATE_TRANSITION = "transition:animate"
+const TRANSITION_ANIMATE = "transition:animate"
+const TRANSITION_NAME = "transition:name"
 
 type TransformOptions struct {
 	Scope               string
@@ -41,14 +42,9 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
-		if HasAttr(n, ANIMATE_TRANSITION) {
+		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) {
 			doc.Transition = true
 			n.TransitionScope = astro.HashString(fmt.Sprintf("%s-%v", opts.Scope, i))
-			n.Attr = append(n.Attr, astro.Attribute{
-				Key:  "data-astro-transition-scope",
-				Val:  n.TransitionScope,
-				Type: astro.QuotedAttribute,
-			})
 		}
 		if len(definedVars) > 0 {
 			didAdd := AddDefineVars(n, definedVars)

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -53,6 +53,7 @@ export interface TransformOptions {
    * @deprecated "as" has been removed and no longer has any effect!
    */
   as?: 'document' | 'fragment';
+  experimentalTransitions?: boolean;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
 }

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -54,6 +54,7 @@ export interface TransformOptions {
    */
   as?: 'document' | 'fragment';
   experimentalTransitions?: boolean;
+  transitionsAnimationURL?: string;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
 }

--- a/packages/compiler/test/basic/trailing-newline.ts
+++ b/packages/compiler/test/basic/trailing-newline.ts
@@ -27,7 +27,7 @@ test.before(async () => {
 });
 
 test('does not add trailing newline to rendered output', () => {
-  assert.match(result.code, `}\`;\n}, '<stdin>');`, 'Does not include a trailing newline in the render function');
+  assert.match(result.code, `}\`;\n}, '<stdin>', undefined);`, 'Does not include a trailing newline in the render function');
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- `transition:animate` on an element is turned into `data-astro-transition-scope={renderTransition()}` which is used to create a scope name for the particular element and set up the CSS.
- Automatically includes the View transition CSS if one of the directives are used.

## Testing

- Testing all done in core for now

## Docs

N/A