### PR TITLE
chore: enable running go tests in CI on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ concurrency:
 jobs:
   test:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        OS: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.OS }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Changes

CI tests on go didn't run on windows. This PR enables that

## Testing


## Docs

N/A bug fix
