### PR TITLE
feat(tsx): Return interesting ranges for TSX output

### DIFF
--- a/.changeset/fair-windows-wave.md
+++ b/.changeset/fair-windows-wave.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Return generated frontmatter and body ranges in TSX output

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -173,6 +173,7 @@ type TSXResult struct {
 	Code        string                  `js:"code"`
 	Map         string                  `js:"map"`
 	Diagnostics []loc.DiagnosticMessage `js:"diagnostics"`
+	Ranges      printer.TSXRanges       `js:"metaRanges"`
 }
 
 type TransformResult struct {
@@ -269,6 +270,7 @@ func ConvertToTSX() any {
 			Code:        code,
 			Map:         sourcemapString,
 			Diagnostics: h.Diagnostics(),
+			Ranges:      result.TSXRanges,
 		}).Value
 	})
 }

--- a/internal/loc/loc.go
+++ b/internal/loc/loc.go
@@ -20,6 +20,11 @@ type Span struct {
 	Start, End int
 }
 
+type TSXRange struct {
+	Start int `js:"start"`
+	End   int `js:"end"`
+}
+
 // A NodeType is the type of a Node.
 type DiagnosticSeverity int
 

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -130,11 +130,18 @@ func renderTsx(p *printer, n *Node) {
 				// We always need to start the body with `<Fragment>`
 				p.addNilSourceMapping()
 				p.print("<Fragment>\n")
+
+				// Update the start location of the body to the start of the first child
+				startLoc = len(p.output)
+
 				hasChildren = true
 			}
 			if c.PrevSibling == nil && c.Type != FrontmatterNode {
 				p.addNilSourceMapping()
 				p.print("<Fragment>\n")
+
+				startLoc = len(p.output)
+
 				hasChildren = true
 			}
 			renderTsx(p, c)
@@ -143,6 +150,11 @@ func renderTsx(p *printer, n *Node) {
 		p.print("\n")
 
 		p.addNilSourceMapping()
+		p.setTSXBodyRange(loc.TSXRange{
+			Start: startLoc,
+			End:   len(p.output),
+		})
+
 		// Only close the body with `</Fragment>` if we printed a body
 		if hasChildren {
 			p.print("</Fragment>\n")
@@ -157,10 +169,6 @@ func renderTsx(p *printer, n *Node) {
 			}
 		}
 
-		p.setTSXBodyRange(loc.TSXRange{
-			Start: startLoc,
-			End:   len(p.output),
-		})
 		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}\n", componentName, props.Statement, propsIdent, props.Generics))
 		if hasGetStaticPaths {
 			p.printf(`type ASTRO__ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -195,7 +195,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 
 	if n.Type == FrontmatterNode {
 		p.addSourceMapping(loc.Loc{Start: 0})
-		var frontmatterStart = len(p.output)
+		frontmatterStart := len(p.output)
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
 			if c.Type == TextNode {
 				if len(c.Loc) > 0 {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -19,6 +19,8 @@ import (
 type PrintResult struct {
 	Output         []byte
 	SourceMapChunk sourcemap.Chunk
+	// Optional, used only for TSX output
+	TSXRanges TSXRanges
 }
 
 type printer struct {
@@ -31,6 +33,9 @@ type printer struct {
 	hasInternalImports bool
 	hasCSSImports      bool
 	needsTransitionCSS bool
+
+	// Optional, used only for TSX output
+	ranges TSXRanges
 }
 
 var TEMPLATE_TAG = "$$render"
@@ -66,6 +71,14 @@ func (p *printer) printf(format string, a ...interface{}) {
 
 func (p *printer) println(text string) {
 	p.print(text + "\n")
+}
+
+func (p *printer) setTSXFrontmatterRange(frontmatterRange loc.TSXRange) {
+	p.ranges.Frontmatter = frontmatterRange
+}
+
+func (p *printer) setTSXBodyRange(componentRange loc.TSXRange) {
+	p.ranges.Body = componentRange
 }
 
 func (p *printer) printTextWithSourcemap(text string, l loc.Loc) {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -106,6 +106,16 @@ export interface TSXResult {
   code: string;
   map: SourceMap;
   diagnostics: DiagnosticMessage[];
+  metaRanges: {
+    frontmatter: {
+      start: number;
+      end: number;
+    };
+    body: {
+      start: number;
+      end: number;
+    };
+  };
 }
 
 export interface ParseResult {

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -261,4 +261,20 @@ test('return ranges', async () => {
   });
 });
 
+test('return ranges - no frontmatter', async () => {
+  const input = `<div></div>`;
+  const { metaRanges } = await convertToTSX(input, { sourcemap: 'external' });
+
+  assert.equal(metaRanges, {
+    frontmatter: {
+      start: 31,
+      end: 31,
+    },
+    body: {
+      start: 42,
+      end: 54,
+    },
+  });
+});
+
 test.run();

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -245,4 +245,20 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
   assert.snapshot(code, output, `expected code to match snapshot`);
 });
 
+test('return ranges', async () => {
+  const input = `---\nconsole.log("Hello!")\n---\n\n<div></div>`;
+  const { metaRanges } = await convertToTSX(input, { sourcemap: 'external' });
+
+  assert.equal(metaRanges, {
+    frontmatter: {
+      start: 31,
+      end: 55,
+    },
+    body: {
+      start: 69,
+      end: 81,
+    },
+  });
+});
+
 test.run();

--- a/packages/compiler/test/tsx/escape.ts
+++ b/packages/compiler/test/tsx/escape.ts
@@ -1,10 +1,11 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 test('escapes braces in comment', async () => {
   const input = `<!-- {<div>Not JSX!<div/>}-->`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 {/** \\\\{<div>Not JSX!<div/>\\\\}*/}
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -14,7 +15,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('always inserts space before comment', async () => {
   const input = `<!--/<div>Error?<div/>-->`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 {/** /<div>Error?<div/>*/}
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -24,7 +25,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('simple escapes star slashes (*/)', async () => {
   const input = `<!--*/<div>Evil comment<div/>-->`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 {/** *\\/<div>Evil comment<div/>*/}
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
@@ -34,7 +35,7 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 
 test('multiple escapes star slashes (*/)', async () => {
   const input = `<!--***/*/**/*/*/*/<div>Even more evil comment<div/>-->`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 {/** ***\\/*\\/**\\/*\\/*\\/*\\/<div>Even more evil comment<div/>*/}
 </Fragment>
 export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;


### PR DESCRIPTION
## Changes

A common issue in the language server is it being hard to map things to the "frontmatter" of the TSX file because, well, we don't know where it is inside the TSX. This PR now returns the start and end of both the frontmatter and the body of the file, which the language server can use to map things.

This is for https://github.com/withastro/language-tools/pull/733

## Testing

Added a test

## Docs

N/A, I updated the types though
