### PR TITLE
Fix wrong component object path for namespaced default exported components

### DIFF
--- a/.changeset/fuzzy-bulldogs-add.md
+++ b/.changeset/fuzzy-bulldogs-add.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue which caused the hydration script of some kind default exported components to fail loading

--- a/.changeset/fuzzy-bulldogs-add.md
+++ b/.changeset/fuzzy-bulldogs-add.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Fixes an issue which caused the hydration script of some kind default exported components to fail loading
+Fixes an issue which caused the hydration script of default and named exported components to fail loading in some cases.

--- a/.changeset/fuzzy-bulldogs-add.md
+++ b/.changeset/fuzzy-bulldogs-add.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Fixes an issue which caused the hydration script of default and named exported components to fail loading in some cases.
+Fixes an issue which caused the hydration script of default exported components to fail loading in some cases.

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -703,3 +703,30 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 		i += len(value)
 	}
 }
+
+/*
+Determines the export name of a component, i.e. the object path to which
+we can access the module, if it were imported using a dynamic import (`import()`)
+
+Returns the export name and a boolean indicating whether
+the component is imported AND used in the template.
+*/
+func ExtractComponentExportName(data string, imported Import) (string, bool) {
+	dotPrefix := fmt.Sprintf("%s.", imported.LocalName)
+	hasDotPrefix := strings.Contains(data, ".") && strings.HasPrefix(data, dotPrefix)
+	isNamespacedImport := imported.ExportName == "*"
+	isDefaultImport := imported.ExportName == "default"
+	if (isNamespacedImport || isDefaultImport) && hasDotPrefix || imported.LocalName == data {
+		var exportName string
+		switch true {
+		case imported.LocalName == data:
+			exportName = imported.ExportName
+		case isNamespacedImport:
+			exportName = strings.Replace(data, fmt.Sprintf("%s.", imported.LocalName), "", 1)
+		case isDefaultImport:
+			exportName = strings.Replace(data, imported.LocalName, "default", 1)
+		}
+		return exportName, true
+	}
+	return "", false
+}

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -712,21 +712,22 @@ Returns the export name and a boolean indicating whether
 the component is imported AND used in the template.
 */
 func ExtractComponentExportName(data string, imported Import) (string, bool) {
-	dotPrefix := fmt.Sprintf("%s.", imported.LocalName)
-	hasDotPrefix := strings.Contains(data, ".") && strings.HasPrefix(data, dotPrefix)
-	isNamespacedImport := imported.ExportName == "*"
-	isDefaultImport := imported.ExportName == "default"
-	if hasDotPrefix || imported.LocalName == data {
+	namespacePrefix := fmt.Sprintf("%s.", imported.LocalName)
+	isNamespacedComponent := strings.Contains(data, ".") && strings.HasPrefix(data, namespacePrefix)
+	localNameEqualsData := imported.LocalName == data
+	if isNamespacedComponent || localNameEqualsData {
 		var exportName string
 		switch true {
-		case imported.LocalName == data:
+		case localNameEqualsData:
 			exportName = imported.ExportName
-		case isNamespacedImport:
-			exportName = strings.Replace(data, dotPrefix, "", 1)
-		case isDefaultImport:
+		case imported.ExportName == "*":
+			// matched a namespaced import
+			exportName = strings.Replace(data, namespacePrefix, "", 1)
+		case imported.ExportName == "default":
+			// matched a default import
 			exportName = strings.Replace(data, imported.LocalName, "default", 1)
 		default:
-			// we matched a named import
+			// matched a named import
 			exportName = data
 		}
 		return exportName, true

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -716,15 +716,18 @@ func ExtractComponentExportName(data string, imported Import) (string, bool) {
 	hasDotPrefix := strings.Contains(data, ".") && strings.HasPrefix(data, dotPrefix)
 	isNamespacedImport := imported.ExportName == "*"
 	isDefaultImport := imported.ExportName == "default"
-	if (isNamespacedImport || isDefaultImport) && hasDotPrefix || imported.LocalName == data {
+	if hasDotPrefix || imported.LocalName == data {
 		var exportName string
 		switch true {
 		case imported.LocalName == data:
 			exportName = imported.ExportName
 		case isNamespacedImport:
-			exportName = strings.Replace(data, fmt.Sprintf("%s.", imported.LocalName), "", 1)
+			exportName = strings.Replace(data, dotPrefix, "", 1)
 		case isDefaultImport:
 			exportName = strings.Replace(data, imported.LocalName, "default", 1)
+		default:
+			// we matched a named import
+			exportName = data
 		}
 		return exportName, true
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -870,6 +870,64 @@ import * as components from '../components';
 			},
 		},
 		{
+			name: "client:only component (namespaced default)",
+			source: `---
+import defaultImport from '../components/ui-1';
+---
+<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+	<defaultImport.Counter1 client:only />
+  </body>
+</html>`,
+			want: want{
+				frontmatter: []string{"import defaultImport from '../components/ui-1';"},
+				metadata: metadata{
+					hydrationDirectives:  []string{"only"},
+					clientOnlyComponents: []string{"../components/ui-1"},
+				},
+				// Specifically do NOT render any metadata here, we need to skip this import
+				code: `<html>
+  <head>
+    <title>Hello world</title>
+  ` + RENDER_HEAD_RESULT + `</head>
+  <body>
+	${` + RENDER_COMPONENT + `($$result,'defaultImport.Counter1',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components/ui-1")),"client:component-export":"default.Counter1"})}
+  </body></html>`,
+			},
+		},
+		{
+			name: "client:only component (namespaced named)",
+			source: `---
+import { namedImport } from '../components/ui-2';
+---
+<html>
+  <head>
+    <title>Hello world</title>
+  </head>
+  <body>
+	<namedImport.Counter2 client:only />
+  </body>
+</html>`,
+			want: want{
+				frontmatter: []string{"import { namedImport } from '../components/ui-2';"},
+				metadata: metadata{
+					hydrationDirectives:  []string{"only"},
+					clientOnlyComponents: []string{"../components/ui-2"},
+				},
+				// Specifically do NOT render any metadata here, we need to skip this import
+				code: `<html>
+  <head>
+    <title>Hello world</title>
+  ` + RENDER_HEAD_RESULT + `</head>
+  <body>
+	${` + RENDER_COMPONENT + `($$result,'namedImport.Counter2',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components/ui-2")),"client:component-export":"namedImport.Counter2"})}
+  </body></html>`,
+			},
+		},
+		{
 			name: "client:only component (multiple)",
 			source: `---
 import Component from '../components';

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -476,22 +476,10 @@ func matchNodeToImportStatement(doc *astro.Node, n *astro.Node) *ImportMatch {
 
 	eachImportStatement(doc, func(stmt js_scanner.ImportStatement) bool {
 		for _, imported := range stmt.Imports {
-
-			if strings.Contains(n.Data, ".") && strings.HasPrefix(n.Data, fmt.Sprintf("%s.", imported.LocalName)) {
-				exportName := n.Data
-				if imported.ExportName == "*" {
-					exportName = strings.Replace(exportName, fmt.Sprintf("%s.", imported.LocalName), "", 1)
-				} else if imported.ExportName == "default" {
-					exportName = strings.Replace(exportName, imported.LocalName, "default", 1)
-				}
+			exportName, isUsed := js_scanner.ExtractComponentExportName(n.Data, imported)
+			if isUsed {
 				match = &ImportMatch{
 					ExportName: exportName,
-					Specifier:  stmt.Specifier,
-				}
-				return false
-			} else if imported.LocalName == n.Data {
-				match = &ImportMatch{
-					ExportName: imported.ExportName,
 					Specifier:  stmt.Specifier,
 				}
 				return false

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -481,6 +481,8 @@ func matchNodeToImportStatement(doc *astro.Node, n *astro.Node) *ImportMatch {
 				exportName := n.Data
 				if imported.ExportName == "*" {
 					exportName = strings.Replace(exportName, fmt.Sprintf("%s.", imported.LocalName), "", 1)
+				} else if imported.ExportName == "default" {
+					exportName = strings.Replace(exportName, imported.LocalName, "default", 1)
 				}
 				match = &ImportMatch{
 					ExportName: exportName,


### PR DESCRIPTION
## Changes

- Closes https://github.com/withastro/compiler/issues/899
- Generate a correct `exportName` for namespaced default exports
- Remove duplicated code that determines the exported module's object path

## Testing

- Added tests for namespaced components imported from default and named exports
- I'll add a test in core too after we get this merged

## Docs

N/A bug fix only