### PR TITLE
Remove experimental transition flags

### DIFF
--- a/.changeset/giant-boats-mate.md
+++ b/.changeset/giant-boats-mate.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Remove experimental flags from `transition:` directives. They are now enabled by default.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -95,14 +95,6 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 	if jsBool(options.Get("resultScopedSlot")) {
 		scopedSlot = true
 	}
-	experimentalTransitions := false
-	if jsBool(options.Get("experimentalTransitions")) {
-		experimentalTransitions = true
-	}
-	experimentalPersistence := false
-	if jsBool(options.Get("experimentalPersistence")) {
-		experimentalPersistence = true
-	}
 	transitionsAnimationURL := jsString(options.Get("transitionsAnimationURL"))
 	if transitionsAnimationURL == "" {
 		transitionsAnimationURL = "astro/components/viewtransitions.css"
@@ -139,8 +131,6 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		PreprocessStyle:         preprocessStyle,
 		ResultScopedSlot:        scopedSlot,
 		ScopedStyleStrategy:     scopedStyleStrategy,
-		ExperimentalTransitions: experimentalTransitions,
-		ExperimentalPersistence: experimentalPersistence,
 		TransitionsAnimationURL: transitionsAnimationURL,
 	}
 }

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -110,7 +110,7 @@ func emptyTextNodeWithoutSiblings(n *Node) bool {
 func render1(p *printer, n *Node, opts RenderOptions) {
 	depth := opts.depth
 
-	if opts.opts.ExperimentalTransitions && n.Transition {
+	if n.Transition {
 		p.needsTransitionCSS = true
 	}
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -119,14 +119,10 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.print("defineStyleVars as " + DEFINE_STYLE_VARS + ",\n  ")
 	p.addNilSourceMapping()
 	p.print("defineScriptVars as " + DEFINE_SCRIPT_VARS + ",\n  ")
-	if opts.opts.ExperimentalTransitions {
-		p.addNilSourceMapping()
-		p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
-	}
-	if opts.opts.ExperimentalPersistence {
-		p.addNilSourceMapping()
-		p.print("createTransitionScope as " + CREATE_TRANSITION_SCOPE + ",\n  ")
-	}
+	p.addNilSourceMapping()
+	p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
+	p.addNilSourceMapping()
+	p.print("createTransitionScope as " + CREATE_TRANSITION_SCOPE + ",\n  ")
 
 	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -30,6 +30,8 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"spreadAttributes as " + SPREAD_ATTRIBUTES,
 	"defineStyleVars as " + DEFINE_STYLE_VARS,
 	"defineScriptVars as " + DEFINE_SCRIPT_VARS,
+	"renderTransition as " + RENDER_TRANSITION,
+	"createTransitionScope as " + CREATE_TRANSITION_SCOPE,
 	"createMetadata as " + CREATE_METADATA,
 }, ",\n  "), "http://localhost:3000/")
 var PRELUDE = fmt.Sprintf(`const $$Component = %s(async ($$result, $$props, %s) => {
@@ -2875,18 +2877,22 @@ const items = ["Dog", "Cat", "Platipus"];
 			hash := astro.HashString(code)
 			transform.ExtractStyles(doc)
 			transformOptions := transform.TransformOptions{
-				Scope:                   hash
+				Scope: hash,
 			}
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
-				Scope:           "XXXX",
-				InternalURL:     "http://localhost:3000/",
-				Filename:        tt.filename,
-				AstroGlobalArgs: "'https://astro.build'",
+				Scope:                   "XXXX",
+				InternalURL:             "http://localhost:3000/",
+				Filename:                tt.filename,
+				AstroGlobalArgs:         "'https://astro.build'",
+				TransitionsAnimationURL: "transitions.css",
 			}, h)
 			output := string(result.Output)
 
 			toMatch := INTERNAL_IMPORTS
+			if strings.Count(tt.source, "transition:") > 0 {
+				toMatch += `import "transitions.css";`
+			}
 			if len(tt.want.frontmatter) > 0 {
 				toMatch += test_utils.Dedent(tt.want.frontmatter[0])
 			}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2875,9 +2875,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			hash := astro.HashString(code)
 			transform.ExtractStyles(doc)
 			transformOptions := transform.TransformOptions{
-				Scope:                   hash,
-				ExperimentalTransitions: true,
-				ExperimentalPersistence: true,
+				Scope:                   hash
 			}
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -27,8 +27,6 @@ type TransformOptions struct {
 	ScopedStyleStrategy     string
 	Compact                 bool
 	ResultScopedSlot        bool
-	ExperimentalTransitions bool
-	ExperimentalPersistence bool
 	TransitionsAnimationURL string
 	ResolvePath             func(string) string
 	PreprocessStyle         interface{}
@@ -46,7 +44,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
-		if opts.ExperimentalTransitions && (HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) || HasAttr(n, TRANSITION_PERSIST)) {
+		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) || HasAttr(n, TRANSITION_PERSIST) {
 			doc.Transition = true
 			getOrCreateTransitionScope(n, &opts, i)
 		}

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -299,9 +299,7 @@ func TestFullTransform(t *testing.T) {
 			ExtractStyles(doc)
 			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
 			doc.Styles = make([]*astro.Node, 0)
-			Transform(doc, TransformOptions{
-				ExperimentalTransitions: true,
-			}, handler.NewHandler(tt.source, "/test.astro"))
+			Transform(doc, TransformOptions{}, handler.NewHandler(tt.source, "/test.astro"))
 			astro.PrintToSource(&b, doc)
 			got := strings.TrimSpace(b.String())
 			if tt.want != got {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -53,8 +53,6 @@ export interface TransformOptions {
    * @deprecated "as" has been removed and no longer has any effect!
    */
   as?: 'document' | 'fragment';
-  experimentalTransitions?: boolean;
-  experimentalPersistence?: boolean;
   transitionsAnimationURL?: string;
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;


### PR DESCRIPTION
## Changes

- Removes `experimental` flags related to ViewTransitions (stable in 3.0)
- Will fix an error that throws in the current RC, since `astro` doesn't pass those flags anymore

## Testing

Manually

## Docs

N/A, bug fix