### PR TITLE
feat(tsx): Prefix tsx output with a JSX pragma

### DIFF
--- a/.changeset/kind-buses-punch.md
+++ b/.changeset/kind-buses-punch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Prefix TSX output with a JSX pragma to ensure proper types are used

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getTSXPrefix() string {
-	return "/** @jsx astroHTML */\n\n"
+	return "/** @jsxImportSource astro */\n\n"
 }
 
 func PrintToTSX(sourcetext string, n *Node, opts transform.TransformOptions, h *handler.Handler) PrintResult {

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -111,7 +111,7 @@ func renderTsx(p *printer, n *Node) {
 			// Without this, TypeScript can get tripped up by the body of our file.
 			if c.PrevSibling != nil && c.PrevSibling.Type == FrontmatterNode {
 				buf := strings.TrimSpace(string(p.output))
-				if len(buf) > 1 {
+				if len(buf)-len(getTSXPrefix()) > 1 {
 					char := rune(buf[len(buf)-1:][0])
 					// If the existing buffer ends with any character other than ;, we need to add a `;`
 					if char != ';' {

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -15,13 +15,17 @@ import (
 	"golang.org/x/net/html/atom"
 )
 
+func getTSXPrefix() string {
+	return "/** @jsx astroHTML */\n\n"
+}
+
 func PrintToTSX(sourcetext string, n *Node, opts transform.TransformOptions, h *handler.Handler) PrintResult {
 	p := &printer{
 		sourcetext: sourcetext,
 		opts:       opts,
 		builder:    sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(sourcetext, len(strings.Split(sourcetext, "\n")))),
 	}
-
+	p.print(getTSXPrefix())
 	renderTsx(p, n)
 	return PrintResult{
 		Output:         p.output,
@@ -112,7 +116,7 @@ func renderTsx(p *printer, n *Node) {
 					// If the existing buffer ends with any character other than ;, we need to add a `;`
 					if char != ';' {
 						p.addNilSourceMapping()
-						p.print("\"\";")
+						p.print("{};")
 					}
 				}
 				// We always need to start the body with `<Fragment>`

--- a/packages/compiler/test/tsx-sourcemaps/tags.ts
+++ b/packages/compiler/test/tsx-sourcemaps/tags.ts
@@ -1,7 +1,7 @@
-import { test } from 'uvu';
-import * as assert from 'uvu/assert';
 import { convertToTSX } from '@astrojs/compiler';
 import { generatedPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
 import { testTSXSourcemap } from '../utils';
 
 test('tag close', async () => {
@@ -24,7 +24,7 @@ test('tag with spaces', async () => {
   const generated = generatedPositionFor(tracer, { source: 'index.astro', line: 1, column: 14 });
 
   assert.equal(generated, {
-    line: 2,
+    line: 4,
     column: 9,
   });
 });

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -1,6 +1,7 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 test('basic', async () => {
   const input = `
@@ -11,7 +12,7 @@ let value = 'world';
 <h1 name="value" empty {shorthand} expression={true} literal=\`tags\`>Hello {value}</h1>
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 let value = 'world';
 
 <Fragment>
@@ -33,7 +34,7 @@ let value = 'world';
 <h1 name="value" empty {shorthand} expression={true} literal=\`tags\`>Hello {value}</h1>
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 let value = 'world';
 
 <Fragment>
@@ -48,7 +49,7 @@ export default function Test__AstroComponent_(_props: Record<string, any>): any 
 
 test('moves @attributes to spread', async () => {
   const input = `<div @click={() => {}} name="value"></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div name="value" {...{"@click":(() => {})}}></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -64,10 +65,10 @@ console.log("hello")
 
 {hello}
 `;
-  const output = `
+  const output = `${TSXPrefix}
 console.log("hello")
 
-"";<Fragment>
+{};<Fragment>
 {hello}
 
 </Fragment>
@@ -84,10 +85,10 @@ const { hello } = Astro.props
 
 <div class={hello}></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 const { hello } = Astro.props
 
-"";<Fragment>
+{};<Fragment>
 <div class={hello}></div>
 
 </Fragment>
@@ -98,7 +99,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('moves attributes with dots in them to spread', async () => {
   const input = `<div x-on:keyup.shift.enter="alert('Astro')" name="value"></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div name="value" {...{"x-on:keyup.shift.enter":"alert('Astro')"}}></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -108,7 +109,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('moves attributes that starts with : to spread', async () => {
   const input = `<div :class="hey" name="value"></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div name="value" {...{":class":"hey"}}></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -118,7 +119,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test("Don't move attributes to spread unnecessarily", async () => {
   const input = `<div 丽dfds_fsfdsfs name="value"></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div 丽dfds_fsfdsfs name="value"></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -128,7 +129,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('preserves unclosed tags', async () => {
   const input = `<components.`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <components.
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -138,7 +139,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('template literal attribute', async () => {
   const input = `<div class=\`\${hello}\`></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div class={\`\${hello}\`}></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -152,7 +153,7 @@ const myMarkdown = await import('../content/post.md');
 ---
 
 <myMarkdown.`;
-  const output = `
+  const output = `${TSXPrefix}
 const myMarkdown = await import('../content/post.md');
 
 <Fragment>
@@ -170,7 +171,7 @@ const myMarkdown = await import('../content/post.md');
 
 <myMarkdown.
 `;
-  const output = `
+  const output = `${TSXPrefix}
 const myMarkdown = await import('../content/post.md');
 
 <Fragment>
@@ -184,7 +185,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('spread object', async () => {
   const input = `<DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <DocSearch {...{ lang, labels: { modal, placeholder } }} client:only="preact" />
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -195,7 +196,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 test('spread object II', async () => {
   const input = `<MainLayout {...Astro.props}>
 </MainLayout>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <MainLayout {...Astro.props}>
 </MainLayout>
 </Fragment>
@@ -206,7 +207,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('fragment with no name', async () => {
   const input = '<>+0123456789</>';
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <>+0123456789</>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -216,7 +217,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('preserves spaces in tag', async () => {
   const input = '<Button ></Button>';
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <Button ></Button>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -226,7 +227,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('preserves spaces after attributes in tag', async () => {
   const input = '<Button a="b" ></Button>';
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <Button a="b" ></Button>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -236,7 +237,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('preserves spaces in tag', async () => {
   const input = '<Button      >';
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <Button ></Button>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;

--- a/packages/compiler/test/tsx/non-latin.ts
+++ b/packages/compiler/test/tsx/non-latin.ts
@@ -1,6 +1,7 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 // https://mathiasbynens.be/notes/javascript-identifiers
 const value = `
@@ -55,7 +56,7 @@ ${value}
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 ${value}
 
 <Fragment>

--- a/packages/compiler/test/tsx/props-and-getStaticPaths.ts
+++ b/packages/compiler/test/tsx/props-and-getStaticPaths.ts
@@ -1,6 +1,7 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 function getPrefix({
   props = `ASTRO__MergeUnion<ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>>`,
@@ -37,13 +38,14 @@ export function getStaticPaths() {
 
 <div></div>`;
   const output =
+    TSXPrefix +
     '\n' +
     `interface Props {};
 export function getStaticPaths() {
   return {};
 }
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 </Fragment>
 export default function __AstroComponent_(_props: Props): any {}
@@ -62,12 +64,13 @@ export function getStaticPaths() {
 
 <div></div>`;
   const output =
+    TSXPrefix +
     '\n' +
     `export function getStaticPaths() {
   return {};
 }
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 </Fragment>
 export default function __AstroComponent_(_props: ASTRO__MergeUnion<ASTRO__Get<ASTRO__InferredGetStaticPath, 'props'>>): any {}

--- a/packages/compiler/test/tsx/props.ts
+++ b/packages/compiler/test/tsx/props.ts
@@ -1,6 +1,7 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 const PREFIX = (component: string = '__AstroComponent_') => `/**
  * Astro global available in all contexts in .astro files
@@ -11,7 +12,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<Props, typeof ${compon
 
 test('no props', async () => {
   const input = `<div></div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div></div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -23,7 +24,7 @@ test('nested Props', async () => {
   const input = `---
 function DoTheThing(Props) {}
 ---`;
-  const output = `
+  const output = `${TSXPrefix}
 function DoTheThing(Props) {}
 
 
@@ -40,10 +41,10 @@ interface Props {}
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -61,7 +62,7 @@ import { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 import { Props } from './somewhere';
 
 <Fragment>
@@ -82,7 +83,7 @@ import { MyComponent as Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 import { MyComponent as Props } from './somewhere';
 
 <Fragment>
@@ -103,7 +104,7 @@ import type { Props } from './somewhere';
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 import type { Props } from './somewhere';
 
 <Fragment>
@@ -124,10 +125,10 @@ type Props = {}
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 type Props = {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -145,10 +146,10 @@ interface Props<T> {}
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props<T> {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -166,10 +167,10 @@ interface Props<T extends Other<{ [key: string]: any }>> {}
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props<T extends Other<{ [key: string]: any }>> {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -187,10 +188,10 @@ interface Props<T extends { [key: string]: any }, P extends string ? { [key: str
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props<T extends { [key: string]: any }, P extends string ? { [key: string]: any }: never> {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -208,10 +209,10 @@ interface Props<T extends Something<false> ? A : B, P extends string ? { [key: s
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props<T extends Something<false> ? A : B, P extends string ? { [key: string]: any }: never> {}
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -231,12 +232,12 @@ interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<
 
 <div></div>
 `;
-  const output = `
+  const output = `${TSXPrefix}
 interface Props<Tag extends keyof JSX.IntrinsicElements> extends HTMLAttributes<Tag> {
   as?: Tag;
 }
 
-"";<Fragment>
+{};<Fragment>
 <div></div>
 
 </Fragment>
@@ -254,7 +255,7 @@ import SvelteOptionalProps from './SvelteOptionalProps.svelte';
 
 <SvelteOptionalProps />
 `;
-  const output = `
+  const output = `${TSXPrefix}
 import SvelteOptionalProps from './SvelteOptionalProps.svelte';
 
 <Fragment>
@@ -273,10 +274,10 @@ import type { Props as ComponentBProps } from './ComponentB.astro'
 
 <div />
 `;
-  const output = `
+  const output = `${TSXPrefix}
 import type { Props as ComponentBProps } from './ComponentB.astro'
 
-"";<Fragment>
+{};<Fragment>
 <div />
 
 </Fragment>

--- a/packages/compiler/test/tsx/raw.ts
+++ b/packages/compiler/test/tsx/raw.ts
@@ -1,10 +1,11 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 test('style is raw', async () => {
   const input = `<style>div { color: red; }</style>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <style>{\`div { color: red; }\`}</style>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -14,7 +15,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('is:raw is raw', async () => {
   const input = `<div is:raw>A{B}C</div>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <div is:raw>{\`A{B}C\`}</div>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;

--- a/packages/compiler/test/tsx/script.ts
+++ b/packages/compiler/test/tsx/script.ts
@@ -1,10 +1,11 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 test('script function', async () => {
   const input = `<script type="module">console.log({ test: \`literal\` })</script>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <script type="module">
 {() => {console.log({ test: \`literal\` })}}
 </script>
@@ -16,7 +17,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('partytown function', async () => {
   const input = `<script type="text/partytown">console.log({ test: \`literal\` })</script>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <script type="text/partytown">
 {() => {console.log({ test: \`literal\` })}}
 </script>
@@ -28,7 +29,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('ld+json wrapping', async () => {
   const input = `<script type="application/ld+json">{"a":"b"}</script>`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 <script type="application/ld+json">{\`{"a":"b"}\`}</script>
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;

--- a/packages/compiler/test/utils.ts
+++ b/packages/compiler/test/utils.ts
@@ -1,5 +1,5 @@
-import { transform, convertToTSX } from '@astrojs/compiler';
-import { generatedPositionFor, originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { convertToTSX, transform } from '@astrojs/compiler';
+import { TraceMap, generatedPositionFor, originalPositionFor } from '@jridgewell/trace-mapping';
 import sass from 'sass';
 
 export async function preprocessStyle(value, attrs): Promise<any> {
@@ -78,3 +78,4 @@ export async function testJSSourcemap(input: string, snippet: string) {
 
   return originalPosition;
 }
+export const TSXPrefix = '/** @jsxImportSource astro */\n\n';


### PR DESCRIPTION
## Changes

Add `/** @jsxImportSource astro */` to our TSX output so it uses the newly exported types at https://github.com/withastro/astro/pull/9501, this is all to attempt to fix https://github.com/withastro/language-tools/issues/727

## Testing

Adjusted tests

## Docs

N/A
