### PR TITLE
Adds detected language to extracted style tags in TSX

### DIFF
--- a/.changeset/angry-donuts-punch.md
+++ b/.changeset/angry-donuts-punch.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": minor
+---
+
+Adds detected language to extracted style tags in TSX

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -96,7 +96,7 @@ func (p *printer) addTSXScript(start int, end int, content string, scriptType st
 	})
 }
 
-func (p *printer) addTSXStyle(start int, end int, content string, styleType string) {
+func (p *printer) addTSXStyle(start int, end int, content string, styleType string, styleLang string) {
 	p.ranges.Styles = append(p.ranges.Styles, TSXExtractedTag{
 		Loc: loc.TSXRange{
 			Start: start,
@@ -104,6 +104,7 @@ func (p *printer) addTSXStyle(start int, end int, content string, styleType stri
 		},
 		Content: content,
 		Type:    styleType,
+		Lang:    styleLang,
 	})
 }
 

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -135,11 +135,22 @@ export interface TSXExtractedTag {
 }
 
 export interface TSXExtractedScript extends TSXExtractedTag {
-	type: 'processed-module' | 'module' | 'inline' | 'event-attribute' | 'json' | 'unknown';
+	type: 'processed-module' | 'module' | 'inline' | 'event-attribute' | 'json' | 'raw' | 'unknown';
 }
 
 export interface TSXExtractedStyle extends TSXExtractedTag {
 	type: 'tag' | 'style-attribute';
+	lang:
+		| 'css'
+		| 'scss'
+		| 'sass'
+		| 'less'
+		| 'stylus'
+		| 'styl'
+		| 'postcss'
+		| 'pcss'
+		| 'unknown'
+		| (string & {});
 }
 
 export interface TSXResult {

--- a/packages/compiler/test/tsx/meta.ts
+++ b/packages/compiler/test/tsx/meta.ts
@@ -39,7 +39,7 @@ test('return ranges - no frontmatter', async () => {
 });
 
 test('extract scripts', async () => {
-	const input = `<script type="module">console.log({ test: \`literal\` })</script><script type="text/partytown">console.log({ test: \`literal\` })</script><script type="application/ld+json">{"a":"b"}</script><script is:inline>console.log("hello")</script><div onload="console.log('hey')"></div>`;
+	const input = `<script type="module">console.log({ test: \`literal\` })</script><script type="text/partytown">console.log({ test: \`literal\` })</script><script type="application/ld+json">{"a":"b"}</script><script is:inline>console.log("hello")</script><div onload="console.log('hey')"></div><script>console.log({ test: \`literal\` })</script><script is:raw>something;</script>`;
 
 	const { metaRanges } = await convertToTSX(input, { sourcemap: 'external' });
 	assert.equal(
@@ -52,6 +52,7 @@ test('extract scripts', async () => {
 				},
 				type: 'module',
 				content: 'console.log({ test: `literal` })',
+				lang: '',
 			},
 			{
 				position: {
@@ -60,6 +61,7 @@ test('extract scripts', async () => {
 				},
 				type: 'inline',
 				content: 'console.log({ test: `literal` })',
+				lang: '',
 			},
 			{
 				position: {
@@ -68,6 +70,7 @@ test('extract scripts', async () => {
 				},
 				type: 'json',
 				content: '{"a":"b"}',
+				lang: '',
 			},
 			{
 				position: {
@@ -76,6 +79,7 @@ test('extract scripts', async () => {
 				},
 				type: 'inline',
 				content: 'console.log("hello")',
+				lang: '',
 			},
 			{
 				position: {
@@ -84,6 +88,25 @@ test('extract scripts', async () => {
 				},
 				type: 'event-attribute',
 				content: "console.log('hey')",
+				lang: '',
+			},
+			{
+				position: {
+					start: 281,
+					end: 346,
+				},
+				type: 'processed-module',
+				content: 'console.log({ test: `literal` })',
+				lang: '',
+			},
+			{
+				position: {
+					start: 337,
+					end: 358,
+				},
+				type: 'raw',
+				content: 'something;',
+				lang: '',
 			},
 		],
 		'expected metaRanges.scripts to match snapshot'
@@ -91,7 +114,7 @@ test('extract scripts', async () => {
 });
 
 test('extract styles', async () => {
-	const input = `<style>body { color: red; }</style><div style="color: blue;"></div>`;
+	const input = `<style>body { color: red; }</style><div style="color: blue;"></div><style lang="scss">body { color: red; }</style><style lang="pcss">body { color: red; }</style>`;
 
 	const { metaRanges } = await convertToTSX(input, { sourcemap: 'external' });
 	assert.equal(
@@ -104,6 +127,7 @@ test('extract styles', async () => {
 				},
 				type: 'tag',
 				content: 'body { color: red; }',
+				lang: 'css',
 			},
 			{
 				position: {
@@ -112,6 +136,25 @@ test('extract styles', async () => {
 				},
 				type: 'style-attribute',
 				content: 'color: blue;',
+				lang: 'css',
+			},
+			{
+				position: {
+					start: 86,
+					end: 127,
+				},
+				type: 'tag',
+				content: 'body { color: red; }',
+				lang: 'scss',
+			},
+			{
+				position: {
+					start: 133,
+					end: 174,
+				},
+				type: 'tag',
+				content: 'body { color: red; }',
+				lang: 'pcss',
 			},
 		],
 		'expected metaRanges.styles to match snapshot'


### PR DESCRIPTION
## Changes

A long time ago, our language tooling would provide helpful intellisense inside SCSS and LESS tags, this was lost without notice. A recent regression made me remember this, so this PR brings it back

Additionally, this PR changes the script tag extraction a bit to handle `is:raw` and other edge cases better.

## Testing

Added tests

## Docs

N/A
