### PR TITLE
fix: escape / exclude scripts with unknown types

### DIFF
--- a/.changeset/tame-games-fold.md
+++ b/.changeset/tame-games-fold.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Escape script tags with unknown types

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -244,6 +244,7 @@ const (
 	Text
 	ScriptText
 	JsonScriptText
+	UnknownScriptText
 	StyleText
 )
 
@@ -254,9 +255,13 @@ func getTextType(n *astro.Node) TextType {
 			return ScriptText
 		}
 
-		if attr != nil && ScriptJSONMimeTypes[strings.ToLower(attr.Val)] {
+		// There's no difference between JSON and unknown script types in the result JSX at this time
+		// however, we might want to add some special handling in the future, so we keep them separate
+		if ScriptJSONMimeTypes[strings.ToLower(attr.Val)] {
 			return JsonScriptText
 		}
+
+		return UnknownScriptText
 	}
 	if style := n.Closest(isStyle); style != nil {
 		return StyleText
@@ -395,9 +400,9 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 				p.print("}}\n")
 			}
 			p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start + len(n.Data)})
-		} else if textType == StyleText || textType == JsonScriptText || textType == RawText {
+		} else if textType == StyleText || textType == JsonScriptText || textType == RawText || textType == UnknownScriptText {
 			p.addNilSourceMapping()
-			if (textType == StyleText && o.IncludeStyles) || textType == JsonScriptText || textType == RawText {
+			if (textType == StyleText && o.IncludeStyles) || ((textType == JsonScriptText || textType == RawText || textType == UnknownScriptText) && o.IncludeScripts) {
 				p.print("{`")
 				p.printTextWithSourcemap(escapeText(n.Data), n.Loc[0])
 				p.addNilSourceMapping()

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -402,7 +402,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 			p.addSourceMapping(loc.Loc{Start: n.Loc[0].Start + len(n.Data)})
 		} else if textType == StyleText || textType == JsonScriptText || textType == RawText || textType == UnknownScriptText {
 			p.addNilSourceMapping()
-			if (textType == StyleText && o.IncludeStyles) || ((textType == JsonScriptText || textType == RawText || textType == UnknownScriptText) && o.IncludeScripts) {
+			if (textType == StyleText && o.IncludeStyles) || ((textType == JsonScriptText || textType == UnknownScriptText) && o.IncludeScripts) || textType == RawText {
 				p.print("{`")
 				p.printTextWithSourcemap(escapeText(n.Data), n.Loc[0])
 				p.addNilSourceMapping()

--- a/packages/compiler/test/tsx/script.ts
+++ b/packages/compiler/test/tsx/script.ts
@@ -37,4 +37,33 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 	assert.snapshot(code, output, 'expected code to match snapshot');
 });
 
+test('escape unknown types', async () => {
+	const input = `<script type="text/somethigndf" is:inline>console.log("something");</script>`;
+	const output = `${TSXPrefix}<Fragment>
+<script type="text/somethigndf" is:inline>{\`console.log("something");\`}</script>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.snapshot(code, output, 'expected code to match snapshot');
+});
+
+test("don't include scripts if disabled", async () => {
+	const input = `
+<script>hello;</script>
+<script type="module">hello;</script>
+<script type="text/partytown">hello;</script>
+<script type="application/ld+json">hello;</script>
+<script type="text/somethigndf" is:inline>hello;</script>`;
+	const output = `${TSXPrefix}<Fragment>
+<script></script>
+<script type="module"></script>
+<script type="text/partytown"></script>
+<script type="application/ld+json"></script>
+<script type="text/somethigndf" is:inline></script>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external', includeScripts: false });
+	assert.snapshot(code, output, 'expected code to match snapshot');
+});
+
 test.run();


### PR DESCRIPTION
## Changes

Script tags with unknown content were not properly escaped / excluded (depending on the includeScripts setting), this fixes that

## Testing

Added more tests for this edge case

## Docs

N/A
