### PR TITLE
Skip printing async if await is not used

### DIFF
--- a/.changeset/warm-zebras-rest.md
+++ b/.changeset/warm-zebras-rest.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Skips printing `async` for component functions if `await` is not used

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -269,8 +269,15 @@ func (p *printer) printFuncPrelude(opts transform.TransformOptions, printAstroGl
 		return
 	}
 	componentName := getComponentName(opts.Filename)
+
+	// Decide whether to print `async` if top-level await is used. Use a loose check for now.
+	funcPrefix := ""
+	if strings.Contains(p.sourcetext, "await") {
+		funcPrefix = "async "
+	}
+
 	p.addNilSourceMapping()
-	p.println(fmt.Sprintf("const %s = %s(async (%s, $$props, %s) => {", componentName, CREATE_COMPONENT, RESULT, SLOTS))
+	p.println(fmt.Sprintf("const %s = %s(%s(%s, $$props, %s) => {", componentName, CREATE_COMPONENT, funcPrefix, RESULT, SLOTS))
 	if printAstroGlobal {
 		p.addNilSourceMapping()
 		p.println(fmt.Sprintf("const Astro = %s.createAstro($$Astro, $$props, %s);", RESULT, SLOTS))

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -35,7 +35,8 @@ var INTERNAL_IMPORTS = fmt.Sprintf("import {\n  %s\n} from \"%s\";\n", strings.J
 	"renderScript as " + RENDER_SCRIPT,
 	"createMetadata as " + CREATE_METADATA,
 }, ",\n  "), "http://localhost:3000/")
-var PRELUDE = fmt.Sprintf(`const $$Component = %s(async ($$result, $$props, %s) => {`, CREATE_COMPONENT, SLOTS)
+var PRELUDE = fmt.Sprintf(`const $$Component = %s(($$result, $$props, %s) => {`, CREATE_COMPONENT, SLOTS)
+var PRELUDE_WITH_ASYNC = fmt.Sprintf(`const $$Component = %s(async ($$result, $$props, %s) => {`, CREATE_COMPONENT, SLOTS)
 var PRELUDE_ASTRO_GLOBAL = fmt.Sprintf(`const Astro = $$result.createAstro($$Astro, $$props, %s);
 Astro.self = $$Component;`, SLOTS)
 var RETURN = fmt.Sprintf("return %s%s", TEMPLATE_TAG, BACKTICK)
@@ -3662,11 +3663,15 @@ const meta = { title: 'My App' };
 			if len(tt.want.getStaticPaths) > 0 {
 				toMatch += strings.TrimSpace(test_utils.Dedent(tt.want.getStaticPaths)) + "\n\n"
 			}
-			if printAstroGlobal {
-				toMatch += test_utils.Dedent(PRELUDE) + test_utils.Dedent(PRELUDE_ASTRO_GLOBAL) + "\n"
+			if strings.Contains(tt.source, "await") {
+				toMatch += test_utils.Dedent(PRELUDE_WITH_ASYNC)
 			} else {
-				toMatch += test_utils.Dedent(PRELUDE) + "\n"
+				toMatch += test_utils.Dedent(PRELUDE)
 			}
+			if printAstroGlobal {
+				toMatch += test_utils.Dedent(PRELUDE_ASTRO_GLOBAL)
+			}
+			toMatch += "\n"
 			if len(tt.want.frontmatter) > 1 {
 				toMatch += strings.TrimSpace(test_utils.Dedent(tt.want.frontmatter[1]))
 			}


### PR DESCRIPTION
## Changes

Idea by @natemoo-re. Currently we always print the component function with async even if no top-level await is used:

```js
const $$stdin = $$createComponent(async ($$result, $$props, $$slots) => {
```

We can skip printing the `async` if no `await` is used so that rendering the component won't always require one tick.

---

Performance:

This should improve page rendering. With the Astro docs repo, it fluctuates between 35-42s a lot, so it's hard to make a concrete comparison. But compared to the old timings, the average timing dropped about 1-2s.

## Testing

Updated test

## Docs

n/a. internal improvement.