### PR TITLE
Allow data-astro-reload to take a value

### DIFF
--- a/.changeset/light-ligers-rhyme.md
+++ b/.changeset/light-ligers-rhyme.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": patch
 ---
 
-Allow data-astro-reload to take a value
+Allow `data-astro-reload` to take a value

--- a/.changeset/light-ligers-rhyme.md
+++ b/.changeset/light-ligers-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Allow data-astro-reload to take a value

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -364,7 +364,6 @@ func WarnAboutMisplacedReload(n *astro.Node, h *handler.Handler) {
 		/*
 		 * When set on <a>, <form> or <area>,
 		 * the data-astro-reload attribute replaces view transitions between pages with a full page loads.
-		 * The data-astro-reload attribute is not supported for other elements. It does not accept a value.
 		 */
 
 		if n.Type != astro.ElementNode || n.Data != "a" && n.Data != "area" && n.Data != "form" {
@@ -373,14 +372,6 @@ func WarnAboutMisplacedReload(n *astro.Node, h *handler.Handler) {
 				Text:  "The data-astro-reload attribute is only supported on <a>, <form> and <area> elements.",
 				Range: loc.Range{Loc: attr.KeyLoc, Len: len(attr.Key)},
 			})
-		}
-		if attr.Val != "" {
-			h.AppendWarning(&loc.ErrorWithRange{
-				Code:  loc.WARNING_UNSUPPORTED_EXPRESSION,
-				Text:  "The data-astro-reload attribute does not accept a value",
-				Range: loc.Range{Loc: attr.ValLoc, Len: len(attr.Val)},
-			})
-			return
 		}
 	}
 }

--- a/packages/compiler/test/transition/data-astro.ts
+++ b/packages/compiler/test/transition/data-astro.ts
@@ -1,4 +1,4 @@
-import { transform } from '@astrojs/compiler';
+import { parse, transform } from '@astrojs/compiler';
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 
@@ -14,10 +14,9 @@ const FIXTURE = `
 
 test('Issues warnings for data-astro-* attributes', async () => {
   const result = await transform(FIXTURE);
-  assert.equal(result.diagnostics.length, 3);
+  assert.equal(result.diagnostics.length, 2);
   assert.equal(result.diagnostics[0].code, 2000);
-  assert.equal(result.diagnostics[1].code, 2005);
-  assert.equal(result.diagnostics[2].code, 2010);
+  assert.equal(result.diagnostics[1].code, 2010);
 });
 
 test.run();


### PR DESCRIPTION
## Changes

- Removes the diagnostic disallowing `data-astro-reload` from having a value.
- I don't know the context for why this was added, but it prevents people from making the property from being conditional, ala `data-astro-reload={false}`. As far as I know we don't care about the value on the front-end.
- https://github.com/withastro/compiler/issues/1006

## Testing

- Updated the existing tests around this

## Docs

N/A, bug fix