### PR TITLE
Fix expression in `th` causing infinite loop

### DIFF
--- a/.changeset/young-cougars-enjoy.md
+++ b/.changeset/young-cougars-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixes an issue where an expression inside a `th` tag would cause an infinite loop

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2730,6 +2730,10 @@ func inLiteralIM(p *parser) bool {
 }
 
 func inExpressionIM(p *parser) bool {
+	// if p.oe.contains(a.Table) {
+	// 	p.clearActiveFormattingElements()
+	// 	return inLiteralIM(p)
+	// }
 	switch p.tok.Type {
 	case ErrorToken:
 		p.oe.pop()
@@ -2762,7 +2766,7 @@ func inExpressionIM(p *parser) bool {
 			}
 		} else {
 			switch p.tok.DataAtom {
-			case a.Table, a.Tbody, a.Thead, a.Tr, a.Td:
+			case a.Table, a.Tbody, a.Thead, a.Tr, a.Td, a.Th:
 				p.im = inLiteralIM
 				p.originalIM = inExpressionIM
 				p.exitLiteralIM = getExitLiteralFunc(p)

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2730,10 +2730,6 @@ func inLiteralIM(p *parser) bool {
 }
 
 func inExpressionIM(p *parser) bool {
-	// if p.oe.contains(a.Table) {
-	// 	p.clearActiveFormattingElements()
-	// 	return inLiteralIM(p)
-	// }
 	switch p.tok.Type {
 	case ErrorToken:
 		p.oe.pop()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2413,6 +2413,100 @@ const content = "lol";
 			},
 		},
 		{
+			name: "blah blah",
+			source: `---
+const { title, footnotes, tables } = Astro.props;
+
+interface Table {
+	title: string;
+	data: any[];
+	showTitle: boolean;
+	footnotes: string;
+}
+console.log(tables);
+---
+
+<div>
+	<div>
+	<h2>
+		{title}
+	</h2>
+	{
+		tables.map((table: Table) => (
+		<>
+			<div>
+			<h3 class="text-3xl sm:text-5xl font-bold">{table.title}</h3>
+			<table>
+				<thead>
+				{Object.keys(table.data[0]).map((thead) => (
+					<th>{thead}</th>
+				))}
+				</thead>
+				<tbody>
+				{table.data.map((trow) => (
+					<tr>
+					{Object.values(trow).map((cell, index) => (
+						<td>
+						{cell}
+						</td>
+					))}
+					</tr>
+				))}
+				</tbody>
+			</table>
+			</div>
+		</>
+		))
+	}
+	</div>
+</div>`,
+			want: want{
+				frontmatter: []string{``, `const { title, footnotes, tables } = Astro.props;
+
+interface Table {
+	title: string;
+	data: any[];
+	showTitle: boolean;
+	footnotes: string;
+}
+console.log(tables);`},
+				code: `${$$maybeRenderHead($$result)}<div>
+	<div>
+	<h2>
+		${title}
+	</h2>
+	${
+		tables.map((table: Table) => (
+		$$render` + BACKTICK + `${$$renderComponent($$result,'Fragment',Fragment,{},({"default": () => $$render` + BACKTICK + `
+			<div>
+			<h3 class="text-3xl sm:text-5xl font-bold">${table.title}</h3>
+			<table>
+				<thead>
+				${Object.keys(table.data[0]).map((thead) => (
+					$$render` + BACKTICK + `<th>${thead}</th>` + BACKTICK + `
+				))}
+				</thead>
+				<tbody>
+				${table.data.map((trow) => (
+					$$render` + BACKTICK + `<tr>
+					${Object.values(trow).map((cell, index) => (
+						$$render` + BACKTICK + `<td>
+						${cell}
+						</td>` + BACKTICK + `
+					))}
+					</tr>` + BACKTICK + `
+				))}
+				</tbody>
+			</table>
+			</div>
+		` + BACKTICK + `,}))}` + BACKTICK + `
+		))
+	}
+	</div>
+</div>`,
+			},
+		},
+		{
 			name: "table expressions (no implicit tbody)",
 			source: `---
 const items = ["Dog", "Cat", "Platipus"];

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2413,7 +2413,7 @@ const content = "lol";
 			},
 		},
 		{
-			name: "blah blah",
+			name: "table with expression in 'th'",
 			source: `---
 const { title, footnotes, tables } = Astro.props;
 


### PR DESCRIPTION
## Changes

Fix [an issue reported on discord](https://discord.com/channels/830184174198718474/1199343177446998116/1199343177446998116) in which if there were an expression in a `th` element, that would cause an infinite loop
This regression was introduced in 2.4.0, but I'm not sure what exactly caused it

## Testing

Added printer test to make sure that it doesn't hang and it's printed correctly

## Docs

N/A bug fix only
