### PR TITLE
Skip printing `createAstro` code if unused

### DIFF
--- a/.changeset/khaki-ways-wait.md
+++ b/.changeset/khaki-ways-wait.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Skips printing `createAstro` code if the `Astro` global is not referenced

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -148,6 +148,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		return
 	}
 
+	// Decide whether to print code for `Astro` global variable. Use a loose check for now.
+	printAstroGlobal := strings.Contains(p.sourcetext, "Astro")
+
 	// Render frontmatter (will be the first node, if it exists)
 	if n.Type == FrontmatterNode {
 		if n.FirstChild == nil {
@@ -179,9 +182,11 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				// 1. Component imports, if any exist.
 				p.addNilSourceMapping()
 				p.printComponentMetadata(n.Parent, opts.opts, []byte(p.sourcetext))
-				// 2. Top-level Astro global.
 
-				p.printTopLevelAstro(opts.opts)
+				// 2. Top-level Astro global.
+				if printAstroGlobal {
+					p.printTopLevelAstro(opts.opts)
+				}
 
 				exports := make([][]byte, 0)
 				exportLocs := make([]loc.Loc, 0)
@@ -228,7 +233,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 				}
 
-				p.printFuncPrelude(opts.opts)
+				p.printFuncPrelude(opts.opts, printAstroGlobal)
 				// PRINT BODY
 				if len(bodies) > 0 {
 					for i, body := range bodies {
@@ -267,10 +272,12 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		return
 	} else if !p.hasFuncPrelude {
 		p.printComponentMetadata(n.Parent, opts.opts, []byte{})
-		p.printTopLevelAstro(opts.opts)
+		if printAstroGlobal {
+			p.printTopLevelAstro(opts.opts)
+		}
 
 		// Render func prelude. Will only run for the first non-frontmatter node
-		p.printFuncPrelude(opts.opts)
+		p.printFuncPrelude(opts.opts, printAstroGlobal)
 		// This just ensures a newline
 		p.println("")
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -264,17 +264,19 @@ func (p *printer) printDefineVarsClose(n *astro.Node) {
 	}
 }
 
-func (p *printer) printFuncPrelude(opts transform.TransformOptions) {
+func (p *printer) printFuncPrelude(opts transform.TransformOptions, printAstroGlobal bool) {
 	if p.hasFuncPrelude {
 		return
 	}
 	componentName := getComponentName(opts.Filename)
 	p.addNilSourceMapping()
 	p.println(fmt.Sprintf("const %s = %s(async (%s, $$props, %s) => {", componentName, CREATE_COMPONENT, RESULT, SLOTS))
-	p.addNilSourceMapping()
-	p.println(fmt.Sprintf("const Astro = %s.createAstro($$Astro, $$props, %s);", RESULT, SLOTS))
-	p.addNilSourceMapping()
-	p.println(fmt.Sprintf("Astro.self = %s;", componentName))
+	if printAstroGlobal {
+		p.addNilSourceMapping()
+		p.println(fmt.Sprintf("const Astro = %s.createAstro($$Astro, $$props, %s);", RESULT, SLOTS))
+		p.addNilSourceMapping()
+		p.println(fmt.Sprintf("Astro.self = %s;", componentName))
+	}
 	p.hasFuncPrelude = true
 }
 


### PR DESCRIPTION
## Changes

Idea from https://github.com/withastro/astro/pull/10773#pullrequestreview-2005386326

If the `Astro` global is not used, we don't need to print code that calls `createAstro`. This saves on runtime execution as it's created but not used.

---

Perf:

- `createAstro()` calls dropped from 571ms o 551ms. -0.02s (not a lot, but it helps other cases instead like garbage collection and AST parsing)
- `garbage collection` dropped from  59.52s to 40.88s. -18.7s

## Testing

Updated tests to handle cases where the `createAstro` code is no longer present.

## Docs

n/a. internal improvement.