### PR TITLE
fix: better sourcemaps handling with multibyte characters

### DIFF
--- a/.changeset/strange-beans-scream.md
+++ b/.changeset/strange-beans-scream.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue causing `index out of range` errors when handling some multibyte characters like `\u2028`.

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -70,17 +70,17 @@ func (p *printer) println(text string) {
 func (p *printer) printTextWithSourcemap(text string, l loc.Loc) {
 	start := l.Start
 	for pos, c := range text {
-		// nextChar will eventually be `RuneError` when we reach the last iteration
-		// but it's ok, as we'll exit the loop anyway
-		nextChar, nextPos := utf8.DecodeRuneInString(text[pos:])
 		// Handle Windows-specific "\r\n" newlines
-		if c == '\r' && len(text[pos:]) > 1 && nextChar == '\n' {
-			start += nextPos
+		if c == '\r' && len(text[pos:]) > 1 && text[pos+1] == '\n' {
+			// tiny optimization: avoid calling `utf8.DecodeRuneInString`
+			// if we know the next char is `\n`
+			start++
 			continue
 		}
+		_, nextCharByteSize := utf8.DecodeRuneInString(text[pos:])
 		p.addSourceMapping(loc.Loc{Start: start})
 		p.print(string(c))
-		start += nextPos
+		start += nextCharByteSize
 	}
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -107,7 +107,7 @@ func TestPrinter(t *testing.T) {
 		},
 		{
 			name:   "unusual line terminator",
-			source: `Pre-set & Ti/me-limited \u2028holiday campaigns`,
+			source: `Pre-set & Time-limited \u2028holiday campaigns`,
 			want: want{
 				code: `Pre-set & Time-limited \\u2028holiday campaigns`,
 			},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -106,6 +106,13 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name:   "unusual line terminator",
+			source: `Pre-set & Ti/me-limited \u2028holiday campaigns`,
+			want: want{
+				code: `Pre-set & Time-limited \\u2028holiday campaigns`,
+			},
+		},
+		{
 			name:   "basic (no frontmatter)",
 			source: `<button>Click</button>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -106,10 +106,17 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
-			name:   "unusual line terminator",
+			name:   "unusual line terminator I",
 			source: `Pre-set & Time-limited \u2028holiday campaigns`,
 			want: want{
 				code: `Pre-set & Time-limited \\u2028holiday campaigns`,
+			},
+		},
+		{
+			name:   "unusual line terminator II",
+			source: `Pre-set & Time-limited  holiday campaigns`,
+			want: want{
+				code: `Pre-set & Time-limited  holiday campaigns`,
 			},
 		},
 		{

--- a/packages/compiler/test/tsx/line-terminator.ts
+++ b/packages/compiler/test/tsx/line-terminator.ts
@@ -1,14 +1,17 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { convertToTSX } from '@astrojs/compiler'; 
-    
-test('handles non-standard line terminators', async () => {
-  const input = ` `;
+import { convertToTSX } from '@astrojs/compiler';
+
+test('handles non-standard line terminators', async () =>
+{
+  const inputs = [` `, `something something`, `something  `, `   `, ];
   let err = 0;
-  try {
-    await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
-  } catch (e) {
-    err = 1;
+  for (const input of inputs){
+    try {
+      await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
+    } catch (e) {
+      err = 1;
+    }
   }
   assert.equal(err, 0, 'did not error');
 });


### PR DESCRIPTION
## Changes

Fix #872

The initial code inaccurately incremented `start` for each character iteration without considering variable byte sizes. The updated code utilizing `utf8.DecodeRuneInString`, correctly adjusts `start` based on the byte size of each character.

## Testing

Added a printer test

## Docs

N/A bug fix
