### PR TITLE
[WIP] Automatically enforce `satisfies` for `getStaticPaths`

### DIFF
--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -3,6 +3,7 @@ package printer
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -44,6 +45,39 @@ func getTSXComponentName(filename string) string {
 	} else {
 		return "__AstroComponent_"
 	}
+}
+
+func trimExt(filename string) string {
+	return strings.TrimSuffix(filename, filepath.Ext(filename))
+}
+
+func getParamsTypeFromFilename(filename string) string {
+	defaultType := "Record<string, string | number>"
+	if filename == "<stdin>" {
+		return defaultType
+	}
+	if len(filename) == 0 {
+		return defaultType
+	}
+	parts := strings.Split(filename, "/")
+	params := make([]string, 0)
+	r, err := regexp.Compile(`\[(?:\.{3})?([^]]+)\]`)
+	if err != nil {
+		return defaultType
+	}
+	for _, part := range parts {
+		if !strings.ContainsAny(part, "[]") {
+			continue
+		}
+		part = trimExt(part)
+		for _, match := range r.FindAllStringSubmatch(part, -1) {
+			params = append(params, fmt.Sprintf(`"%s"`, match[1]))
+		}
+	}
+	if len(params) == 0 {
+		return defaultType
+	}
+	return fmt.Sprintf("Record<%s, string | number>", strings.Join(params, " | "))
 }
 
 func getComponentName(filename string) string {

--- a/internal/printer/utils_test.go
+++ b/internal/printer/utils_test.go
@@ -1,0 +1,52 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/withastro/compiler/internal/test_utils"
+)
+
+type paramsTestcase struct {
+	name string
+	want string
+}
+
+func TestUtilParamsType(t *testing.T) {
+	tests := []paramsTestcase{
+		{
+			name: "/src/pages/index.astro",
+			want: `Record<string, string | number>`,
+		},
+		{
+			name: "/src/pages/blog/[slug].astro",
+			want: `Record<"slug", string | number>`,
+		},
+		{
+			name: "/src/pages/[lang]/blog/[slug].astro",
+			want: `Record<"lang" | "slug", string | number>`,
+		},
+		{
+			name: "/src/pages/[...fallback].astro",
+			want: `Record<"fallback", string | number>`,
+		},
+		{
+			name: "/src/pages/[year]-[month]-[day]/[post].astro",
+			want: `Record<"year" | "month" | "day" | "post", string | number>`,
+		},
+		{
+			name: "/src/pages/post-[id]/[post].astro",
+			want: `Record<"id" | "post", string | number>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getParamsTypeFromFilename(tt.name)
+			// compare to expected string, show diff if mismatch
+			if diff := test_utils.ANSIDiff(strings.TrimSpace(tt.want), strings.TrimSpace(string(result))); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

- Follow-up to https://github.com/withastro/compiler/pull/873
- This PR is relevant for consumers of our TSX output (namely language tools)
- It would be helpful to automatically inject `satisfies` for `getStaticPaths` clauses
- So far, this PR implements:
  - [x] Utility for generating expected `Params` type based on input filename
  - [ ] Injecting utility types when `getStaticPaths` exists
  - [ ] Injecting `satisfies` for `getStaticPaths`

## Testing

- [x] New utility tests added for `Params` inference
- [ ] [I asked for more complex](https://discord.com/channels/830184174198718474/1159190468073115648/1159190514181095444) `getStaticPaths` examples on Discord.

## Docs

N/A