### PR TITLE
Fix issue with head content pushed into body

### DIFF
--- a/.changeset/khaki-schools-reflect.md
+++ b/.changeset/khaki-schools-reflect.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix issue with head content being pushed into body

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -392,6 +392,7 @@ func (p *parser) addExpression() {
 		HandledScript: false,
 		Loc:           p.generateLoc(),
 	})
+
 }
 
 func isFragment(data string) bool {
@@ -942,6 +943,7 @@ func inHeadIM(p *parser) bool {
 	case StartExpressionToken:
 		p.addExpression()
 		p.afe = append(p.afe, &scopeMarker)
+		p.templateStack = append(p.templateStack, inExpressionIM)
 		if p.originalIM == nil {
 			p.setOriginalIM()
 		}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3505,6 +3505,31 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `${$$renderComponent($$result,'Component',Component,{})}${(void 0)}`,
 			},
 		},
+		{
+			name: "nested head content stays in the head",
+			source: `---
+const meta = { title: 'My App' };
+---
+
+<html>
+	<head>
+		<meta charset="utf-8" />
+
+		{
+			meta && <title>{meta.title}</title>
+		}
+
+		<meta name="after">
+	</head>
+	<body>
+		<h1>My App</h1>
+	</body>
+</html>`,
+			want: want{
+				frontmatter: []string{"", `const meta = { title: 'My App' };`},
+				code:        `<html>	<head>		<meta charset="utf-8">		${			meta && $$render` + BACKTICK + `<title>${meta.title}</title>` + BACKTICK + `		}		<meta name="after">	${$$renderHead($$result)}</head>	<body>		<h1>My App</h1>	</body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -3535,6 +3560,7 @@ const items = ["Dog", "Cat", "Platipus"];
 				RenderScript: tt.transformOptions.RenderScript,
 			}
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
+
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{
 				Scope:                   "XXXX",
 				InternalURL:             "http://localhost:3000/",

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -551,6 +551,7 @@ import type data from "test"
 		}
 	</main>
 </Layout>`,
+
 			want: want{
 				code: `${$$renderComponent($$result,'Layout',Layout,{"title":"Welcome to Astro."},{"default": () => $$render` + BACKTICK + `
 	${$$maybeRenderHead($$result)}<main>
@@ -569,8 +570,8 @@ import type data from "test"
 					</div>
 					<p>
 						</p><h2>p+h2 ${dummyKey}</h2>
-					` + BACKTICK + `	
-			);
+					` + BACKTICK + `
+				);
 			})
 		}
 	</main>


### PR DESCRIPTION
## Changes

- Since `resetInsertionMode` is used when expressions are ended there needs to be something on the `templateStack` for nested expressions. 
- There should be an `inExpressionIM` in the `templateStack`.
- Fixes https://github.com/withastro/compiler/issues/985
- Fixes https://github.com/withastro/compiler/issues/935

## Testing

- New printer test

## Docs

N/A, bug fix