### PR TITLE
Updates deprecated Node.js 16 github actions

### DIFF
--- a/.changeset/modern-flies-watch.md
+++ b/.changeset/modern-flies-watch.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Updates deprecated Node.js 16 github actions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           go-version: 1.19
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v2
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v2
         with:
           node-version: 16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.19
 
@@ -33,10 +33,10 @@ jobs:
         OS: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.OS }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.19
 
@@ -44,7 +44,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'pnpm'
@@ -67,7 +67,7 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -77,9 +77,9 @@ jobs:
     timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.19
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Changelog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: 1.19
 
@@ -23,7 +23,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'pnpm'

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ steps.refs.outputs.head_ref }}
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Extract the snapshot name from comment body
         id: getSnapshotName
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const splitComment = context.payload.comment.body.split(' ');
@@ -83,7 +83,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Pull Request Notification
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           MESSAGE: ${{ steps.publish.outputs.result }}
         with:

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check if user has admin access (only admins can publish snapshot releases).'
-        uses: 'lannonbr/repo-permission-check-action@2.0.0'
+        uses: 'lannonbr/repo-permission-check-action@2.0.2'
         with:
           permission: 'admin'
         env:
@@ -43,7 +43,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ steps.refs.outputs.head_ref }}
 
@@ -51,7 +51,7 @@ jobs:
         uses: pnpm/action-setup@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Changes

The plan is to update all action that log deprecation warnings starting with pnpm/action-setup.
I will keep this PR open as long as I try to cover the most common workflows.

- Updated actions/setup-go@v2 to v5
- Updated actions/checkout@v2/v3 to V4
- Updated pnpm/action-setup@v2 to v3
- Update actions/setup-node@v2 to v4
- Update golangci/golangci-lint-action@v2 to v4
- Update actions/github-script@v6 to v7

> - No new version for lannonbr/repo-permission-check-action@2.0.0
> - No new version for eficode/resolve-pr-refs@main

Not addressed in this PR:
- The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. 


## Testing

scan github warnings, update versions, trigger github actions, repeat

## Docs

n.a.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
