### PR TITLE
Implement transition:persist-props

### DIFF
--- a/.changeset/real-otters-mix.md
+++ b/.changeset/real-otters-mix.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Implement the `transition:persist-props` transformation

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -514,6 +514,12 @@ func maybeConvertTransition(n *astro.Node) {
 				Type: astro.ExpressionAttribute,
 			})
 		}
+
+		// Do a simple rename for `transition:persist-props`
+		transitionPersistPropsIndex := transform.AttrIndex(n, transform.TRANSITION_PERSIST_PROPS)
+		if transitionPersistPropsIndex != -1 {
+			n.Attr[transitionPersistPropsIndex].Key = "data-astro-transition-persist-props"
+		}
 	}
 }
 

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3491,6 +3491,14 @@ const items = ["Dog", "Cat", "Platipus"];
 			},
 		},
 		{
+			name:        "transition:persist-props converted to a data attribute",
+			source:      `<my-island transition:persist transition:persist-props="false"></my-island>`,
+			transitions: true,
+			want: want{
+				code: `${$$renderComponent($$result,'my-island','my-island',{"data-astro-transition-persist-props":"false","data-astro-transition-persist":($$createTransitionScope($$result, "otghnj5u"))})}`,
+			},
+		},
+		{
 			name:   "trailing expression",
 			source: `<Component />{}`,
 			want: want{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -16,6 +16,7 @@ import (
 const TRANSITION_ANIMATE = "transition:animate"
 const TRANSITION_NAME = "transition:name"
 const TRANSITION_PERSIST = "transition:persist"
+const TRANSITION_PERSIST_PROPS = "transition:persist-props"
 
 type TransformOptions struct {
 	Scope                   string


### PR DESCRIPTION
## Changes

- Implements `transition:persist-props` as explained in https://github.com/withastro/astro/pull/10136
- This is a simple transformation to `data-astro-transition-persist-props` with the same value.
  - Very similar to how `transition:persist` works.
- This means for dynamic use-cases users can use the `data-` attribute instead.

## Testing

- New test case added

## Docs

- https://github.com/withastro/docs/pull/6915