### PR TITLE
Fix regression in expressions

### DIFF
--- a/.changeset/strong-chairs-walk.md
+++ b/.changeset/strong-chairs-walk.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Fix expression regression when the first child of an expression is whitespace and is followed by any other node
+Fixes a bug where expressions starting with whitespace, followed by anything else, weren't printed correctly.

--- a/.changeset/strong-chairs-walk.md
+++ b/.changeset/strong-chairs-walk.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix expression regression when the first child of an expression is whitespace and is followed by any other node

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -316,11 +316,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 
 	// Tip! Comment this block out to debug expressions
 	if n.Expression {
-		clean := ""
-		if n.FirstChild != nil {
-			clean = strings.TrimSpace(n.FirstChild.Data)
-		}
-		if n.FirstChild == nil || clean == "" {
+		if n.FirstChild == nil || emptyTextNodeWithoutSiblings(n.FirstChild) {
 			p.print("${(void 0)")
 		} else if expressionOnlyHasComment(n) {
 			// we do not print expressions that only contain comment blocks

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2487,6 +2487,20 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name: "expression with leading whitespace",
+			source: `<section>
+<ul class="font-mono text-sm flex flex-col gap-0.5">
+	{
+		<li>Build: { new Date().toISOString() }</li>
+		<li>NODE_VERSION: { process.env.NODE_VERSION }</li>
+	}
+</ul>
+</section>`,
+			want: want{
+				code: "${$$maybeRenderHead($$result)}<section>\n<ul class=\"font-mono text-sm flex flex-col gap-0.5\">\n\t${\n\n\t\t$$render`<li>Build: ${ new Date().toISOString() }</li>\n\t\t<li>NODE_VERSION: ${ process.env.NODE_VERSION }</li>`\n\t}\n</ul>\n</section>",
+			},
+		},
+		{
 			name:   "Empty attribute expression",
 			source: "<body attr={}></body>",
 			want: want{


### PR DESCRIPTION
## Changes

Found the issue on [discord](https://discord.com/channels/830184174198718474/830184175176122389/1194085209369477130)
Fixes a regression introduced in https://github.com/withastro/compiler/pull/930. We were only looking for `nil` or an empty text node in the first child of the expression, instead making sure that all children match that criteria before assuming it's an empty expression

## Testing

Added a printer test

## Docs

N/A bug fix