### PR TITLE
fix(improper escaping): do not print "name"

### DIFF
--- a/.changeset/stupid-buttons-ring.md
+++ b/.changeset/stupid-buttons-ring.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixed an issue where spread attributes could not include double quotation marks.

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -417,9 +417,9 @@ func (p *printer) printAttribute(attr astro.Attribute, n *astro.Node) {
 		p.addSourceMapping(loc.Loc{Start: attr.KeyLoc.Start - 3})
 		p.print(strings.TrimSpace(attr.Key))
 		if !injectClass {
-			p.printf(`,"%s")}`, strings.TrimSpace(attr.Key))
+			p.print(`)}`)
 		} else {
-			p.printf(`,"%s",{"class":"astro-%s"})}`, strings.TrimSpace(attr.Key), p.opts.Scope)
+			p.printf(`,undefined,{"class":"astro-%s"})}`, p.opts.Scope)
 		}
 	case astro.ShorthandAttribute:
 		withoutComments, _ := removeComments(attr.Key)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1665,17 +1665,24 @@ import { Container, Col, Row } from 'react-bootstrap';
 			},
 		},
 		{
+			name:   "spread with double quotation marks",
+			source: `<div {...propsFn("string")}/>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(propsFn("string"))}></div>`,
+			},
+		},
+		{
 			name:   "class with spread",
 			source: `<div class="something" {...Astro.props} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div class="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div class="something"${$$spreadAttributes(Astro.props)}></div>`,
 			},
 		},
 		{
 			name:   "class:list with spread",
 			source: `<div class:list="something" {...Astro.props} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div class:list="something"${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div class:list="something"${$$spreadAttributes(Astro.props)}></div>`,
 			},
 		},
 		{
@@ -1710,14 +1717,14 @@ import { Container, Col, Row } from 'react-bootstrap';
 			name:   "spread without style or class",
 			source: `<div {...Astro.props} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,"Astro.props")}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props)}></div>`,
 			},
 		},
 		{
 			name:   "spread with style but no explicit class",
 			source: `<style>div { color: red; }</style><div {...Astro.props} />`,
 			want: want{
-				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,"Astro.props",{"class":"astro-XXXX"})}></div>`,
+				code: `${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"})}></div>`,
 			},
 		},
 		{


### PR DESCRIPTION
## Changes
- Closes #871 
- For reference: [runtime#spreadAttributes](https://github.com/withastro/astro/blob/astro@3.3.0/packages/astro/src/runtime/server/index.ts#L73)

## Testing
- Added a printer snapshot test.
- Edited existing printer snapshot tests where name was expected.

## Docs
Does not affect usage.