### PR TITLE
chore: upgrade to go 1.22

### DIFF
--- a/.changeset/tender-rockets-agree.md
+++ b/.changeset/tender-rockets-agree.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+The WASM binaries for the compiler are now built using Go 1.22.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Test
         run: go test -v -timeout 30s ./internal/...
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Set up PNPM
         uses: pnpm/action-setup@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
     branches: ['main', 'next']
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Set up PNPM
         uses: pnpm/action-setup@v3

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome to the Go compiler!
 
 ### Go
 
-[Go][go] `1.19.x` is needed to work with this repo. On Macs, installing via [Homebrew][homebrew] is recommended: `brew install go`. For Windows & Linux, you can [follow Go’s installation guide][go] if you don’t have your own preferred method of package installation.
+[Go][go] `1.20+` is needed to work with this repo. On Macs, installing via [Homebrew][homebrew] is recommended: `brew install go`. For Windows & Linux, you can [follow Go’s installation guide][go] if you don’t have your own preferred method of package installation.
 
 If you use VS Code as your primary editor, installing the [Go extension][go-vscode] is highly recommended.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/withastro/compiler
 
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.5.9

--- a/packages/compiler/src/browser/wasm_exec.ts
+++ b/packages/compiler/src/browser/wasm_exec.ts
@@ -269,7 +269,7 @@ export default class Go {
 
     const timeOrigin = Date.now() - performance.now();
     this.importObject = {
-      go: {
+      gojs: {
         // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
         // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
         // function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).

--- a/packages/compiler/src/node/wasm_exec.ts
+++ b/packages/compiler/src/node/wasm_exec.ts
@@ -165,7 +165,7 @@ export default class Go {
 
     const timeOrigin = Date.now() - performance.now();
     this.importObject = {
-      go: {
+      gojs: {
         // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
         // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
         // function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).


### PR DESCRIPTION
## Changes
- Updates the entrypoint to reflect renaming of the imports object in 1.20.

## Testing
- Existing tests should pass.

## Docs
- Does not affect usage.