### PR TITLE
Fix expression parsing when final node

### DIFF
--- a/.changeset/big-crabs-burn.md
+++ b/.changeset/big-crabs-burn.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes a memory reference error when an expression is the final node in a file

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2786,6 +2786,9 @@ func inExpressionIM(p *parser) bool {
 		p.addLoc()
 		p.oe.pop()
 		nextOpenElement := p.oe.top()
+		if nextOpenElement == nil {
+			return true
+		}
 		// only switch the insertion mode when we're no longer inside an expression
 		if !nextOpenElement.Parent.Expression {
 			p.im = textIM

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2950,6 +2950,13 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$maybeRenderHead($$result)}<div data-astro-transition-persist="foo"${$$addAttribute($$renderTransition($$result, "peuy4xf7", "", "foo"), "data-astro-transition-scope")}></div>`,
 			},
 		},
+		{
+			name:   "trailing expression",
+			source: `<Component />{}`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{})}${(void 0)}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Fixes a crash discovered in https://github.com/withastro/astro/pull/9445
- When an expression is the final node in a file, we need to check the access to `p.oe.top()` to ensure there is actually an open element.

## Testing

Test added

## Docs

Bug fix only