### PR TITLE
Handle expressions for transition:name

### DIFF
--- a/.changeset/silent-bags-lay.md
+++ b/.changeset/silent-bags-lay.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes use of expression in transition:name

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -447,6 +447,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					transitionExpr = fmt.Sprintf(`"%s"`, attr.Val)
 				case astro.ExpressionAttribute:
 					transitionExpr = fmt.Sprintf(`(%s)`, attr.Val)
+				case astro.TemplateLiteralAttribute:
+					transitionExpr = fmt.Sprintf("`%s`", attr.Val)
 				}
 			}
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -439,14 +439,20 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			if transform.HasAttr(n, transform.TRANSITION_ANIMATE) {
 				animationName = transform.GetAttr(n, transform.TRANSITION_ANIMATE).Val
 			}
-			transitionName := ""
+			transitionExpr := ""
 			if transform.HasAttr(n, transform.TRANSITION_NAME) {
-				transitionName = transform.GetAttr(n, transform.TRANSITION_NAME).Val
+				attr := transform.GetAttr(n, transform.TRANSITION_NAME)
+				switch attr.Type {
+				case astro.QuotedAttribute:
+					transitionExpr = fmt.Sprintf(`"%s"`, attr.Val)
+				case astro.ExpressionAttribute:
+					transitionExpr = fmt.Sprintf(`(%s)`, attr.Val)
+				}
 			}
 
 			n.Attr = append(n.Attr, astro.Attribute{
 				Key:  "data-astro-transition-scope",
-				Val:  fmt.Sprintf(`%s(%s, "%s", "%s", "%s")`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationName, transitionName),
+				Val:  fmt.Sprintf(`%s(%s, "%s", "%s", %s)`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationName, transitionExpr),
 				Type: astro.ExpressionAttribute,
 			})
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2799,6 +2799,14 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute($$renderTransition($$result, "", "", (one + '-' + 'two')), "data-astro-transition-scope")}></div>`,
 			},
 		},
+		{
+			name:     "transition:name with an template literal",
+			source:   "<div transition:name=`${one}-two`></div>",
+			filename: "/projects/app/src/pages/page.astro",
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute($$renderTransition($$result, "", "", ` + BACKTICK + `${one}-two` + BACKTICK + `), "data-astro-transition-scope")}></div>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2791,6 +2791,14 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${($$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `<${Node.tag} ${stringifyAttributes(Node.attributes)}>` + BACKTICK + `)}` + BACKTICK + `,})}${Node.children.map((child) => ($$render` + BACKTICK + `${$$renderComponent($$result,'Astro.self',Astro.self,{"node":(child)})}` + BACKTICK + `))}${$$renderComponent($$result,'Fragment',Fragment,{},{"default": () => $$render` + BACKTICK + `${$$unescapeHTML(` + BACKTICK + `</${Node.tag}>` + BACKTICK + `)}` + BACKTICK + `,})}` + BACKTICK + `,})})` + BACKTICK + `}`,
 			},
 		},
+		{
+			name:     "transition:name with an expression",
+			source:   `<div transition:name={one + '-' + 'two'}></div>`,
+			filename: "/projects/app/src/pages/page.astro",
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute($$renderTransition($$result, "", "", (one + '-' + 'two')), "data-astro-transition-scope")}></div>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Fixes this: `<div transition:name={post.data.slug}>`. Previously only worked correctly with string values.

## Testing

- Test added

## Docs

Bug fix