### PR TITLE
Adjust handling of incomplete tags

### DIFF
--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -3803,6 +3803,16 @@ const c = '\''
 			source: `<main id=` + BACKTICK + `gotcha />`,
 			want:   []ASTNode{{Type: "element", Name: "main", Attributes: []ASTNode{{Type: "attribute", Kind: "template-literal", Name: "id", Value: "gotcha", Raw: "`gotcha"}}}},
 		},
+		{
+			name:   "text with <",
+			source: `<span>n <value </span>`,
+			want:   []ASTNode{{Type: "element", Name: "span", Children: []ASTNode{{Type: "text", Value: "n <value "}}}},
+		},
+		{
+			name:   "unclosed element",
+			source: "<div class=\"name\"\n<h1 />",
+			want:   []ASTNode{{Type: "element", Name: "div", Attributes: []ASTNode{{Type: "attribute", Kind: "quoted", Name: "class", Value: "name", Raw: `"name"`}}, Children: []ASTNode{{Type: "element", Name: "h1"}}}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -500,6 +500,21 @@ func TestBasic(t *testing.T) {
 			`<div></div><MyAstroComponent` + "\n",
 			[]TokenType{StartTagToken, EndTagToken, TextToken},
 		},
+		{
+			"incomplete tag IV",
+			`<span>n < value</span>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"incomplete tag V",
+			`<span>n<value</span>`,
+			[]TokenType{StartTagToken, TextToken, EndTagToken},
+		},
+		{
+			"incomplete tag V",
+			"<div class=\"name\"\n<h1 />",
+			[]TokenType{StartTagToken, TextToken, SelfClosingTagToken},
+		},
 	}
 
 	runTokenTypeTest(t, Basic)


### PR DESCRIPTION
## Changes

- Still a WIP!
- Fixes #862
- The goal is to introduce a new heuristic for tokenization that allows incomplete tags to be preserved in the TSX output

## Testing

- [x] New tests added
- [ ] New tests passing
- [ ] Comprehensive regression tests

## Docs

This will be a bug fix