### PR TITLE
Set `transform` to literal mode

### DIFF
--- a/.changeset/shiny-plums-smile.md
+++ b/.changeset/shiny-plums-smile.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Fixes an edge case that caused `html` and `body` tags with attributes to be ignored when they were wrapped in a component.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -226,7 +226,7 @@ func Parse() any {
 		h := handler.NewHandler(source, parseOptions.Filename)
 
 		var doc *astro.Node
-		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h), astro.ParseOptionEnableLiteral(true))
+		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionEnableLiteral(true), astro.ParseOptionWithHandler(h))
 		if err != nil {
 			h.AppendError(err)
 		}
@@ -250,7 +250,7 @@ func ConvertToTSX() any {
 		h := handler.NewHandler(source, transformOptions.Filename)
 
 		var doc *astro.Node
-		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h), astro.ParseOptionEnableLiteral(true))
+		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionEnableLiteral(true), astro.ParseOptionWithHandler(h))
 		if err != nil {
 			h.AppendError(err)
 		}
@@ -301,7 +301,7 @@ func Transform() any {
 					}
 				}()
 
-				doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h))
+				doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionEnableLiteral(true), astro.ParseOptionWithHandler(h))
 				if err != nil {
 					reject.Invoke(wasm_utils.ErrorToJSError(h, err))
 					return

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1412,6 +1412,14 @@ const name = 'named';
 			},
 		},
 		{
+			name:   "top-level component does not drop body attributes",
+			source: `<Base><body class="foobar"><slot /></body></Base>`,
+			only:   true,
+			want: want{
+				code: "${$$renderComponent($$result,'Base',Base,{},{\"default\": () => $$render`${$$maybeRenderHead($$result)}<body class=\"foobar\">${$$renderSlot($$result,$$slots[\"default\"])}</body>`,})}",
+			},
+		},
+		{
 			name: "custom elements",
 			source: `---
 import 'test';
@@ -3227,8 +3235,8 @@ const items = ["Dog", "Cat", "Platipus"];
 			// transform output from source
 			code := test_utils.Dedent(tt.source)
 
-			doc, err := astro.Parse(strings.NewReader(code))
 			h := handler.NewHandler(code, "<stdin>")
+			doc, err := astro.ParseWithOptions(strings.NewReader(code), astro.ParseOptionEnableLiteral(true), astro.ParseOptionWithHandler(h))
 
 			if err != nil {
 				t.Error(err)
@@ -3480,6 +3488,11 @@ const c = '\''
 			name:   "element with unterminated template literal attribute",
 			source: `<main id=` + BACKTICK + `gotcha />`,
 			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "template-literal", Name: "id", Value: "gotcha", Raw: "`gotcha"}}}},
+		},
+		{
+			name:   "top-level component does not drop body attributes",
+			source: `<Base><body class="foobar"><slot /></body></Base>`,
+			want:   []ASTNode{{Type: "component", Name: "Base", Attributes: []ASTNode{}, Children: []ASTNode{{Type: "element", Name: "body", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "class", Value: "foobar", Raw: "\"foobar\""}}, Children: []ASTNode{{Type: "element", Name: "slot"}}}}}},
 		},
 	}
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -234,7 +234,7 @@ func TrimTrailingSpace(doc *astro.Node) {
 		return
 	}
 
-	if doc.LastChild.Type == astro.TextNode {
+	if doc.LastChild.Type == astro.TextNode && len(doc.LastChild.Data) < len(strings.TrimRightFunc(doc.LastChild.Data, unicode.IsSpace)) {
 		doc.LastChild.Data = strings.TrimRightFunc(doc.LastChild.Data, unicode.IsSpace)
 		return
 	}
@@ -246,7 +246,6 @@ func TrimTrailingSpace(doc *astro.Node) {
 			n = n.LastChild
 			continue
 		} else {
-			n = nil
 			break
 		}
 	}

--- a/packages/compiler/test/basic/body-in-component.ts
+++ b/packages/compiler/test/basic/body-in-component.ts
@@ -1,0 +1,24 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+---
+let value = 'world';
+---
+
+<Base><body class="foobar"><slot /></body></Base>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('top-level component does not drop body attributes', () => {
+  console.log(result.code);
+  assert.match(result.code, "${$$renderComponent($$result,'Base',Base,{},{\"default\": () => $$render`${$$maybeRenderHead($$result)}<body class=\"foobar\">${$$renderSlot($$result,$$slots[\"default\"])}</body>`,})}", `Expected body to be included!`);
+});
+
+
+test.run();

--- a/packages/compiler/test/basic/trailing-spaces-ii.ts
+++ b/packages/compiler/test/basic/trailing-spaces-ii.ts
@@ -23,7 +23,7 @@ test.before(async () => {
 });
 
 test('trailing space', () => {
-  assert.ok(result.code, 'Expected to compiler');
+  assert.ok(result.code, 'Expected to compile');
   assert.match(
     result.code,
     `<span class="spoiler astro-bqati2k5">


### PR DESCRIPTION
## Changes

- Updates `transform` to use the "literal" mode that already powers the `AST` and `TSX` outputs.
- Turns out our parser could handle this use case, we just didn't flip the flag to make it do so.
- Found a few other issues while fixing this, including tests that had encoded the incorrect behavior.
- Closes #935. Closes PLT-1381.

## Testing

Added new test for: Printer (JS), Printer (AST), Transform, Wasm output.
Existing tests should pass.
Updated old tests that relied on the previous behavior.

## Docs

This is a bug fix