### PR TITLE
chore: use better maintained permission checker action 

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check if user has admin access (only admins can publish snapshot releases).
         id: checkAccess
-        uses: actions-cool/check-user-permission@v2.2.1
+        uses: actions-cool/check-user-permission@v2
         with:
           require: admin
           username: ${{ github.triggering_actor }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -15,12 +15,21 @@ jobs:
     if: ${{ github.repository_owner == 'withastro' && github.event.issue.pull_request && startsWith(github.event.comment.body, '!preview') }}
     runs-on: ubuntu-latest
     steps:
-      - name: 'Check if user has admin access (only admins can publish snapshot releases).'
-        uses: 'lannonbr/repo-permission-check-action@2.0.2'
+      - name: Check if user has admin access (only admins can publish snapshot releases).
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2.2.1
         with:
-          permission: 'admin'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          require: admin
+          username: ${{ github.triggering_actor }}
+
+      # if the user does not have the required permission, we should return exit code 1 to stop the workflow
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 0
 
       - name: Extract the snapshot name from comment body
         id: getSnapshotName

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -23,7 +23,7 @@ jobs:
           username: ${{ github.triggering_actor }}
 
       # if the user does not have the required permission, we should return exit code 1 to stop the workflow
-      - name: Check User Permission
+      - name: Check user permission
         if: steps.checkAccess.outputs.require-result == 'false'
         run: |
           echo "${{ github.triggering_actor }} does not have permissions on this repo."


### PR DESCRIPTION
## Changes

Drop `lannonbr/repo-permission-check-action` for [`actions-cool/check-user-permission`](https://github.com/actions-cool/maintain-one-comment)
The earlier wasn't working anymore [after we updated it](https://github.com/withastro/compiler/pull/972/files#diff-9dc5e53b8fc4bd9d74ca8c2d8d9d5bf7f94c6a8ccc49f2bcc142ec5c171686d1R19).
[Martin opened an issue](https://github.com/actions-cool/maintain-one-comment) on that repo to suggest updating to Node 20 (to remove the deprecation warnings) but I'm not sure it's gonna move forward as the repo looks abandoned.

I checked, and the main repo doesn't currently use the bugged version of the action, but to get rid of the warnings, we shall make the switch to the better maintained one.

## Testing

Not tested but the usage looked straightforward after looking at the docs and how other repos use it

## Docs

N/A just a chore, doesn't touch the code