### PR TITLE
Pass transition directives onto components

### DIFF
--- a/.changeset/tall-keys-repair.md
+++ b/.changeset/tall-keys-repair.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Pass transition directives onto components

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	. "github.com/withastro/compiler/internal"
-	astro "github.com/withastro/compiler/internal"
 	"github.com/withastro/compiler/internal/handler"
 	"github.com/withastro/compiler/internal/js_scanner"
 	"github.com/withastro/compiler/internal/loc"
@@ -404,6 +403,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	if isImplicit {
 		// do nothing
 	} else if isComponent {
+		maybeConvertTransition(n)
 		p.print(",")
 		p.printAttributesToObject(n)
 	} else if isSlot {
@@ -434,16 +434,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		}
 		p.print(`]`)
 	} else {
-		if transform.HasAttr(n, transform.TRANSITION_ANIMATE) || transform.HasAttr(n, transform.TRANSITION_NAME) {
-			animationExpr := convertAttributeValue(n, transform.TRANSITION_ANIMATE)
-			transitionExpr := convertAttributeValue(n, transform.TRANSITION_NAME)
-
-			n.Attr = append(n.Attr, astro.Attribute{
-				Key:  "data-astro-transition-scope",
-				Val:  fmt.Sprintf(`%s(%s, "%s", %s, %s)`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationExpr, transitionExpr),
-				Type: astro.ExpressionAttribute,
-			})
-		}
+		maybeConvertTransition(n)
 
 		for _, a := range n.Attr {
 			if transform.IsImplicitNodeMarker(a) || a.Key == "is:inline" {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -283,7 +283,8 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 		if i != 0 && !lastAttributeSkipped {
 			p.print(",")
 		}
-		if a.Key == "set:text" || a.Key == "set:html" || a.Key == "is:raw" {
+		if a.Key == "set:text" || a.Key == "set:html" || a.Key == "is:raw" || a.Key == "transition:animate" || a.Key == "transition:name" {
+			lastAttributeSkipped = true
 			continue
 		}
 		if a.Namespace != "" {
@@ -444,6 +445,19 @@ func remove(slice []*astro.Node, node *astro.Node) []*astro.Node {
 		}
 	}
 	return append(slice[:s], slice[s+1:]...)
+}
+
+func maybeConvertTransition(n *astro.Node) {
+	if transform.HasAttr(n, transform.TRANSITION_ANIMATE) || transform.HasAttr(n, transform.TRANSITION_NAME) {
+		animationExpr := convertAttributeValue(n, transform.TRANSITION_ANIMATE)
+		transitionExpr := convertAttributeValue(n, transform.TRANSITION_NAME)
+
+		n.Attr = append(n.Attr, astro.Attribute{
+			Key:  "data-astro-transition-scope",
+			Val:  fmt.Sprintf(`%s(%s, "%s", %s, %s)`, RENDER_TRANSITION, RESULT, n.TransitionScope, animationExpr, transitionExpr),
+			Type: astro.ExpressionAttribute,
+		})
+	}
 }
 
 func (p *printer) printComponentMetadata(doc *astro.Node, opts transform.TransformOptions, source []byte) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2815,6 +2815,15 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<div${$$addAttribute($$renderTransition($$result, "", (slide({duration:15})), ""), "data-astro-transition-scope")}></div>`,
 			},
 		},
+		{
+			name:     "transition:animate on Component",
+			only:     true,
+			source:   `<Component class="bar" transition:animate="morph"></Component>`,
+			filename: "/projects/app/src/pages/page.astro",
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{"class":"bar","data-astro-transition-scope":($$renderTransition($$result, "", "morph", ""))})}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Adds the `data-astro-transition-scope` var into components as well. This is needed so they can pass the result down to children, if they want.

## Testing

- New test added

## Docs

- N/A