### PR TITLE
Add server island metadata

### DIFF
--- a/.changeset/nine-ants-bow.md
+++ b/.changeset/nine-ants-bow.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Add localName to serverComponents output

--- a/.changeset/nine-ants-bow.md
+++ b/.changeset/nine-ants-bow.md
@@ -1,5 +1,0 @@
----
-'@astrojs/compiler': patch
----
-
-Add localName to serverComponents output

--- a/.changeset/yellow-cooks-deliver.md
+++ b/.changeset/yellow-cooks-deliver.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': minor
+---
+
+Add server island metadata

--- a/.changeset/yellow-cooks-deliver.md
+++ b/.changeset/yellow-cooks-deliver.md
@@ -2,4 +2,6 @@
 '@astrojs/compiler': minor
 ---
 
-Add server island metadata
+Adds `serverComponents` metadata
+
+This adds a change necessary to support server islands. During transformation the compiler discovers `server:defer` directives and appends them to the `serverComponents` array. This is exported along with the other metadata so that it can be used inside of Astro.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -183,6 +183,7 @@ type HoistedScript struct {
 
 type HydratedComponent struct {
 	ExportName   string `js:"exportName"`
+	LocalName    string `js:"localName"`
 	Specifier    string `js:"specifier"`
 	ResolvedPath string `js:"resolvedPath"`
 }
@@ -443,6 +444,7 @@ func Transform() any {
 				for _, c := range doc.ServerComponents {
 					serverComponents = append(serverComponents, HydratedComponent{
 						ExportName:   c.ExportName,
+						LocalName:    c.LocalName,
 						Specifier:    c.Specifier,
 						ResolvedPath: c.ResolvedPath,
 					})

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -359,6 +359,7 @@ func Transform() any {
 				scripts := []HoistedScript{}
 				hydratedComponents := []HydratedComponent{}
 				clientOnlyComponents := []HydratedComponent{}
+				serverComponents := []HydratedComponent{}
 				css_result := printer.PrintCSS(source, doc, transformOptions)
 				for _, bytes := range css_result.Output {
 					css = append(css, string(bytes))
@@ -439,6 +440,14 @@ func Transform() any {
 					})
 				}
 
+				for _, c := range doc.ServerComponents {
+					serverComponents = append(serverComponents, HydratedComponent{
+						ExportName:   c.ExportName,
+						Specifier:    c.Specifier,
+						ResolvedPath: c.ResolvedPath,
+					})
+				}
+
 				var value vert.Value
 				result := printer.PrintToJS(source, doc, len(css), transformOptions, h)
 				transformResult := &TransformResult{
@@ -447,6 +456,7 @@ func Transform() any {
 					Scripts:              scripts,
 					HydratedComponents:   hydratedComponents,
 					ClientOnlyComponents: clientOnlyComponents,
+					ServerComponents:     serverComponents,
 					ContainsHead:         doc.ContainsHead,
 					StyleError:           styleError,
 					Propagation:          doc.HeadPropagation,

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -208,6 +208,7 @@ type TransformResult struct {
 	Scripts              []HoistedScript         `js:"scripts"`
 	HydratedComponents   []HydratedComponent     `js:"hydratedComponents"`
 	ClientOnlyComponents []HydratedComponent     `js:"clientOnlyComponents"`
+	ServerComponents     []HydratedComponent     `js:"serverComponents"`
 	ContainsHead         bool                    `js:"containsHead"`
 	StyleError           []string                `js:"styleError"`
 	Propagation          bool                    `js:"propagation"`

--- a/internal/node.go
+++ b/internal/node.go
@@ -65,6 +65,7 @@ var scopeMarker = Node{Type: scopeMarkerNode}
 
 type HydratedComponentMetadata struct {
 	ExportName   string
+	LocalName    string
 	Specifier    string
 	ResolvedPath string
 }

--- a/internal/node.go
+++ b/internal/node.go
@@ -98,6 +98,7 @@ type Node struct {
 	ClientOnlyComponentNodes []*Node
 	ClientOnlyComponents     []*HydratedComponentMetadata
 	HydrationDirectives      map[string]bool
+	ServerComponents         []*HydratedComponentMetadata
 	ContainsHead             bool
 	HeadPropagation          bool
 

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -535,7 +535,7 @@ func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 
 				match := matchNodeToImportStatement(doc, n)
 				if match != nil {
-					doc.HydratedComponents = append(doc.HydratedComponents, &astro.HydratedComponentMetadata{
+					doc.ServerComponents = append(doc.ServerComponents, &astro.HydratedComponentMetadata{
 						ExportName:   match.ExportName,
 						Specifier:    match.Specifier,
 						ResolvedPath: ResolveIdForMatch(match.Specifier, opts),

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -523,6 +523,38 @@ func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 				}
 
 				break
+			} else if strings.HasPrefix(attr.Key, "server:") {
+				parts := strings.Split(attr.Key, ":")
+				directive := parts[1]
+
+				hydrationAttr := astro.Attribute{
+					Key: "server:component-directive",
+					Val: directive,
+				}
+				n.Attr = append(n.Attr, hydrationAttr)
+
+				match := matchNodeToImportStatement(doc, n)
+				if match != nil {
+					doc.HydratedComponents = append(doc.HydratedComponents, &astro.HydratedComponentMetadata{
+						ExportName:   match.ExportName,
+						Specifier:    match.Specifier,
+						ResolvedPath: ResolveIdForMatch(match.Specifier, opts),
+					})
+
+					pathAttr := astro.Attribute{
+						Key:  "server:component-path",
+						Val:  fmt.Sprintf(`"%s"`, ResolveIdForMatch(match.Specifier, opts)),
+						Type: astro.ExpressionAttribute,
+					}
+					n.Attr = append(n.Attr, pathAttr)
+
+					exportAttr := astro.Attribute{
+						Key:  "server:component-export",
+						Val:  fmt.Sprintf(`"%s"`, match.ExportName),
+						Type: astro.ExpressionAttribute,
+					}
+					n.Attr = append(n.Attr, exportAttr)
+				}
 			}
 		}
 	}

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -537,6 +537,7 @@ func AddComponentProps(doc *astro.Node, n *astro.Node, opts *TransformOptions) {
 				if match != nil {
 					doc.ServerComponents = append(doc.ServerComponents, &astro.HydratedComponentMetadata{
 						ExportName:   match.ExportName,
+						LocalName:    n.Data,
 						Specifier:    match.Specifier,
 						ResolvedPath: ResolveIdForMatch(match.Specifier, opts),
 					})

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -95,6 +95,7 @@ export type HoistedScript = { type: string } & (
 
 export interface HydratedComponent {
 	exportName: string;
+	localName: string;
 	specifier: string;
 	resolvedPath: string;
 }

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -109,6 +109,7 @@ export interface TransformResult {
 	scripts: HoistedScript[];
 	hydratedComponents: HydratedComponent[];
 	clientOnlyComponents: HydratedComponent[];
+	serverComponents: HydratedComponent[];
 	containsHead: boolean;
 	propagation: boolean;
 }

--- a/packages/compiler/test/server-islands/meta.ts
+++ b/packages/compiler/test/server-islands/meta.ts
@@ -15,31 +15,31 @@ import {Other} from './Other.astro';
 
 let result: Awaited<ReturnType<typeof transform>>;
 test.before(async () => {
-  result = await transform(FIXTURE, {
-    resolvePath: async (s: string) => {
-      const out = new URL(s, import.meta.url);
-      return fileURLToPath(out);
-    },
-  });
+	result = await transform(FIXTURE, {
+		resolvePath: async (s: string) => {
+			const out = new URL(s, import.meta.url);
+			return fileURLToPath(out);
+		},
+	});
 });
 
 test('component metadata added', () => {
-  assert.equal(result.serverComponents.length, 2);
+	assert.equal(result.serverComponents.length, 2);
 });
 
 test('path resolved to the filename', () => {
-  const m = result.serverComponents[0];
-  assert.ok(m.specifier !== m.resolvedPath);
+	const m = result.serverComponents[0];
+	assert.ok(m.specifier !== m.resolvedPath);
 });
 
 test('localName is the name used in the template', () => {
-  assert.equal(result.serverComponents[0].localName, 'Avatar');
-  assert.equal(result.serverComponents[1].localName, 'Other');
+	assert.equal(result.serverComponents[0].localName, 'Avatar');
+	assert.equal(result.serverComponents[1].localName, 'Other');
 });
 
 test('exportName is the export name of the imported module', () => {
-  assert.equal(result.serverComponents[0].exportName, 'default');
-  assert.equal(result.serverComponents[1].exportName, 'Other');
+	assert.equal(result.serverComponents[0].exportName, 'default');
+	assert.equal(result.serverComponents[1].exportName, 'Other');
 });
 
 test.run();

--- a/packages/compiler/test/server-islands/meta.ts
+++ b/packages/compiler/test/server-islands/meta.ts
@@ -1,7 +1,7 @@
+import { fileURLToPath } from 'node:url';
+import { transform } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { transform } from '@astrojs/compiler';
-import { fileURLToPath } from 'node:url';
 
 const FIXTURE = `
 ---
@@ -17,9 +17,9 @@ let result: Awaited<ReturnType<typeof transform>>;
 test.before(async () => {
   result = await transform(FIXTURE, {
     resolvePath: async (s: string) => {
-      let out = new URL(s, import.meta.url);
+      const out = new URL(s, import.meta.url);
       return fileURLToPath(out);
-    }
+    },
   });
 });
 
@@ -28,7 +28,7 @@ test('component metadata added', () => {
 });
 
 test('path resolved to the filename', () => {
-  let m = result.serverComponents[0];
+  const m = result.serverComponents[0];
   assert.ok(m.specifier !== m.resolvedPath);
 });
 

--- a/packages/compiler/test/server-islands/meta.ts
+++ b/packages/compiler/test/server-islands/meta.ts
@@ -1,0 +1,45 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { transform } from '@astrojs/compiler';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE = `
+---
+import Avatar from './Avatar.astro';
+import {Other} from './Other.astro';
+---
+
+<Avatar server:defer />
+<Other server:defer />
+`;
+
+let result: Awaited<ReturnType<typeof transform>>;
+test.before(async () => {
+  result = await transform(FIXTURE, {
+    resolvePath: async (s: string) => {
+      let out = new URL(s, import.meta.url);
+      return fileURLToPath(out);
+    }
+  });
+});
+
+test('component metadata added', () => {
+  assert.equal(result.serverComponents.length, 2);
+});
+
+test('path resolved to the filename', () => {
+  let m = result.serverComponents[0];
+  assert.ok(m.specifier !== m.resolvedPath);
+});
+
+test('localName is the name used in the template', () => {
+  assert.equal(result.serverComponents[0].localName, 'Avatar');
+  assert.equal(result.serverComponents[1].localName, 'Other');
+});
+
+test('exportName is the export name of the imported module', () => {
+  assert.equal(result.serverComponents[0].exportName, 'default');
+  assert.equal(result.serverComponents[1].exportName, 'Other');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

- Discovers `server:defer` directive usage, then links that back to the import statement like what is done with `client:` islands. This information is exported as part of the compile result, on the `serverComponents` field, to be used by Astro.

## Testing

- Since the only visible change is to the metadata, this is tested by adding a wasm test, to verify that the information is included and is correct.

## Docs

N/A