### PR TITLE
Fix compact for empty text nodes in elements

### DIFF
--- a/.changeset/real-mice-exist.md
+++ b/.changeset/real-mice-exist.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix compact collapse for empty text nodes between elements

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -277,10 +277,7 @@ func isRawElement(n *astro.Node) bool {
 }
 
 func isWhitespaceInsensitiveElement(n *astro.Node) bool {
-	if n.Data == "head" {
-		return true
-	}
-	return false
+	return n.Data == "head"
 }
 
 func collapseWhitespace(doc *astro.Node) {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -262,15 +262,25 @@ func isRawElement(n *astro.Node) bool {
 	if n.Type == astro.FrontmatterNode {
 		return true
 	}
+	for _, attr := range n.Attr {
+		if attr.Key == "is:raw" {
+			return true
+		}
+	}
 	rawTags := []string{"pre", "listing", "iframe", "noembed", "noframes", "math", "plaintext", "script", "style", "textarea", "title", "xmp"}
 	for _, tag := range rawTags {
 		if n.Data == tag {
 			return true
 		}
-		for _, attr := range n.Attr {
-			if attr.Key == "is:raw" {
-				return true
-			}
+	}
+	return false
+}
+
+func isWhitespaceInsensitiveElement(n *astro.Node) bool {
+	rawTags := []string{"head"}
+	for _, tag := range rawTags {
+		if n.Data == tag {
+			return true
 		}
 	}
 	return false
@@ -300,7 +310,12 @@ func collapseWhitespace(doc *astro.Node) {
 
 			// If the node is only whitespace, clear it
 			if len(strings.TrimFunc(n.Data, unicode.IsSpace)) == 0 {
-				n.Data = ""
+				// If it's a lone text node, or if it's within a whitespace-insensitive element, clear completely
+				if (n.PrevSibling == nil && n.NextSibling == nil) || n.Closest(isWhitespaceInsensitiveElement) != nil {
+					n.Data = ""
+				} else {
+					n.Data = " "
+				}
 				return
 			}
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -277,11 +277,8 @@ func isRawElement(n *astro.Node) bool {
 }
 
 func isWhitespaceInsensitiveElement(n *astro.Node) bool {
-	rawTags := []string{"head"}
-	for _, tag := range rawTags {
-		if n.Data == tag {
-			return true
-		}
+	if n.Data == "head" {
+		return true
 	}
 	return false
 }

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -404,6 +404,11 @@ func TestCompactTransform(t *testing.T) {
 			want:   "<div>\nC O O L\n</div>",
 		},
 		{
+			name:   "collapse in-between inline elements",
+			source: "<div>Click   <a>here</a> <span>space</span></div>",
+			want:   "<div>Click <a>here</a> <span>space</span></div>",
+		},
+		{
 			name:   "expression trim first",
 			source: "<div>{\n() => {\n\t\treturn <span />}}</div>",
 			want:   "<div>{() => {\n\t\treturn <span></span>}}</div>",

--- a/packages/compiler/test/compact/minify.ts
+++ b/packages/compiler/test/compact/minify.ts
@@ -47,9 +47,9 @@ test('space normalization around text', async () => {
   assert.match(await minify('<p>foo<wbr baz moo="">bar</p>'), '<p>foo<wbr baz moo="">bar</p>');
   assert.match(await minify('<p>foo <wbr baz moo="">bar</p>'), '<p>foo <wbr baz moo="">bar</p>');
   assert.match(await minify('<p>foo<wbr baz moo=""> bar</p>'), '<p>foo<wbr baz moo=""> bar</p>');
-  assert.match(await minify('<p>  <a href="#">  <code>foo</code></a> bar</p>'), '<p><a href="#"><code>foo</code></a> bar</p>');
+  assert.match(await minify('<p>  <a href="#">  <code>foo</code></a> bar</p>'), '<p> <a href="#"> <code>foo</code></a> bar</p>');
   assert.match(await minify('<p><a href="#"><code>foo  </code></a> bar</p>'), '<p><a href="#"><code>foo </code></a> bar</p>');
-  assert.match(await minify('<p>  <a href="#">  <code>   foo</code></a> bar   </p>'), '<p><a href="#"><code> foo</code></a> bar </p>');
+  assert.match(await minify('<p>  <a href="#">  <code>   foo</code></a> bar   </p>'), '<p> <a href="#"> <code> foo</code></a> bar </p>');
   assert.match(await minify('<div> Empty <!-- or --> not </div>'), '<div> Empty <!-- or --> not </div>');
   assert.match(await minify('<div> a <input><!-- b --> c </div>'), '<div> a <input><!-- b --> c </div>');
   await Promise.all(


### PR DESCRIPTION
## Changes

fix https://github.com/withastro/compiler/issues/879

We're previously collapsing empty text nodes (only contains whitespace) to `""`, but sometimes this is unsafe and should convey a `" "` instead (one space).

This PR checks for cases where we can collapse completely with no spaces, but otherwise would only always collapse to one space. I'm not sure if there's a safer way else to deal with it.

## Testing

Added new test in go

## Docs

n/a. bug fix.