### PR TITLE
fix(tokenizer): handle unterminated quoted attributes gracefully

### DIFF
--- a/.changeset/chilled-starfishes-search.md
+++ b/.changeset/chilled-starfishes-search.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where unterminated quoted attributes caused the compiler to crash

--- a/internal/printer/print-to-json.go
+++ b/internal/printer/print-to-json.go
@@ -230,7 +230,7 @@ func renderNode(p *printer, parent *ASTNode, n *Node, opts t.ParseOptions) {
 				}
 				position := attrPositionAt(p, &attr, opts)
 				raw := ""
-				if attr.Type == QuotedAttribute {
+				if attr.Type == QuotedAttribute || attr.Type == TemplateLiteralAttribute {
 					start := attr.ValLoc.Start - 1
 					end := attr.ValLoc.Start + len(attr.Val)
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3280,12 +3280,17 @@ const c = '\''
 		{
 			name:   "element with unterminated double quote attribute",
 			source: `<main id="gotcha />`,
-			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "", Raw: "\"g"}}}},
+			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "gotcha", Raw: "\"gotcha"}}}},
 		},
 		{
 			name:   "element with unterminated single quote attribute",
 			source: `<main id='gotcha />`,
-			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "", Raw: "'g"}}}},
+			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "gotcha", Raw: "'gotcha"}}}},
+		},
+		{
+			name:   "element with unterminated template literal attribute",
+			source: `<main id=` + BACKTICK + `gotcha />`,
+			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "template-literal", Name: "id", Value: "gotcha", Raw: "`gotcha"}}}},
 		},
 	}
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3277,6 +3277,16 @@ const c = '\''
 			source: `<html><body><h1>Hello world!</h1><style></style></body></html>`,
 			want:   []ASTNode{{Type: "element", Name: "html", Children: []ASTNode{{Type: "element", Name: "body", Children: []ASTNode{{Type: "element", Name: "h1", Children: []ASTNode{{Type: "text", Value: "Hello world!"}}}, {Type: "element", Name: "style"}}}}}},
 		},
+		{
+			name:   "element with unterminated double quote attribute",
+			source: `<main id="gotcha />`,
+			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "", Raw: "\"g"}}}},
+		},
+		{
+			name:   "element with unterminated single quote attribute",
+			source: `<main id='gotcha />`,
+			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "id", Value: "", Raw: "'g"}}}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/token.go
+++ b/internal/token.go
@@ -1449,7 +1449,17 @@ func (z *Tokenizer) readTagAttrVal() {
 			c := z.readByte()
 			if z.err != nil {
 				if z.err == io.EOF {
-					z.pendingAttr[1].End = z.pendingAttr[1].Start
+					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
+						c := z.buf[i]
+						if c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '/' || c == '>' {
+							z.pendingAttr[1].End = i
+							break
+						}
+						if i == z.raw.End-1 {
+							z.pendingAttr[1].End = i
+							break
+						}
+					}
 					z.handler.AppendError(&loc.ErrorWithRange{
 						Code: loc.ERROR_UNTERMINATED_STRING,
 						Text: `Unterminated quoted attribute`,
@@ -1475,7 +1485,17 @@ func (z *Tokenizer) readTagAttrVal() {
 			c := z.readByte()
 			if z.err != nil {
 				if z.err == io.EOF {
-					z.pendingAttr[1].End = z.pendingAttr[1].Start
+					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
+						c := z.buf[i]
+						if c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '/' || c == '>' {
+							z.pendingAttr[1].End = i
+							break
+						}
+						if i == z.raw.End-1 {
+							z.pendingAttr[1].End = i
+							break
+						}
+					}
 					z.handler.AppendError(&loc.ErrorWithRange{
 						Code: loc.ERROR_UNTERMINATED_STRING,
 						Text: `Unterminated template literal attribute`,

--- a/internal/token.go
+++ b/internal/token.go
@@ -1448,6 +1448,18 @@ func (z *Tokenizer) readTagAttrVal() {
 		for {
 			c := z.readByte()
 			if z.err != nil {
+				if z.err == io.EOF {
+					z.pendingAttr[1].End = z.pendingAttr[1].Start
+					z.handler.AppendError(&loc.ErrorWithRange{
+						Code: loc.ERROR_UNTERMINATED_STRING,
+						Text: `Unterminated quoted attribute`,
+						Range: loc.Range{
+							Loc: loc.Loc{Start: z.data.Start},
+							Len: z.raw.End,
+						},
+					})
+					return
+				}
 				z.pendingAttr[1].End = z.raw.End
 				return
 			}

--- a/internal/token.go
+++ b/internal/token.go
@@ -1486,6 +1486,7 @@ func (z *Tokenizer) readTagAttrVal() {
 			c := z.readByte()
 			if z.err != nil {
 				if z.err == io.EOF {
+					// rescan, closing any potentially unterminated attribute values
 					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
 						c := z.buf[i]
 						if unicode.IsSpace(rune(c)) || c == '/' || c == '>' {

--- a/internal/token.go
+++ b/internal/token.go
@@ -1451,7 +1451,7 @@ func (z *Tokenizer) readTagAttrVal() {
 				if z.err == io.EOF {
 					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
 						c := z.buf[i]
-						if c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '/' || c == '>' {
+						if unicode.IsSpace(rune(c)) || c == '/' || c == '>' {
 							z.pendingAttr[1].End = i
 							break
 						}
@@ -1487,7 +1487,7 @@ func (z *Tokenizer) readTagAttrVal() {
 				if z.err == io.EOF {
 					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
 						c := z.buf[i]
-						if c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '/' || c == '>' {
+						if unicode.IsSpace(rune(c)) || c == '/' || c == '>' {
 							z.pendingAttr[1].End = i
 							break
 						}

--- a/internal/token.go
+++ b/internal/token.go
@@ -1449,6 +1449,7 @@ func (z *Tokenizer) readTagAttrVal() {
 			c := z.readByte()
 			if z.err != nil {
 				if z.err == io.EOF {
+					// rescan, closing any potentially unterminated quoted attribute values
 					for i := z.pendingAttr[1].Start; i < z.raw.End; i++ {
 						c := z.buf[i]
 						if unicode.IsSpace(rune(c)) || c == '/' || c == '>' {

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -16,13 +16,27 @@ test('does not panic on unfinished template literal attribute', async () => {
   assert.equal(error, 0, `compiler should not have panicked`);
 });
 
-test('does not panic on unfinished quoted attribute', async () => {
+test('does not panic on unfinished double quoted attribute', async () => {
   const input = `<main id="gotcha />`;
   let error = 0;
   try {
     const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
     assert.match(output.code, `id=""`);
   } catch (e) {
+    error = 1;
+  }
+
+  assert.equal(error, 0, `compiler should not have panicked`);
+});
+
+test('does not panic on unfinished single quoted attribute', async () => {
+  const input = `<main id='gotcha />`;
+  let error = 0;
+  try {
+    const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
+    assert.match(output.code, `id=""`);
+  } catch (e) {
+    console.log;
     error = 1;
   }
 

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -2,14 +2,26 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { convertToTSX } from '@astrojs/compiler';
 
-const input = `<div class=\`></div>
-`;
-
 test('does not panic on unfinished template literal attribute', async () => {
+  const input = `<div class=\`></div>
+  `;
   let error = 0;
   try {
     const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
     assert.match(output.code, `class={\`\`}`);
+  } catch (e) {
+    error = 1;
+  }
+
+  assert.equal(error, 0, `compiler should not have panicked`);
+});
+
+test('does not panic on unfinished quoted attribute', async () => {
+  const input = `<main id="gotcha />`;
+  let error = 0;
+  try {
+    const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
+    assert.match(output.code, `id=""`);
   } catch (e) {
     error = 1;
   }

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -21,7 +21,7 @@ test('does not panic on unfinished double quoted attribute', async () => {
   let error = 0;
   try {
     const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
-    assert.match(output.code, `id=""`);
+    assert.match(output.code, `id="gotcha"`);
   } catch (e) {
     error = 1;
   }
@@ -30,13 +30,12 @@ test('does not panic on unfinished double quoted attribute', async () => {
 });
 
 test('does not panic on unfinished single quoted attribute', async () => {
-  const input = `<main id='gotcha />`;
+  const input = `<main id='gotcha/>`;
   let error = 0;
   try {
     const output = await convertToTSX(input, { filename: 'index.astro', sourcemap: 'inline' });
-    assert.match(output.code, `id=""`);
+    assert.match(output.code, `id="gotcha"`);
   } catch (e) {
-    console.log;
     error = 1;
   }
 


### PR DESCRIPTION
## Changes

- Fix #904
- Complement to #636.

Fix an issue where unterminated quoted attributes caused the compiler to crash

## Testing

Added a TSX output test to make sure the compiler doesn't crash

## Docs
N/A bug fix