### PR TITLE
Fix template literal attributes on components

### DIFF
--- a/.changeset/perfect-falcons-build.md
+++ b/.changeset/perfect-falcons-build.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where components with template literal attributes were printed with the name of the attribute as value.

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -352,7 +352,7 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 			p.addSourceMapping(a.KeyLoc)
 			p.printf(`"%s"`, strings.TrimSpace(a.Key))
 			p.print(":")
-			p.print("`" + strings.TrimSpace(a.Key) + "`")
+			p.print("`" + strings.TrimSpace(a.Val) + "`")
 		}
 	}
 	p.print("}")

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2740,6 +2740,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "template literal attribute with variable on component",
+			source: `<Component class=` + BACKTICK + `${color}` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{"class":` + BACKTICK + `${color}` + BACKTICK + `})}`,
+			},
+		},
+		{
 			name:   "define:vars on style",
 			source: "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2733,6 +2733,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "template literal attribute on component",
+			source: `<Component class=` + BACKTICK + `red` + BACKTICK + ` />`,
+			want: want{
+				code: `${$$renderComponent($$result,'Component',Component,{"class":` + BACKTICK + `red` + BACKTICK + `})}`,
+			},
+		},
+		{
 			name:   "define:vars on style",
 			source: "<style>h1{color:green;}</style><style define:vars={{color:'green'}}>h1{color:var(--color)}</style><h1>testing</h1>",
 			want: want{


### PR DESCRIPTION
## Changes

Fix #903
Components with template literal attributes were printed with the attribute name as value.

## Testing

Added a printer test

## Docs

N/A bug fix
