### PR TITLE
Fix incorrect table parsing when it contains expressions in certain cases

### DIFF
--- a/.changeset/perfect-fishes-cover.md
+++ b/.changeset/perfect-fishes-cover.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where a `tr` element which contained an expression would cause its parent table to swallow any trailing element inside said table

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -793,6 +793,7 @@ func inHeadIM(p *parser) bool {
 				return true
 			}
 			p.tok.Data = s
+			return textIM(p)
 		} else if p.oe.top() != nil && (isComponent(p.oe.top().Data) || isFragment((p.oe.top().Data))) {
 			p.addText(p.tok.Data)
 			return true

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2786,14 +2786,7 @@ func inExpressionIM(p *parser) bool {
 	case EndExpressionToken:
 		p.addLoc()
 		p.oe.pop()
-		nextOpenElement := p.oe.top()
-		if nextOpenElement == nil {
-			return true
-		}
-		// only switch the insertion mode when we're no longer inside an expression
-		if !nextOpenElement.Parent.Expression {
-			p.im = textIM
-		}
+		p.resetInsertionMode()
 		return true
 	case CommentToken:
 		p.addChild(&Node{

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2736,10 +2736,6 @@ func inLiteralIM(p *parser) bool {
 }
 
 func inExpressionIM(p *parser) bool {
-	if p.oe.contains(a.Table) {
-		p.clearActiveFormattingElements()
-		return inLiteralIM(p)
-	}
 	switch p.tok.Type {
 	case ErrorToken:
 		p.oe.pop()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2033,8 +2033,9 @@ const content = "lol";
             <td>1</td>
           </tr>` + BACKTICK + `
         )
-      }    Hello
-  </table></body>
+      }
+    </table>Hello
+  </body>
 </html>`,
 			},
 		},

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2057,6 +2057,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:   "table expression with trailing div",
+			source: `<table><tr><td>{title}</td></tr></table><div>Div</div>`,
+			want: want{
+				code: `${$$maybeRenderHead($$result)}<table><tr><td>${title}</td></tr></table><div>Div</div>`,
+			},
+		},
+		{
 			name: "tbody expressions",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2019,8 +2019,6 @@ const content = "lol";
 `,
 			want: want{
 				frontmatter: []string{"", `const content = "lol";`},
-				// TODO: This output is INCORRECT, but we're testing a regression
-				// The trailing text (`Hello`) shouldn't be consumed by the <table> element!
 				code: `<html>
   ${$$maybeRenderHead($$result)}<body>
     <table>


### PR DESCRIPTION
## Changes

- Fixes #870
- Fixes #695

Inside a `table` element, when there was an implied `tr` tag which had a `td` or `th` which contained an expression (that's a mouthful yeah 😅), it would cause any trailing element/component/text node to be swallowed by the table element (just before the `table` closing tag). This fixes that.

## Testing

- Edit the (deliberately) incorrect printer test case introduced in #889
- Brought back the test case reverted in that PR to makes sure that trailing elements aren't swallowed

## Docs

N/A bug fix
