### PR TITLE
Revert "Fix expressions within td exitLiteralIM tracking (#885)"

### DIFF
--- a/.changeset/stupid-rats-cough.md
+++ b/.changeset/stupid-rats-cough.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Revert table related parsing change as it resulted in a regression

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2176,10 +2176,9 @@ func inRowIM(p *parser) bool {
 func inCellIM(p *parser) bool {
 	switch p.tok.Type {
 	case StartExpressionToken:
-		p.exitLiteralIM = getExitLiteralFunc(p)
 		p.addExpression()
 		p.afe = append(p.afe, &scopeMarker)
-		p.originalIM = inCellIM
+		p.originalIM = inBodyIM
 		p.im = inExpressionIM
 		return true
 	case EndExpressionToken:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1978,13 +1978,6 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
-			name:   "table expression with trailing div",
-			source: `<table><tr><td>{title}</td></tr></table><div>Div</div>`,
-			want: want{
-				code: `${$$maybeRenderHead($$result)}<table><tr><td>${title}</td></tr></table><div>Div</div>`,
-			},
-		},
-		{
 			name: "tbody expressions",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1960,6 +1960,50 @@ const value = 'test';
 			},
 		},
 		{
+			name: "table simple case",
+			source: `---
+const content = "lol";
+---
+
+<html>
+  <body>
+    <table>
+      <tr>
+        <td>{content}</td>
+      </tr>
+      {
+        (
+          <tr>
+            <td>1</td>
+          </tr>
+        )
+      }
+    </table>Hello
+  </body>
+</html>
+`,
+			want: want{
+				frontmatter: []string{"", `const content = "lol";`},
+				// TODO: This output is INCORRECT, but we're testing a regression
+				// The trailing text (`Hello`) shouldn't be consumed by the <table> element!
+				code: `<html>
+  ${$$maybeRenderHead($$result)}<body>
+    <table>
+      <tr>
+        <td>${content}</td>
+      </tr>
+      ${
+        (
+          $$render` + BACKTICK + `<tr>
+            <td>1</td>
+          </tr>` + BACKTICK + `
+        )
+      }    Hello
+  </table></body>
+</html>`,
+			},
+		},
+		{
 			name: "table expressions (no implicit tbody)",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];


### PR DESCRIPTION
## Changes

- This reverts commit e241f2d545e5753eaafe19fac8626f0191cca96c.
- Don't want to break people, going to release this quickly. Can circle back to actually fix the table issue.

## Testing

The following case regressed, throwing a parsing error for the user. Notably, even with the regression, this case is still broken, albeit not fatally. Tables are fun! 😭

```astro
---
const content = "lol";
---

<html>
  <body>
    <table>
      <tr>
        <td>{content}</td>
      </tr>
      {
        (
          <tr>
            <td>1</td>
          </tr>
        )
      }
    </table>
     1
  </body>
</html>
```

## Docs

N/A
