### PR TITLE
Add renderScript option

### DIFF
--- a/.changeset/gold-apples-shout.md
+++ b/.changeset/gold-apples-shout.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Adds a new `renderScript` option to render non-inline script tags using a `renderScript` function from `internalURL`, instead of stripping the script entirely

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -126,6 +126,11 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		scopedStyleStrategy = "where"
 	}
 
+	renderScript := false
+	if jsBool(options.Get("renderScript")) {
+		renderScript = true
+	}
+
 	return transform.TransformOptions{
 		Filename:                filename,
 		NormalizedFilename:      normalizedFilename,
@@ -139,6 +144,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		ScopedStyleStrategy:     scopedStyleStrategy,
 		TransitionsAnimationURL: transitionsAnimationURL,
 		AnnotateSourceFile:      annotateSourceFile,
+		RenderScript:            renderScript,
 	}
 }
 

--- a/internal/node.go
+++ b/internal/node.go
@@ -85,6 +85,9 @@ type Node struct {
 	Expression      bool
 	Transition      bool
 	TransitionScope string
+	// Whether this node is a script that should be rendered with the `renderScript` runtime,
+	// so that the runtime handles how this is bundled and referenced.
+	HandledScript bool
 
 	Parent, FirstChild, LastChild, PrevSibling, NextSibling *Node
 
@@ -233,6 +236,7 @@ func (n *Node) clone() *Node {
 		Attr:          make([]Attribute, len(n.Attr)),
 		CustomElement: n.CustomElement,
 		Component:     n.Component,
+		HandledScript: n.HandledScript,
 		Loc:           n.Loc,
 	}
 	copy(m.Attr, n.Attr)

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -389,6 +389,7 @@ func (p *parser) addExpression() {
 		Expression:    true,
 		Component:     false,
 		CustomElement: false,
+		HandledScript: false,
 		Loc:           p.generateLoc(),
 	})
 }
@@ -433,6 +434,7 @@ func (p *parser) addElement() {
 		Fragment:      isFragment(p.tok.Data),
 		Component:     isComponent(p.tok.Data),
 		CustomElement: isCustomElement(p.tok.Data),
+		HandledScript: false,
 		Loc:           p.generateLoc(),
 	})
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -54,6 +54,7 @@ var SPREAD_ATTRIBUTES = "$$spreadAttributes"
 var DEFINE_STYLE_VARS = "$$defineStyleVars"
 var DEFINE_SCRIPT_VARS = "$$defineScriptVars"
 var CREATE_METADATA = "$$createMetadata"
+var RENDER_SCRIPT = "$$renderScript"
 var METADATA = "$$metadata"
 var RESULT = "$$result"
 var SLOTS = "$$slots"
@@ -137,8 +138,10 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.print("renderTransition as " + RENDER_TRANSITION + ",\n  ")
 	p.addNilSourceMapping()
 	p.print("createTransitionScope as " + CREATE_TRANSITION_SCOPE + ",\n  ")
+	p.addNilSourceMapping()
+	p.print("renderScript as " + RENDER_SCRIPT + ",\n  ")
 
-	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
+	// Only needed if using fazllback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {
 		p.addNilSourceMapping()
 		p.print("createMetadata as " + CREATE_METADATA)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -141,7 +141,7 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.addNilSourceMapping()
 	p.print("renderScript as " + RENDER_SCRIPT + ",\n  ")
 
-	// Only needed if using fazllback `resolvePath` as it calls `$$metadata.resolvePath`
+	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {
 		p.addNilSourceMapping()
 		p.print("createMetadata as " + CREATE_METADATA)

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -31,6 +31,7 @@ type TransformOptions struct {
 	ResolvePath             func(string) string
 	PreprocessStyle         interface{}
 	AnnotateSourceFile      bool
+	RenderScript            bool
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -81,8 +82,10 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 	NormalizeSetDirectives(doc, h)
 
 	// Important! Remove scripts from original location *after* walking the doc
-	for _, script := range doc.Scripts {
-		script.Parent.RemoveChild(script)
+	if !opts.RenderScript {
+		for _, script := range doc.Scripts {
+			script.Parent.RemoveChild(script)
+		}
 	}
 
 	// If we've emptied out all the nodes, this was a Fragment that only contained hoisted elements
@@ -389,6 +392,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 			// prepend node to maintain authored order
 			if shouldAdd {
 				doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
+				n.HandledScript = true
 			}
 		} else {
 			for _, attr := range n.Attr {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -57,6 +57,12 @@ export interface TransformOptions {
   resolvePath?: (specifier: string) => Promise<string>;
   preprocessStyle?: (content: string, attrs: Record<string, string>) => null | Promise<PreprocessorResult | PreprocessorError>;
   annotateSourceFile?: boolean;
+  /**
+   * Render script tags to be processed (e.g. script tags that have no attributes or only a `src` attribute)
+   * using a `renderScript` function from `internalURL`, instead of stripping the script entirely.
+   * @experimental
+   */
+  renderScript?: boolean;
 }
 
 export type ConvertToTSXOptions = Pick<TransformOptions, 'filename' | 'normalizedFilename'>;


### PR DESCRIPTION
## Changes

This PR allows rendering non-inline script tags using a runtime API from `internalURL`, e.g.

```html
<script>console.log("a")</script>
```

becomes:

```js
`${$$renderScript($$metadata, "/src/pages/index.astro?astro&type=script&index=0&lang.ts")}`
```

Personally I'm not a fan of the hardcoded script URL default, but the styles were also hardcoded this way, and it was easier to implement.

## Testing

Added go tests

## Docs

Only added jsdoc to the types explaining this feature. Options added in the past didn't have public docs either (?)
