### PR TITLE
ci: add workflow to close issues without repro automatically

### DIFF
--- a/.github/workflows/issue-needs-repro.yml
+++ b/.github/workflows/issue-needs-repro.yml
@@ -1,0 +1,18 @@
+name: Close Issues (needs repro)
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    if: github.repository == 'withastro/compiler'
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs repro
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "close-issues"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "needs repro"
+          inactive-day: 3


### PR DESCRIPTION
## Changes

When this was setup on the main repo, this repo didn't get the workflow

## Testing

N/A

## Docs

N/A
