### PR TITLE
Fix expressions within td exitLiteralIM tracking

### DIFF
--- a/.changeset/odd-dryers-flow.md
+++ b/.changeset/odd-dryers-flow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix generated code for expressions within `td` elements

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2176,9 +2176,10 @@ func inRowIM(p *parser) bool {
 func inCellIM(p *parser) bool {
 	switch p.tok.Type {
 	case StartExpressionToken:
+		p.exitLiteralIM = getExitLiteralFunc(p)
 		p.addExpression()
 		p.afe = append(p.afe, &scopeMarker)
-		p.originalIM = inBodyIM
+		p.originalIM = inCellIM
 		p.im = inExpressionIM
 		return true
 	case EndExpressionToken:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1978,6 +1978,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "table expression with trailing div",
+			source: `<table><tr><td>{title}</td></tr></table><div>Div</div>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<table><tr><td>${title}</td></tr></table><div>Div</div>`,
+			},
+		},
+		{
 			name: "tbody expressions",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];


### PR DESCRIPTION
## Changes

Fix https://github.com/withastro/compiler/issues/870

For starting expressions within a table cell (`td`), `p.exitLiteralIM` (used to check when we can exit the insertion mode while parsing literals) was not assigned so the exit check at

https://github.com/withastro/compiler/blob/f5cff0127d2b2ea59201f6f84d308c57540bde68/internal/parser.go#L2697

Always returned false (default behaviour). Causing any tokens after the first `{` expression to be considered a literal incorrectly, since it'll never exit the insertion mode.

This PR sets `p.exitLiteralIM` to fix it, and also fix a slightly unrelated issue where exiting the literal IM in a table returned to a body IM, which I think is incorrect (?).

## Testing

Added a new test in go

## Docs

n/a. bug fix
