### PR TITLE
Add propagation metadata to the TransformResult

### DIFF
--- a/.changeset/clean-sloths-try.md
+++ b/.changeset/clean-sloths-try.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Add propagation metadata to the TransformResult

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -179,6 +179,7 @@ type TransformResult struct {
 	ClientOnlyComponents []HydratedComponent     `js:"clientOnlyComponents"`
 	ContainsHead         bool                    `js:"containsHead"`
 	StyleError           []string                `js:"styleError"`
+	Propagation          bool                    `js:"propagation"`
 }
 
 // This is spawned as a goroutine to preprocess style nodes using an async function passed from JS
@@ -412,6 +413,7 @@ func Transform() any {
 					ClientOnlyComponents: clientOnlyComponents,
 					ContainsHead:         doc.ContainsHead,
 					StyleError:           styleError,
+					Propagation:          doc.HeadPropagation,
 				}
 				switch transformOptions.SourceMap {
 				case "external":

--- a/internal/node.go
+++ b/internal/node.go
@@ -96,6 +96,7 @@ type Node struct {
 	ClientOnlyComponents     []*HydratedComponentMetadata
 	HydrationDirectives      map[string]bool
 	ContainsHead             bool
+	HeadPropagation          bool
 
 	Type      NodeType
 	DataAtom  atom.Atom

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -46,6 +46,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		}
 		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) || HasAttr(n, TRANSITION_PERSIST) {
 			doc.Transition = true
+			doc.HeadPropagation = true
 			getOrCreateTransitionScope(n, &opts, i)
 		}
 		if len(definedVars) > 0 {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -89,6 +89,7 @@ export interface TransformResult {
   hydratedComponents: HydratedComponent[];
   clientOnlyComponents: HydratedComponent[];
   containsHead: boolean;
+  propagation: boolean;
 }
 
 export interface SourceMap {

--- a/packages/compiler/test/transition/meta.ts
+++ b/packages/compiler/test/transition/meta.ts
@@ -1,0 +1,20 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<div transition:animate="slide"></div>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    resolvePath: async (s) => s,
+  });
+});
+
+test('tagged with propagation metadata', () => {
+  assert.equal(result.propagation, true);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- When `transition:` is used we are going to append styles. This adds the propagation flag to metadata so that Astro will propagate this up the tree, and wait for the component to load before resolving the head.

## Testing

- Added JS test to see that it's part of the metadata.