### PR TITLE
Prevent printing tagged render function on whitespace only text nodes

### DIFF
--- a/.changeset/hot-clocks-judge.md
+++ b/.changeset/hot-clocks-judge.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes a regression that caused whitespace between elements in an expression to result invalid code

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -335,7 +335,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.printTextWithSourcemap(c.Data, c.Loc[0])
 				continue
 			}
-			if c.PrevSibling == nil || (c.PrevSibling.Type == TextNode && strings.TrimSpace(c.PrevSibling.Data) != "") {
+			// Only print the template literal open if the previous sibling is not
+			// nil or a text node with only whitespace
+			// we always open on the first child
+			if c.PrevSibling == nil || c.PrevSibling == n.FirstChild || (c.PrevSibling.Type == TextNode && strings.TrimSpace(c.PrevSibling.Data) != "") {
 				p.printTemplateLiteralOpen()
 			}
 			render1(p, c, RenderOptions{
@@ -346,7 +349,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				cssLen:           opts.cssLen,
 				printedMaybeHead: opts.printedMaybeHead,
 			})
-			if c.NextSibling == nil || (c.NextSibling.Type == TextNode && strings.TrimSpace(c.NextSibling.Data) != "") {
+			// Only print the template literal close if the next sibling is not
+			// nil or a text node with only whitespace
+			// we always close on the last child
+			if c.NextSibling == nil || c.NextSibling == n.LastChild || (c.NextSibling.Type == TextNode && strings.TrimSpace(c.NextSibling.Data) != "") {
 				p.printTemplateLiteralClose()
 			}
 		}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -335,9 +335,11 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.printTextWithSourcemap(c.Data, c.Loc[0])
 				continue
 			}
-			// Only print the template literal open if the previous sibling is not
-			// nil or a text node with only whitespace
-			// we always open on the first child
+			// Print a tagged render function before a node, but only when it
+			// meets either of these conditions:
+			// - It does not have a previous sibling.
+			// - It has a text node that contains more than just whitespace.
+			// - It is the first child of its parent expression.
 			if c.PrevSibling == nil || c.PrevSibling == n.FirstChild || (c.PrevSibling.Type == TextNode && strings.TrimSpace(c.PrevSibling.Data) != "") {
 				p.printTemplateLiteralOpen()
 			}
@@ -349,9 +351,12 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				cssLen:           opts.cssLen,
 				printedMaybeHead: opts.printedMaybeHead,
 			})
-			// Only print the template literal close if the next sibling is not
-			// nil or a text node with only whitespace
-			// we always close on the last child
+
+			// Print a tagged render function after a node, but only when it
+			// meets either of these conditions:
+			// - It does not have a next sibling.
+			// - It has a text node that contains more than just whitespace.
+			// - It is the last child of its parent expression.
 			if c.NextSibling == nil || c.NextSibling == n.LastChild || (c.NextSibling.Type == TextNode && strings.TrimSpace(c.NextSibling.Data) != "") {
 				p.printTemplateLiteralClose()
 			}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -335,8 +335,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.printTextWithSourcemap(c.Data, c.Loc[0])
 				continue
 			}
-			// Print a tagged render function before a node, but only when it
-			// meets either of these conditions:
+			// Print the opening of a tagged render function before
+			// a node, only when it meets either of these conditions:
 			// - It does not have a previous sibling.
 			// - It has a text node that contains more than just whitespace.
 			// - It is the first child of its parent expression.
@@ -352,8 +352,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				printedMaybeHead: opts.printedMaybeHead,
 			})
 
-			// Print a tagged render function after a node, but only when it
-			// meets either of these conditions:
+			// Print the closing of a tagged render function after
+			// a node, only when it meets either of these conditions:
 			// - It does not have a next sibling.
 			// - It has a text node that contains more than just whitespace.
 			// - It is the last child of its parent expression.

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -335,7 +335,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.printTextWithSourcemap(c.Data, c.Loc[0])
 				continue
 			}
-			if c.PrevSibling == nil || c.PrevSibling.Type == TextNode {
+			if c.PrevSibling == nil || (c.PrevSibling.Type == TextNode && strings.TrimSpace(c.PrevSibling.Data) != "") {
 				p.printTemplateLiteralOpen()
 			}
 			render1(p, c, RenderOptions{
@@ -346,7 +346,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				cssLen:           opts.cssLen,
 				printedMaybeHead: opts.printedMaybeHead,
 			})
-			if c.NextSibling == nil || c.NextSibling.Type == TextNode {
+			if c.NextSibling == nil || (c.NextSibling.Type == TextNode && strings.TrimSpace(c.NextSibling.Data) != "") {
 				p.printTemplateLiteralClose()
 			}
 		}
@@ -557,7 +557,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						printedMaybeHead: opts.printedMaybeHead,
 					})
 				}
-				p.printTemplateLiteralClose()
+				// p.printTemplateLiteralClose()
 				p.print(`,}`)
 			case isComponent:
 				p.print(`,`)

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -557,7 +557,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						printedMaybeHead: opts.printedMaybeHead,
 					})
 				}
-				// p.printTemplateLiteralClose()
+				p.printTemplateLiteralClose()
 				p.print(`,}`)
 			case isComponent:
 				p.print(`,`)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -527,13 +527,17 @@ import type data from "test"
 				return (
 					$$render` + BACKTICK + `<p>
 						onlyp ${dummyKey}
-					</p><h2>
+					</p>
+					<h2>
 						onlyh2 ${dummyKey}
-					</h2><div>
+					</h2>
+					<div>
 						<h2>div+h2 ${dummyKey}</h2>
-					</div><p>
-						</p><h2>p+h2 ${dummyKey}</h2>` + BACKTICK + `
-				);
+					</div>
+					<p>
+						</p><h2>p+h2 ${dummyKey}</h2>
+					` + BACKTICK + `	
+			);
 			})
 		}
 	</main>

--- a/packages/compiler/test/tsx/comment-whitespace.ts
+++ b/packages/compiler/test/tsx/comment-whitespace.ts
@@ -1,6 +1,7 @@
 import { convertToTSX } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils';
 
 test('preverve whitespace around jsx comments', async () => {
   const input = `{/* @ts-expect-error */}
@@ -20,7 +21,7 @@ test('preverve whitespace around jsx comments', async () => {
 // @ts-expect-error
 <Component prop="value"></Component>
 }`;
-  const output = `<Fragment>
+  const output = `${TSXPrefix}<Fragment>
 {/* @ts-expect-error */}
 <Component prop="value"></Component>
 


### PR DESCRIPTION
## Changes

https://github.com/withastro/compiler/pull/930 introduced a regression which broke a test added in https://github.com/withastro/compiler/pull/928, but we didn't catch that probably because we didn't update the branch before merging. This fixes the regression and updates tests

## Testing

Update tests to account for recently merged changes

## Docs

N/A bug fix
