### PR TITLE
test: re-enable all printer tests

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2817,7 +2817,6 @@ const items = ["Dog", "Cat", "Platipus"];
 		},
 		{
 			name:     "transition:animate on Component",
-			only:     true,
 			source:   `<Component class="bar" transition:animate="morph"></Component>`,
 			filename: "/projects/app/src/pages/page.astro",
 			want: want{


### PR DESCRIPTION
## Changes

re-enables printer tests (an `only: true` flag managed to slip in).

## Testing

N/A

## Docs

N/A
