### PR TITLE
fix(tsx): prevent slashes in html comment from causing premature closing of comments in the tsx output

### DIFF
--- a/.changeset/smooth-timers-remember.md
+++ b/.changeset/smooth-timers-remember.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where `/` or `*/` would cause prematurely closed comments in the tsx output

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -217,6 +217,10 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 		// p.addSourceMapping(n.Loc[0])
 		p.addNilSourceMapping()
 		p.print("{/**")
+		if !unicode.IsSpace(rune(n.Data[0])) {
+			// always add a space after the opening comment
+			p.print(" ")
+		}
 		p.addSourceMapping(n.Loc[0])
 		p.printTextWithSourcemap(escapeBraces(n.Data), n.Loc[0])
 		p.addNilSourceMapping()

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -20,9 +20,14 @@ func escapeText(src string) string {
 }
 
 func escapeBraces(src string) string {
-	return escapeTSXExpressions(
+	return escapeStarSlash(escapeTSXExpressions(
 		escapeExistingEscapes(src),
-	)
+	))
+}
+
+func escapeStarSlash(src string) string {
+	return strings.ReplaceAll(src, "*/", "*\\/")
+	// return src
 }
 
 func getTSXComponentName(filename string) string {

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -27,7 +27,6 @@ func escapeBraces(src string) string {
 
 func escapeStarSlash(src string) string {
 	return strings.ReplaceAll(src, "*/", "*\\/")
-	// return src
 }
 
 func getTSXComponentName(filename string) string {

--- a/packages/compiler/test/tsx/escape.ts
+++ b/packages/compiler/test/tsx/escape.ts
@@ -1,0 +1,45 @@
+import { convertToTSX } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+test('escapes braces in comment', async () => {
+  const input = `<!-- {<div>Not JSX!<div/>}-->`;
+  const output = `<Fragment>
+{/** \\\\{<div>Not JSX!<div/>\\\\}*/}
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test('always inserts space before comment', async () => {
+  const input = `<!--/<div>Error?<div/>-->`;
+  const output = `<Fragment>
+{/** /<div>Error?<div/>*/}
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test('simple escapes star slashes (*/)', async () => {
+  const input = `<!--*/<div>Evil comment<div/>-->`;
+  const output = `<Fragment>
+{/** *\\/<div>Evil comment<div/>*/}
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test('multiple escapes star slashes (*/)', async () => {
+  const input = `<!--***/*/**/*/*/*/<div>Even more evil comment<div/>-->`;
+  const output = `<Fragment>
+{/** ***\\/*\\/**\\/*\\/*\\/*\\/<div>Even more evil comment<div/>*/}
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+  const { code } = await convertToTSX(input, { sourcemap: 'external' });
+  assert.snapshot(code, output, `expected code to match snapshot`);
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Closes #922
- Always insert a space after opening comments
- Escape `*/`  into `*\/`

## Testing

Added TS tests:
- For escaping curly braces, didn't find any that covered that.
- For escaping `*/`
- To make sure a space is always inserted after an opening comment in the tsx output

## Docs

N/A bug fix only
