### PR TITLE
Add lint rule for implicit `is:inline` on script tags.

### DIFF
--- a/.changeset/cuddly-pumas-call.md
+++ b/.changeset/cuddly-pumas-call.md
@@ -2,4 +2,4 @@
 '@astrojs/compiler': patch
 ---
 
-Adds a lint rules when attributes are added to a script tag, causing the script to be treated as `is:inline`.
+Adds a lint rule to display a message when attributes are added to a script tag, explaining that the script will be treated as `is:inline`.

--- a/.changeset/cuddly-pumas-call.md
+++ b/.changeset/cuddly-pumas-call.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Adds a lint rules when attributes are added to a script tag, causing the script to be treated as `is:inline`.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -45,6 +45,7 @@ func (h *Handler) AppendWarning(err error) {
 func (h *Handler) AppendInfo(err error) {
 	h.infos = append(h.infos, err)
 }
+
 func (h *Handler) AppendHint(err error) {
 	h.hints = append(h.hints, err)
 }

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -412,7 +412,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
+			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -412,7 +412,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
+			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.\n\nAdd the `is:inline` directive explicitly to silence this hint.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -406,13 +406,15 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 }
 
 func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
-	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && (!HasInlineDirective(n) || len(n.Attr) == 1 && n.Attr[0].Key != "src") {
+	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && !HasInlineDirective(n) {
+		if len(n.Attr) == 1 && n.Attr[0].Key == "src" {
+			return
+		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
 			Text:  "Astro processes your script tags to allow using TypeScript and npm packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
-
 	}
 }
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -412,7 +412,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.\n\nAdd the `is:inline` directive explicitly to silence this hint.",
+			Text:  "This script will be treated as if it has the `is:inline` directive because it contains an attribute. Therefore, features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.\n\nAdd the `is:inline` directive explicitly to silence this hint.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -412,7 +412,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text:  "Astro processes your script tags to allow using TypeScript and npm packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
+			Text: "This script contains an attribute (ex: `type="module"`, `type="text/partytown"`, `async`) or a directive (`define:vars`) and will not be processed and bundled for optimized browser performance.\n\nThis script will be treated as if it has the `is:inline` directive and therefore features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -406,7 +406,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 }
 
 func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
-	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && len(n.Attr) == 1 && n.Attr[0].Key != "src" && !HasInlineDirective(n) {
+	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && (!HasInlineDirective(n) || len(n.Attr) == 1 && n.Attr[0].Key != "src") {
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
 			Text:  "Astro processes your script tags to allow using TypeScript and npm packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -40,7 +40,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 	i := 0
 	walk(doc, func(n *astro.Node) {
 		i++
-		HintAboutImplicitInlineDirective(doc, n, &opts, h)
+		HintAboutImplicitInlineDirective(n, h)
 		ExtractScript(doc, n, &opts, h)
 		AddComponentProps(doc, n, &opts)
 		if shouldScope {
@@ -405,7 +405,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 	}
 }
 
-func HintAboutImplicitInlineDirective(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *handler.Handler) {
+func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && !HasInlineDirective(n) {
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -412,7 +412,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 		}
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text: "This script contains an attribute (ex: `type="module"`, `type="text/partytown"`, `async`) or a directive (`define:vars`) and will not be processed and bundled for optimized browser performance.\n\nThis script will be treated as if it has the `is:inline` directive and therefore features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
+			Text:  "This script will be treated as if it has the `is:inline` directive, because it contains an attribute. Therefore features that require processing (e.g. using TypeScript or npm packages in the script) are unavailable.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -406,7 +406,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 }
 
 func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
-	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && !HasInlineDirective(n) {
+	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && len(n.Attr) == 1 && n.Attr[0].Key != "src" && !HasInlineDirective(n) {
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
 			Text:  "Astro processes your script tags to allow using TypeScript and npm packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -409,7 +409,7 @@ func HintAboutImplicitInlineDirective(n *astro.Node, h *handler.Handler) {
 	if n.Type == astro.ElementNode && n.DataAtom == a.Script && len(n.Attr) > 0 && !HasInlineDirective(n) {
 		h.AppendHint(&loc.ErrorWithRange{
 			Code:  loc.HINT,
-			Text:  "Astro processes your script tags to allow using TypeScript and NPM packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
+			Text:  "Astro processes your script tags to allow using TypeScript and npm packages, and to optimize browser performance.\n\nAttributes cannot be used on Astro-processed script tags. Therefore, this script tag will be treated as if it has the `is:inline` directive, opting it out of the processing steps and its features.\n\nFor clarity, you might want to add the `is:inline` directive explicitly.\n\nSee docs for more details: https://docs.astro.build/en/guides/client-side-scripts/#script-processing.",
 			Range: loc.Range{Loc: n.Attr[0].KeyLoc, Len: len(n.Attr[0].Key)},
 		})
 

--- a/packages/compiler/test/client-directive/warn.ts
+++ b/packages/compiler/test/client-directive/warn.ts
@@ -11,9 +11,9 @@ test.before(async () => {
   result = await transform(FIXTURE);
 });
 
-test('logs a warning for using a client directive', () => {
+test('reports a warning for using a client directive', () => {
   assert.ok(Array.isArray(result.diagnostics));
-  assert.is(result.diagnostics.length, 1);
+  assert.is(result.diagnostics.length, 2);
   assert.equal(result.diagnostics[0].severity, 2);
   assert.match(result.diagnostics[0].text, 'does not need the client:load directive');
 });

--- a/packages/compiler/test/scripts/isinline-hint.ts
+++ b/packages/compiler/test/scripts/isinline-hint.ts
@@ -1,0 +1,19 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+
+const FIXTURE = `
+<script type="module"></script>
+`;
+
+let result;
+test.before(async () => {
+  result = await transform(FIXTURE);
+});
+
+test('reports a hint for adding attributes to a script tag without is:inline', () => {
+  assert.equal(result.diagnostics[0].severity, 4);
+  assert.match(result.diagnostics[0].text, /Astro processes your script tags to allow using TypeScript and NPM packages/);
+});
+
+test.run();

--- a/packages/compiler/test/scripts/isinline-hint.ts
+++ b/packages/compiler/test/scripts/isinline-hint.ts
@@ -12,8 +12,9 @@ test.before(async () => {
 });
 
 test('reports a hint for adding attributes to a script tag without is:inline', () => {
+  console.log(result.diagnostics[0])
   assert.equal(result.diagnostics[0].severity, 4);
-  assert.match(result.diagnostics[0].text, /Astro processes your script tags to allow using TypeScript and NPM packages/);
+  assert.match(result.diagnostics[0].text, /Astro processes your script tags to allow using TypeScript and npm packages/);
 });
 
 test.run();

--- a/packages/compiler/test/scripts/isinline-hint.ts
+++ b/packages/compiler/test/scripts/isinline-hint.ts
@@ -2,19 +2,16 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { transform } from '@astrojs/compiler';
 
-const FIXTURE = `
-<script type="module"></script>
-`;
-
-let result;
-test.before(async () => {
-  result = await transform(FIXTURE);
-});
-
-test('reports a hint for adding attributes to a script tag without is:inline', () => {
-  console.log(result.diagnostics[0])
+test('reports a hint for adding attributes to a script tag without is:inline', async () => {
+  const result = await transform(`<script type="module"></script>`);
   assert.equal(result.diagnostics[0].severity, 4);
   assert.match(result.diagnostics[0].text, /Astro processes your script tags to allow using TypeScript and npm packages/);
+});
+
+test('does not report a diagnostic for the src attribute', async () => {
+  const result = await transform(`<script src="/external.js"></script>`);
+  console.log(result.diagnostics)
+  assert.equal(result.diagnostics.length, 0);
 });
 
 test.run();

--- a/packages/compiler/test/scripts/isinline-hint.ts
+++ b/packages/compiler/test/scripts/isinline-hint.ts
@@ -5,7 +5,7 @@ import { transform } from '@astrojs/compiler';
 test('reports a hint for adding attributes to a script tag without is:inline', async () => {
   const result = await transform(`<script type="module"></script>`);
   assert.equal(result.diagnostics[0].severity, 4);
-  assert.match(result.diagnostics[0].text, /Astro processes your script tags to allow using TypeScript and npm packages/);
+  assert.match(result.diagnostics[0].text, /\#script-processing/);
 });
 
 test('does not report a diagnostic for the src attribute', async () => {


### PR DESCRIPTION
## Changes

- https://github.com/withastro/roadmap/blob/main/proposals/0016-style-script-defaults.md?plain=1#L74

## Testing
Added `scripts/isinline-hint.ts`.

## Docs
Would like docs review on the message.