### PR TITLE
fix(tsx): Transform top level returns into throws

### DIFF
--- a/.changeset/bright-plums-suffer.md
+++ b/.changeset/bright-plums-suffer.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Transform top level returns into throws in the TSX output

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -376,7 +376,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 					for i < len(c.Data) {
 						if slices.Contains(topLevelReturn, i) {
 							newString = append(newString, []byte("throw ")...)
-							i += 6
+							i += len("return")
 						} else {
 							newString = append(newString, c.Data[i])
 							i++

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -361,11 +362,31 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 		p.addSourceMapping(loc.Loc{Start: 0})
 		frontmatterStart := len(p.output)
 		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			topLevelReturn := js_scanner.FindTopLevelReturns([]byte(c.Data))
 			if c.Type == TextNode {
 				if len(c.Loc) > 0 {
 					p.addSourceMapping(c.Loc[0])
 				}
-				p.printTextWithSourcemap(c.Data, c.Loc[0])
+				// Remplace all the top level returns with a `throw`
+				if topLevelReturn != nil {
+					// Loop over the characters and replace the top level returns with a `throw`
+					newString := ""
+
+					i := 0
+					for i < len(c.Data) {
+						if slices.Contains(topLevelReturn, i) {
+							newString += "throw "
+							i += 6
+						} else {
+							newString += string(c.Data[i])
+							i++
+						}
+					}
+
+					p.printTextWithSourcemap(newString, c.Loc[0])
+				} else {
+					p.printTextWithSourcemap(c.Data, c.Loc[0])
+				}
 			} else {
 				renderTsx(p, c, o)
 			}

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -368,22 +368,22 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 					p.addSourceMapping(c.Loc[0])
 				}
 				// Remplace all the top level returns with a `throw`
-				if topLevelReturn != nil {
+				if len(topLevelReturn) > 0 {
 					// Loop over the characters and replace the top level returns with a `throw`
-					newString := ""
+					newString := []byte{}
 
 					i := 0
 					for i < len(c.Data) {
 						if slices.Contains(topLevelReturn, i) {
-							newString += "throw "
+							newString = append(newString, []byte("throw ")...)
 							i += 6
 						} else {
-							newString += string(c.Data[i])
+							newString = append(newString, c.Data[i])
 							i++
 						}
 					}
 
-					p.printTextWithSourcemap(newString, c.Loc[0])
+					p.printTextWithSourcemap(string(newString), c.Loc[0])
 				} else {
 					p.printTextWithSourcemap(c.Data, c.Loc[0])
 				}

--- a/packages/compiler/test/tsx/top-level-returns.ts
+++ b/packages/compiler/test/tsx/top-level-returns.ts
@@ -1,0 +1,35 @@
+import { convertToTSX } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { TSXPrefix } from '../utils.js';
+
+test('transforms top-level returns to throw statements', async () => {
+	const input = `---
+if (something) {
+	return Astro.redirect();
+}
+
+function thatDoesSomething() {
+	return "Hey";
+}
+
+class Component {
+	render() {
+		return "wow"!
+	}
+}
+---`;
+	const output = `${TSXPrefix}
+if (something) {
+	throw  Astro.redirect();
+}
+
+function thatDoesSomething() {
+	return "Hey";
+}
+`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.snapshot(code, output, 'expected code to match snapshot');
+});
+
+test.run();

--- a/packages/compiler/test/tsx/top-level-returns.ts
+++ b/packages/compiler/test/tsx/top-level-returns.ts
@@ -27,6 +27,15 @@ if (something) {
 function thatDoesSomething() {
 	return "Hey";
 }
+
+class Component {
+	render() {
+		return "wow"!
+	}
+}
+
+
+export default function __AstroComponent_(_props: Record<string, any>): any {}
 `;
 	const { code } = await convertToTSX(input, { sourcemap: 'external' });
 	assert.snapshot(code, output, 'expected code to match snapshot');


### PR DESCRIPTION
## Changes

This PR makes it so top level returns are transformed into throws in the generated TSX

Fixes https://github.com/withastro/language-tools/issues/476

## Testing

Added a test

## Docs

N/A
