### PR TITLE
fix(tsx): Remove unnecessary jsdoc comment

### DIFF
--- a/.changeset/bright-lemons-fry.md
+++ b/.changeset/bright-lemons-fry.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix TSX output prefixing output with unnecessary jsdoc comment

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -17,7 +17,7 @@ import (
 )
 
 func getTSXPrefix() string {
-	return "/** @jsxImportSource astro */\n\n"
+	return "/* @jsxImportSource astro */\n\n"
 }
 
 func PrintToTSX(sourcetext string, n *Node, opts transform.TransformOptions, h *handler.Handler) PrintResult {

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -251,12 +251,12 @@ test('return ranges', async () => {
 
   assert.equal(metaRanges, {
     frontmatter: {
-      start: 31,
-      end: 55,
+      start: 30,
+      end: 54,
     },
     body: {
-      start: 69,
-      end: 81,
+      start: 68,
+      end: 80,
     },
   });
 });
@@ -267,12 +267,12 @@ test('return ranges - no frontmatter', async () => {
 
   assert.equal(metaRanges, {
     frontmatter: {
-      start: 31,
-      end: 31,
+      start: 30,
+      end: 30,
     },
     body: {
-      start: 42,
-      end: 54,
+      start: 41,
+      end: 53,
     },
   });
 });

--- a/packages/compiler/test/utils.ts
+++ b/packages/compiler/test/utils.ts
@@ -78,4 +78,4 @@ export async function testJSSourcemap(input: string, snippet: string) {
 
   return originalPosition;
 }
-export const TSXPrefix = '/** @jsxImportSource astro */\n\n';
+export const TSXPrefix = '/* @jsxImportSource astro */\n\n';


### PR DESCRIPTION
## Changes

I'm not sure why I thought it had to be a `/**` comment, it's not necessary. This was causing the first const in a component to be marked by the JSDoc.

## Testing

Tests should pass! [I also tested that this works in the TypeScript playground](https://www.typescriptlang.org/play?#code/PQKgBAAgVgzgHgSQLYAcD2AnALgZTQVwwGMBTMDEgQyKzBGACgGS51swAzfAOxoEs03MAGE0qQSW5YAFAEowAbwZhyJLISEAeACZ8AbmGAA+BgF8GQA)

## Docs

N/A
