### PR TITLE
chore: fix exit code for failed permission check

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -29,7 +29,7 @@ jobs:
           echo "${{ github.triggering_actor }} does not have permissions on this repo."
           echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
           echo "Job originally triggered by ${{ github.actor }}"
-          exit 0
+          exit 1
 
       - name: Extract the snapshot name from comment body
         id: getSnapshotName


### PR DESCRIPTION
## Changes

The snapshot workflow in https://github.com/withastro/compiler/pull/977 returned `0` instead of `1`, causing the workflow to not fail for non-admins.

## Testing

Not tested but the only issue was the wrong exit code which wouldn't stop the workflow

## Docs

N/A doesn't affect users
