### PR TITLE
fix: `index out of range [0]` error when compent is before the html tag

### DIFF
--- a/.changeset/late-readers-reflect.md
+++ b/.changeset/late-readers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix `index out of range [0]` error when there is a component before the `<html>` tag

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1154,7 +1154,9 @@ func inBodyIM(p *parser) bool {
 			if p.oe.contains(a.Template) {
 				return true
 			}
-			copyAttributes(p.oe[0], p.tok)
+			if len(p.oe) > 0 {
+				copyAttributes(p.oe[0], p.tok)
+			}
 		case a.Base, a.Basefont, a.Bgsound, a.Link, a.Meta, a.Noframes, a.Script, a.Style, a.Template, a.Title:
 			return inHeadIM(p)
 		case a.Body:

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -252,6 +252,11 @@ func TestFullTransform(t *testing.T) {
 			want: `<Component><h1>Hello world</h1></Component>`,
 		},
 		{
+			name:   "Component before html",
+			source: `<Navigation /><html><body><h1>Astro</h1></body></html>`,
+			want:   `<Navigation></Navigation><h1>Astro</h1>`,
+		},
+		{
 			name:   "respects explicitly authored elements",
 			source: `<html><Component /></html>`,
 			want:   `<html><Component></Component></html>`,


### PR DESCRIPTION
## Changes

Fix #880
We were trying to access an element of a slice (stack of open elements) without making sure it exists.

## Testing

Added a transform test

## Docs

N/A Bug fix