### PR TITLE
fix(tsx): add `MergeUnion` util to automatically inferred Props

### DIFF
--- a/.changeset/large-geese-kick.md
+++ b/.changeset/large-geese-kick.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+[TSX] Add ASTRO\_\_MergeUnion util to allow destructuring from automatically inferred union Prop types

--- a/.changeset/large-geese-kick.md
+++ b/.changeset/large-geese-kick.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-[TSX] Add ASTRO\_\_MergeUnion util to allow destructuring from automatically inferred union Prop types
+[TSX] Add `ASTRO__MergeUnion` util to allow destructuring from automatically inferred union Prop types

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -141,7 +141,7 @@ func renderTsx(p *printer, n *Node) {
 		if hasGetStaticPaths {
 			paramsIdent = "ASTRO__Get<ASTRO__InferredGetStaticPath, 'params'>"
 			if propsIdent == "Record<string, any>" {
-				propsIdent = "ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>"
+				propsIdent = "ASTRO__MergeUnion<ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>>"
 			}
 		}
 
@@ -150,6 +150,7 @@ func renderTsx(p *printer, n *Node) {
 			p.printf(`type ASTRO__ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 type ASTRO__Flattened<T> = T extends Array<infer U> ? ASTRO__Flattened<U> : T;
 type ASTRO__InferredGetStaticPath = ASTRO__Flattened<ASTRO__ArrayElement<Awaited<ReturnType<typeof getStaticPaths>>>>;
+type ASTRO__MergeUnion<T, K extends PropertyKey = T extends unknown ? keyof T : never> = T extends unknown ? T & { [P in Exclude<K, keyof T>]?: never } extends infer O ? { [P in keyof O]: O[P] } : never : never;
 type ASTRO__Get<T, K> = T extends undefined ? undefined : K extends keyof T ? T[K] : never;%s`, "\n")
 		}
 

--- a/packages/compiler/test/tsx/props-and-getStaticPaths.ts
+++ b/packages/compiler/test/tsx/props-and-getStaticPaths.ts
@@ -3,7 +3,7 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 
 function getPrefix({
-  props = `ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>`,
+  props = `ASTRO__MergeUnion<ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>>`,
   component = '__AstroComponent_',
   params = `ASTRO__Get<ASTRO__InferredGetStaticPath, 'params'>`,
 }: {
@@ -23,6 +23,7 @@ function getSuffix() {
   return `type ASTRO__ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 type ASTRO__Flattened<T> = T extends Array<infer U> ? ASTRO__Flattened<U> : T;
 type ASTRO__InferredGetStaticPath = ASTRO__Flattened<ASTRO__ArrayElement<Awaited<ReturnType<typeof getStaticPaths>>>>;
+type ASTRO__MergeUnion<T, K extends PropertyKey = T extends unknown ? keyof T : never> = T extends unknown ? T & { [P in Exclude<K, keyof T>]?: never } extends infer O ? { [P in keyof O]: O[P] } : never : never;
 type ASTRO__Get<T, K> = T extends undefined ? undefined : K extends keyof T ? T[K] : never;`;
 }
 
@@ -69,7 +70,7 @@ export function getStaticPaths() {
 "";<Fragment>
 <div></div>
 </Fragment>
-export default function __AstroComponent_(_props: ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>): any {}
+export default function __AstroComponent_(_props: ASTRO__MergeUnion<ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>>): any {}
 ${getSuffix()}
 ${getPrefix()}`;
   const { code } = await convertToTSX(input, { sourcemap: 'external' });


### PR DESCRIPTION
## Changes

- Automatically inferred `Props` has shipped!
- There was an edge case with union `Props` where they couldn't be destructured. 
- This PR adds a `MergeUnion` utility to flatten unions into each other so that divergent props don't need to be manually discriminated before destructuring.

## Testing

Test updated, type util manually tested

## Docs

Bug fix only