### PR TITLE
Fix slot regression when there are multiple expressions

### DIFF
--- a/.changeset/dull-socks-provide.md
+++ b/.changeset/dull-socks-provide.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where a slotted element in an expression would cause subsequent ones to be incorrectly printed

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -432,7 +432,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		p.printAttributesToObject(n)
 	} else if isSlot {
 		if len(n.Attr) == 0 {
-			p.print(`"default"`)
+			p.print(DEFAULT_SLOT_PROP)
 		} else {
 			slotted := false
 			for _, a := range n.Attr {
@@ -454,7 +454,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				}
 			}
 			if !slotted {
-				p.print(`"default"`)
+				p.print(DEFAULT_SLOT_PROP)
 			}
 		}
 		p.print(`]`)
@@ -559,7 +559,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			switch true {
 			case n.CustomElement:
 				p.print(`,({`)
-				p.print(fmt.Sprintf(`"%s": () => `, "default"))
+				p.print(fmt.Sprintf(`%s: () => `, DEFAULT_SLOT_PROP))
 				p.printTemplateLiteralOpen()
 				for c := n.FirstChild; c != nil; c = c.NextSibling {
 					render1(p, c, RenderOptions{
@@ -638,6 +638,8 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	}
 }
 
+const DEFAULT_SLOT_PROP = `"default"`
+
 // Section 12.1.2, "Elements", gives this list of void elements. Void elements
 // are those that can't have any contents.
 // nolint
@@ -667,7 +669,7 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 	numberOfNestedSlots := 0
 
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
-		slotProp := `"default"`
+		slotProp := DEFAULT_SLOT_PROP
 		for _, a := range c.Attr {
 			if a.Key == "slot" {
 				if a.Type == QuotedAttribute {
@@ -747,7 +749,7 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 						}
 					}
 					if !foundNamedSlot && c1.Type == ElementNode {
-						pseudoSlotEntry := &NestedSlotChild{`"default"`, []*Node{c1}, isFirstInGroup}
+						pseudoSlotEntry := &NestedSlotChild{DEFAULT_SLOT_PROP, []*Node{c1}, isFirstInGroup}
 						nestedSlotChildren = append(nestedSlotChildren, pseudoSlotEntry)
 					} else {
 						nestedSlotEntry := &NestedSlotChild{`"@@NON_ELEMENT_ENTRY"`, []*Node{c1}, isFirstInGroup}
@@ -785,7 +787,7 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 			children := slottedChildren[slotProp]
 
 			// If there are named slots, the default slot cannot be only whitespace
-			if numberOfSlots > 1 && slotProp == "\"default\"" {
+			if numberOfSlots > 1 && slotProp == DEFAULT_SLOT_PROP {
 				// Loop over the children and verify that at least one non-whitespace node exists.
 				foundNonWhitespace := false
 				for _, child := range children {
@@ -910,7 +912,7 @@ func generateEndSlotIndexes(nestedSlotChildren []*NestedSlotChild) map[int]bool 
 }
 
 func mergeDefaultSlotsAndUpdateIndexes(nestedSlotChildren *[]*NestedSlotChild, endSlotIndexes map[int]bool) {
-	defaultSlot := &NestedSlotChild{SlotProp: `"default"`, Children: []*Node{}}
+	defaultSlot := &NestedSlotChild{SlotProp: DEFAULT_SLOT_PROP, Children: []*Node{}}
 	mergedSlotChildren := make([]*NestedSlotChild, 0)
 	numberOfMergedSlotsInSlotChain := 0
 
@@ -924,7 +926,7 @@ func mergeDefaultSlotsAndUpdateIndexes(nestedSlotChildren *[]*NestedSlotChild, e
 		if shouldMergeDefaultSlot(endSlotIndexes, i, defaultSlot) {
 			resetEndSlotIndexes(endSlotIndexes, i, &numberOfMergedSlotsInSlotChain)
 			mergedSlotChildren = append(mergedSlotChildren, defaultSlot)
-			defaultSlot = &NestedSlotChild{SlotProp: `"default"`, Children: []*Node{}}
+			defaultSlot = &NestedSlotChild{SlotProp: DEFAULT_SLOT_PROP, Children: []*Node{}}
 		}
 	}
 	*nestedSlotChildren = mergedSlotChildren
@@ -945,7 +947,7 @@ func isNonWhitespaceTextNode(n *Node) bool {
 }
 
 func isDefaultSlot(slot *NestedSlotChild) bool {
-	return slot.SlotProp == `"default"`
+	return slot.SlotProp == DEFAULT_SLOT_PROP
 }
 
 func shouldMergeDefaultSlot(endSlotIndexes map[int]bool, i int, defaultSlot *NestedSlotChild) bool {

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -829,7 +829,7 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 	}
 	p.print(`})`)
 	// print nested slots
-	if len(nestedSlotChildren) > 0 || hasAnyNestedDynamicSlot {
+	if len(nestedSlotChildren) > 0 {
 		endSlotIndexes := generateEndSlotIndexes(nestedSlotChildren)
 		mergeDefaultSlotsAndUpdateIndexes(&nestedSlotChildren, endSlotIndexes)
 

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -688,6 +688,11 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 			}
 		}
 		if c.Expression {
+			// Only slot ElementNodes (except expressions containing only comments) or non-empty TextNodes!
+			// CommentNode, JSX comments and others should not be slotted
+			if expressionOnlyHasComment(c) {
+				continue
+			}
 			nestedSlotsInExprCount := 0
 			hasAnyDynamicSlotsInExpr := false
 			var slotProp = DEFAULT_SLOT_PROP
@@ -757,11 +762,6 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 			}
 		}
 
-		// Only slot ElementNodes (except expressions containing only comments) or non-empty TextNodes!
-		// CommentNode, JSX comments and others should not be slotted
-		if expressionOnlyHasComment(c) {
-			continue
-		}
 		if c.Type == ElementNode || c.Type == TextNode && !emptyTextNodeWithoutSiblings(c) {
 			slottedChildren[slotProp] = append(slottedChildren[slotProp], c)
 		}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -705,12 +705,10 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 							slotProp = fmt.Sprintf(`"%s"`, escapeDoubleQuote(a.Val))
 						} else if a.Type == ExpressionAttribute {
 							slotProp = fmt.Sprintf(`[%s]`, a.Val)
-							hasAnyNestedDynamicSlot = true
-							hasAnyDynamicSlotsInExpr = true
+							hasAnyNestedDynamicSlot, hasAnyDynamicSlotsInExpr = true, true
 						} else if a.Type == TemplateLiteralAttribute {
 							slotProp = fmt.Sprintf(`[%s%s%s]`, BACKTICK, a.Val, BACKTICK)
-							hasAnyNestedDynamicSlot = true
-							hasAnyDynamicSlotsInExpr = true
+							hasAnyNestedDynamicSlot, hasAnyDynamicSlotsInExpr = true, true
 						} else {
 							panic(`unknown slot attribute type`)
 						}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -738,7 +738,6 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 							var nestedSlotEntry *NestedSlotChild
 							if a.Type == QuotedAttribute {
 								nestedSlotProp = fmt.Sprintf(`"%s"`, escapeDoubleQuote(a.Val))
-								hasAnyNestedDynamicSlot = true
 							} else if a.Type == ExpressionAttribute {
 								nestedSlotProp = fmt.Sprintf(`[%s]`, a.Val)
 								hasAnyNestedDynamicSlot = true

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -690,9 +690,8 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 		if c.Expression {
 			nestedSlotsInExprCount := 0
 			hasAnyDynamicSlotsInExpr := false
-			var firstNestedSlotProp string
+			var slotProp = DEFAULT_SLOT_PROP
 			for c1 := c.FirstChild; c1 != nil; c1 = c1.NextSibling {
-				var slotProp = ""
 				for _, a := range c1.Attr {
 					if a.Key == "slot" {
 						if a.Type == QuotedAttribute {
@@ -709,17 +708,14 @@ func handleSlots(p *printer, n *Node, opts RenderOptions, depth int) {
 							panic(`unknown slot attribute type`)
 						}
 					}
-					if firstNestedSlotProp == "" && slotProp != "" {
-						firstNestedSlotProp = slotProp
-					}
 				}
-				if firstNestedSlotProp != "" {
+				if c1.Type == ElementNode {
 					nestedSlotsInExprCount++
 				}
 			}
 
 			if nestedSlotsInExprCount == 1 && !hasAnyDynamicSlotsInExpr {
-				slottedChildren[firstNestedSlotProp] = append(slottedChildren[firstNestedSlotProp], c)
+				slottedChildren[slotProp] = append(slottedChildren[slotProp], c)
 				continue
 			} else if nestedSlotsInExprCount > 1 || hasAnyDynamicSlotsInExpr {
 			child_loop:

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -241,6 +241,35 @@ func TestPrinter(t *testing.T) {
 			},
 		},
 		{
+			name: "ternary slot II",
+			source: `<Layout>
+	{
+		Astro.request.method === 'GET' ? (
+			<h2>Contact Form</h2>
+			<form action="/contact" method="get">
+				<input type="hidden" name="name" value="Testing">
+				<button id="submit" type="submit" formmethod="post" formaction="/form-three">Submit</button>
+			</form>
+		) : (
+			<div id="three-result">Got: {formData?.get('name')}</div>
+		)
+	}
+</Layout>`,
+			want: want{
+				code: `${$$renderComponent($$result,'Layout',Layout,{},$$mergeSlots(({}),
+		Astro.request.method === 'GET' ? (
+			
+			({"default": () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<h2>Contact Form</h2><form action="/contact" method="get">
+				<input type="hidden" name="name" value="Testing">
+				<button id="submit" type="submit" formmethod="post" formaction="/form-three">Submit</button>
+			</form>` + BACKTICK + `})
+		) : (
+			({"default": () => $$render` + BACKTICK + `<div id="three-result">Got: ${formData?.get('name')}</div>` + BACKTICK + `})
+		)
+	))}`,
+			},
+		},
+		{
 			name: "ternary slot with one implicit default",
 			source: `<Main>
 	{useSlot

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -278,7 +278,7 @@ func TestPrinter(t *testing.T) {
 	{true && <span>Default</span>}
 </Slotted>`,
 			want: want{
-				code: "${$$renderComponent($$result,'Slotted',Slotted,{},$$mergeSlots(({\"a\": () => $$render`${true && $$render`${$$maybeRenderHead($$result)}<span>A</span>`}`,}),true ? ({\"b\": () => $$render`<span>B</span>`}) : null,() => ({\"c\": () => $$render`<span>C</span>`}),true && ({\"default\": () => $$render`<span>Default</span>`})))}",
+				code: "${$$renderComponent($$result,'Slotted',Slotted,{},({\"a\": () => $$render`${true && $$render`${$$maybeRenderHead($$result)}<span>A</span>`}`,\"b\": () => $$render`${true ? $$render`<span>B</span>` : null}`,\"c\": () => $$render`${() => $$render`<span>C</span>`}`,\"default\": () => $$render`${true && $$render`<span>Default</span>`}`,}))}",
 			},
 		},
 		{
@@ -300,7 +300,7 @@ func TestPrinter(t *testing.T) {
 	}}
 </Slotted>`,
 			want: want{
-				code: `${$$renderComponent($$result,'Slotted',Slotted,{},$$mergeSlots(({}),true && ({["a"]: () => $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<span>A</span>` + BACKTICK + `}),true ? ({"b": () => $$render` + BACKTICK + `<span>B</span>` + BACKTICK + `}) : null,() => ({"c": () => $$render` + BACKTICK + `<span>C</span>` + BACKTICK + `}),() => {
+				code: `${$$renderComponent($$result,'Slotted',Slotted,{},$$mergeSlots(({"b": () => $$render` + BACKTICK + `${true ? $$render` + BACKTICK + `${$$maybeRenderHead($$result)}<span>B</span>` + BACKTICK + ` : null}` + BACKTICK + `,"c": () => $$render` + BACKTICK + `${() => $$render` + BACKTICK + `<span>C</span>` + BACKTICK + `}` + BACKTICK + `,}),true && ({["a"]: () => $$render` + BACKTICK + `<span>A</span>` + BACKTICK + `}),() => {
 		const value = 0.33;
 		if (value > 0.25) {
 			return ({"hey": () => $$render` + BACKTICK + `<span>Another</span>` + BACKTICK + `, "default": () => $$render` + BACKTICK + `<span>Default</span>` + BACKTICK + `})


### PR DESCRIPTION
## Changes

- Closes #950
- More granular printing of `mergeSlots`

A regression in how we print slot was introduced in my PR in https://github.com/withastro/compiler/pull/933.

Normally, if there is more than one slotted element or any slotted element with dynamic `slot` prop in an expression, we consider it a nested slot. However, instead of doing the count per expression, we aggregated it for all expressions.

Because of that, if there were any slotted element in an expression, any subsequent slotted element of the same kind would be considered a nested slot

To fix that, we localized each of those states per expression

## Testing

- Adapted and added a few printer tests to reflect the changes and ensure a correct output
- Added tests to Astro core to ensure a correct result

## Docs

N/A bug fix only
