### PR TITLE
fix(tsx): Extract positions based on utf-16 encoding

### DIFF
--- a/.changeset/selfish-dogs-love.md
+++ b/.changeset/selfish-dogs-love.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Adjust TSX output to return ranges using UTF-16 code units, as it would in JavaScript

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -574,14 +574,12 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 				p.print(`"`)
 				endLoc = a.ValLoc.Start
 			}
-			contentToValStart := p.sourcetext[:a.ValLoc.Start]
-			contentToValEnd := p.sourcetext[:endLoc]
 
 			if _, ok := htmlEvents[a.Key]; ok {
-				p.addTSXScript(getUTF16Length(contentToValStart), getUTF16Length(contentToValEnd), a.Val, "event-attribute")
+				p.addTSXScript(getUTF16Length(p.sourcetext[:a.ValLoc.Start]), getUTF16Length(p.sourcetext[:endLoc]), a.Val, "event-attribute")
 			}
 			if a.Key == "style" {
-				p.addTSXStyle(getUTF16Length(contentToValStart), getUTF16Length(contentToValEnd), a.Val, "style-attribute", "css")
+				p.addTSXStyle(getUTF16Length(p.sourcetext[:a.ValLoc.Start]), getUTF16Length(p.sourcetext[:endLoc]), a.Val, "style-attribute", "css")
 			}
 		case astro.EmptyAttribute:
 			p.print(a.Key)
@@ -766,7 +764,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 
 	if n.FirstChild != nil && (n.DataAtom == atom.Script || n.DataAtom == atom.Style) {
 		maxLength := endLoc
-		if endLoc > len(p.sourcetext) { // Sometimes, when tags are not closed properly and stuff, endLoc can be greater than the length of the source text, wonky stuff
+		if endLoc > len(p.sourcetext) { // Sometimes, when tags are not closed properly, endLoc can be greater than the length of the source text, wonky stuff
 			maxLength = len(p.sourcetext)
 		}
 		contentToContentEnd := p.sourcetext[:maxLength]

--- a/internal/printer/print-to-tsx_test.go
+++ b/internal/printer/print-to-tsx_test.go
@@ -9,126 +9,17 @@ import (
 	"github.com/withastro/compiler/internal/transform"
 )
 
+// One of the more performance-sensitive parts of the compiler is the handling of multibytes characters, this benchmark is an extreme case of that.
 func BenchmarkPrintToTSX(b *testing.B) {
-	source := `---
-import MobileMenu from "$components/layout/MobileMenu.astro";
-import MobileMenuSide from "$components/layout/MobileMenuSide.astro";
-import Header from "$components/layout/Header.astro";
-import Socials from "$components/layout/Socials.astro";
-import { getBaseSiteURL } from "$utils";
-import { Head } from "astro-capo";
-import "src/assets/style/prin.css";
-import type { MenuItem } from "../data/sidebarMenu";
-import Spritesheet from "$components/Spritesheet.astro";
-import GoBackUp from "$components/layout/GoBackUp.astro";
+	source := `🌘🔅🔘🍮🔭🔁💝🐄👋 🍘👽💽🌉🌒🔝 📇🍨💿🎷🎯💅📱🎭👞🎫💝🍢🕡 augue tincidunt 👠💋🌵💌🍌🏄🕂🍹📣🍟 🐞🍲👷🗻🏢🐫👣🐹🔷🎢👭🍗👃 🐴🐈📐💄 et, 👽👽🔙🐒🔙🍀 🐞🍐🎵💕🍂🍭🎬🎅 ac 🏃👳📑🐶👝🔷 🔕👄🐾👡🍢💗 🌓🔙🌔🏈🔒🔄🎹🎐 🎾🐝🌁📃💞📔🔕🐕 vel 🌟🏁💴🎾🔷📪💼👣📚 👟💻🗾🎋💁🏬🐮💑 🍈🌸🍓🍥💦 et vivamus 🍑🍫🔉🔹💽🍙 rhoncus eu 📰💫💀🌺 🔋💾🔱🔷🐟 convallis facilisi vitae mollis 📨🔚💮🔃🎀🍶 🌠📑🎹🌑📫🗽🐊💁🔼🕓 ac 🌂🌳🌺🎭🍧🐑 🔭🔉💉🍗👠🍦 🔄👔🎭🍇 🏤🍂🌝👜🔺 ornare 🔽🌰🎃💝👩 🐬🌻🍩👺🎆📣 risus 🌼👧🌒🍄💄🌆🐖👐📠 🕙🍈👞🏢👅🎽🏫👃🌾🍘🕑🎼💆🎳 🐻📵🔂🍩🕦👕🐶 💚🏮📟📈🌄👱🔚 sem 🔵💱💭💫 libero bibendum 🌿🍮🎧🍴💉 🐵🔷🍒🍜 sed metus, aliquam 🐷🐬📇👔🎴🔻🏊📴🍂🎽 🏀💡🍺🌾 💣🍇🐼🌀🐟🍂🐰 sed luctus 👾🍠👻💬📋🐈👀🌕💥🐹 consectetur commodo at 📓🐣🔮🐍🔺🍐🗻🍃🍠🔬 🏁🎬🐔🌙 🎿🎊🍳💓👹🐏 👦🐩👶💻 🔉💏📧🔲🍈📹💫🎧 🌟🍯🔭🎿 🎹🗻💳🔄🕁💂 🐩👠🌗🍹 facilisis 👍🍑💤🐕🐞🐻🏩 posuere 🎑🍢🍑🏨📗👣 ultrices. Vestibulum 🌠👰💼📐🍺💫 👘🐖🔕🔤🐖💶🐢📵👍🍪 🔸🎿🔤🍡💡🌄📁👉🎎🎆🎢🔒 📴👉🌱🐍🌓🎆🏩🐀👓💹🎴 🔴🌒🔘👡🕜 🌝🐉🐑🏮🎸🐳💉🎄 🍳🐲🔭📆🐎🔼🎐🐩💾🍈🎶💅🐜🍀. 🍭🍄🌳🍏💍👈🌆 🔦🏦👵🌹🏊🎐📳🌃📘🌷💎📓🎼 🎳🔁🔂🗽 💅🏰🐊👂🌴 💍🕗🐘🔼🔰🏀 🎂📻🕛🍔🎄 vitae 📎🐆🍚🌲🐰 ipsum 👘👎📅🎈🌆💮🔁🎤 💺💉💉👐🔛🐛🐺🍸📭 💠👞🍨💖 integer 🐌📀🍂🍍🐼 volutpat, condimentum elit 🎌🌕🏊👼 🌛🕜🌚🕤🍎 🏢💨👓👤 duis amet 📹🕚🔏🏧🌷🍄👦 🔠🐬👬🍩📫🏧🎷🔢💆🎭🔳👈 🔇👿💈👧🐍🍱🔉 in 🌐🎲🌠🌟🐀👛🌞🎧 sed. Tristique malesuada id 🏆🍕🕚🎯🌶 📺🐘🏀🐮🔶🏀🍥👬💞🎃🌙🎥🔦🍗 👘👣🐂🎪🔂🎾 👎👮💈🗻🌿💰📩🔋💭💃 🍍🕑🔋👠🍆🍈👰🌅 orci nam 🔀🕠🏄🍣👘🐲💘🐥 🏥🎊🎯👾📅 👛🌽🏫🔃👋🐀👶💥🔳 🕥👪👑👯 🐓💡🔠💼🔳💲 👬🔁🍜💘🔌🌎🏃🌶🍏🍯🎺 🔟📨🔜🎱💓🔛 accumsan 🎢🐭🍉🍳🕜🏆🔗📝👿 🍗👑📜🎁🍇🍕🌛 🎓🌰👣📆🌋 👌🍱💏🔇🐆🌞📝💻🌺 dictumst 📡🍝🌐💤🐅🔔🐟📥🌓🌒🍅📨🏡👺🍬🐟 🔹💳🍨💡🎋💕🕜🏦👟🕒🕣💅💗 🏤🔈📀📜📙🍌 📫🕘👍💾📱 purus 🕒🐕👵🏄💗🐤🕝 pharetra adipiscing elit, non 🏬👸🍉👑 🎠🌇👰💄 🌕🗼🏮💇🐗 📌🏤🌲👹📌 🎐🕓📎🏤💾 tellus 💆🍨👂🕟💚🎋🌠🐳 🍘🍫🎵📚📟🔛🐑🏭🔄👌📏👚🏄🐞 💏🍊👾🍘👰📄💯🔑 proin 🐡🔝🐳🎻🐶🍜 🍕🌵📯🔖💅🕔💘🏁🌾💨🔲🔼🍜🍘🕂 in suscipit 🍎🎄🎬🔙👪💣🍣💯🕧 lectus 🌾🍚🍺🐆💉🎡👷 📖🔅👼🕞 🌄🌃📦🔲💘🌶💁🍯💿 senectus 👻💈🗽🍈 📜🍉🍒🍐🔖👙🔀🐅👙 🐬📷🎨👹🎬 🐷🌐🔽💨🎿🌌🌒 🎎🍊🔕🍁. 🍈🌄📧🏊📛👗🕟 🍋💌🔁🐛💫🔰👃🕑 ridiculus mattis 🕓🍌👘🌹 👅💏🍨🔯🍂🕃🌝👠🏁🔔 pellentesque elit eu, 💝🍧💯🔄📈📛🐻📆🔱📴🔸🍻🐘🎀 viverra 🌆🍉🍉🌆 📪🍕🏊🌜📺🔆🐢🎃 mi sed tellus luctus 🍜🍃🔶🗽 laoreet dui tristique 🔆🌸🐛🔣🏤📘🕜🍃🐋 pretium ultrices 🔳🏇🍏🎭🍀 🍱🐠👬📮🌗🌆💺🔆👨🌱 et 👸📁📩🔌👯👏👫👳💸 🐎💉🔱💦👴 🏪🍶🐸🔤 💔🏤👺👻🏤🎥🐽🔦👌🔡📚💡🔁🎻 🎵👡🕀🎩 🍸🐒🍭🕠🔢🎧🍚💪 🌸🍰💏🏁🎥🐕🔬💶 💃🌽💕🐭 💯🍁📭🐚📛📓🌏🔯📦 🕝👾📒📳💵 🏠💺🕔🕁📃 adipiscing nulla congue 🔖💲🕚🎰🔋👬 sem 👽👵👜👇 vehicula 📑🌎🍁💈 consectetur nulla ullamcorper enim, 🏫🍃🐢🔄🍝🕢👖💨👺💰👎💳🏠🏤 vel fermentum porttitor lacus 📱💧🔜🔰👱🎰🐉🔓🕧🍌🕙 🎴🍫🐱🐟🌖🕞🏥🍝📜🔃🏈🔡🐁🔗 💊🍐📝👭🎢🐳🐯📷🐀🔃. 🐦🍚🔵🕜🏩 id 🌔🔤💿🌻🍹 🌎🎈📢🔬🐖💢👸🎭 🍤🔵🔓🕕📪💢🔁👽💴 🐛👶🔢🎹🏄👜📌🍭🔼🎫🍯🎦💎🐦 🐨💧🍴🌊🔁 consequat pretium 👍🏬🏰👖🍥📺👛🌕 🏄🔱🔩🐏🌞🌺🐌👑 🏰🕢💱👖🐶🐥📯🎶💧🍭🔀🎾🏩🍑 massa, est 👶🍭💅🕔🍳💗🍞💚🍩🐷🍘🌄🐇 🐼👀👀🎅 📄🎁🐞💼 placerat erat 💧🌉💻🔣🐥📠🍪📻🐃🔻👠🕘🍞🍈🍔📴 dolor 📁💹🎐🍂🍉 neque, 👗🍁🍪🌵🕛🍄 🕝👔🔼🎡🔺📬 sed 💨💧🏢🐼👘🌳🎼👹🐉🕕 enim 🔏🏁👊💀🔓 🏫🐈💀🌳🔒👵🔘🎺💴🍑 👭🔲🍰💿🔪🌊 🌅🕔🎑📛🔶🔘🎑🍯 🐲📺👬📊🍒 elit, 🌽🎱💇🎥 ultricies 📡💲🐦🌁🍚🌵🍵 🎮📧🔟🍴👕🔏🌴🔊👳🗼💒🌴👍📞🔳👜🔥🐝🐾🐧🍊 🌰🗾🌂🐄 🔛🐀🍏🍞🔔📖💉📼🐥🍱 🐜🎺🍵💿👂🌋🌸 🔞🐤🔟🍀📙🏩👑 porta id 🎄💺🍙👶👪🔪👪🐭💚📗🎅🍐👡🎭 🐦🎌🐆💫 quis nulla dictumst non 📫🍵🔫🕠 🔯🔃🐷📖💙👓💍 🎬🕃🐥🏫🍛🌆🐗👅📷 📚🍭🌞🌎🕐👜👳 🏧💬💴🎆🐄🔠📄🐰📝🌈 🎩🌇🌟📙 suspendisse 🔡👫🍐🏩🌉🕚📘🐮 👐🏁👮🎭🏣 👰📤🍙🏈👓🐰🍦 lacinia diam eu vestibulum donec faucibus 🔝🎴🌷💩🍡🍜💙 🎐🔉🌛📠🏢📄🍆🎆.
 
-interface Props {
-	title?: string;
-	description?: string | undefined;
-	navItems?: MenuItem[];
-	preloadCatalogue?: boolean;
-}
+<script>console.log("That's a lot of emojis.");</script>
 
-const { title, description, navItems, preloadCatalogue } = Astro.props;
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
----
+🔲🍀🏨👆👎🏩🏦🎹 nibh 🕞🍃🔻📨 nec pulvinar 📏🐜💻🐸🐾🐾💖 risus 🍫🕜🐑🌳📇🍋🐪🎣 neque 👝🐝🌹🍫🌌👅 👹🏈🗽🐣 💉📊🐘🔉🏆💡🌸👰🔛📼 🍺🌿🐪🔜💄🎒👟 amet vitae, morbi elit rhoncus 🐙🏫🍪🎡👕💵 🌕💁💯🐷🌾📼🐀🍬🌛🕤🐊👔🔩🍂📚💵 💖🐐👹🔼🏠🍢🎼🐧 👛📩🍯💊 📞🌒📞💽 purus 🔐📼📬🌞🍁💸 morbi 🍁🎾🎡🌋 📨🌈🔈🌆🔨📕💛🏡🏯 💅🎣👽🕦 🌴🍋🔐🔑 ut congue 🔊🐧🌻🕑 gravida 🐉👅👦👢🎉🔎💪🔄🎈 👳🏡🕥🎂 🔵🐘🔠🍑👉🔀📊🏡 🌄🍯💽📁📚🐆👆🌂🎡📖🎱👮🌽🐄 orci 📚🍣🐀🎦📪💶🌓 etiam 🌑🐁💇👬🍓📅💸👟🌕🐊🎁🏪 vehicula sed 📒📭📣🌌🐁🎲🌴🏠🔏👯📥💽🌗💲🍡🔫 🎈🏥🍇🔺💍💐🌳👎🎤🍮📭📊 🍓👠🕞🕘🍂🏣🐺🍬🐖 eget lectus 🍄🍍📉📥🌾🎴🏣 🐾🕤🍼🌃🔩🐂🕣🐉💧📊🎧🎧🌂🎠 🐵🌺📰📑🏰 👣🍸💚🐗🔜🕕🐠🕙🏇📲🌙 👫💛💽🐑💸 🔐🔝🔘🎪💻🔂 nunc, 🍹🕗🏡📤🎷 sem vitae adipiscing tempor, 🕡🍚🐈🌟👎💢🔦 🌴💿💔🎳📍🌽🎒🔭🔨 lectus 🌰🌓🗽💀🍈 est 📬💑🕁🍺 📀🏮🔫🔜🎭🌷🏀💑🍂🔵 vulputate leo eget 🍗🌴🎃🔣👲📙 📺🍈🍏💦🌅💔💌 phasellus 👨💡🔯🐃🍜🐒🔵💆🍩🐦🍬🍅🍧 🎲🍰💊🏣📁💎 🔮🎉🎱👿🐟💪🕤 🍡🐜🕚🌏. Turpis vulputate 🌗🔫📙🎽🎽🎿📓 pretium congue in arcu tincidunt. Nisi 📺💍👃🕃🐫 🐝📨🍁🕕💯💭 📬🏧🔧🌟 🏩👛🏭🌽🎮🌁 magnis porttitor 🔈🎄🌓👶🏮. 👢🌵🏬🌏🍩 rutrum egestas 💙🔠🎧🐜🎣 nisi lectus feugiat 🍀🕚🕢🌀🎰💅 💝📮🌝📃🔈 🎓📝🏮🍄📢📛🍺🔊💐 sagittis 🐖🌂🎓👒👎🔼👊📣📭👿🐦🔖🍵💺🐳 🕗🔭🐭📐👍💯 massa erat 🏧🐁🎤👔💑🍣🐢 🍐🗾🔙🍊🎭🔣👐 💊💖🌳💌💿🏯🔴🎪. Id 🐅🐦💝📱💐👓🎡 ut 🏬🔔🌟🌑 🎦💮🎩🔬 👰📵🍘🎴 👪🐩👳💆🍧 purus 💮🐦🐼🎷🔦 🎺🔇🍴📈 cras pretium volutpat, etiam risus 🐇🕔🐪🔽 👠🔮🔈🎃🎧🌄👜 vel sapien 💯👻👜🎼📜 🎽💀🏊🌉📴🍻📐💉📺🐺 vivamus lorem 📃📉🔞🕦 📣🍨🌉🔩🐺🔎👙 molestie tellus 👹💃🕕📗🔵🕢 vel 📎🐍🔅📁🔁🍚🌀💏🐦 🎱🐮🕣👋📳🎑 🕙🏡🕒📖📪👩 condimentum 🐤💐💷🕞💬💝🎨💰 amet nisl fringilla bibendum 🐘🏃🎃🐉🏰🏦🐎🎱🍅🎥🔳🎵🍠🏧🍖🔭💇 🕞🎱📂🐈👇 🍯👐🎹👘💯📗👷 💂🕘👦💘💆🌗🕃🏀🔚 🔜💃🌒🍧🔝🐹🔑💂👜🐭 🎤👌👐🏩📞🕦🔜🍙 morbi 👑🐸🌄🐹🐃🐢🍳💸 malesuada quam amet, 💰🔗👗🐰🍆🕑📮 🍋🌘🐞🍧 🔻🎺🍘👐🍬🔷 pulvinar 🔭🏬👦💆 vivamus tempus 🏧👉🕢📭🔠🌔🕧💧📊🔼 👬🐑🌘🍮🎎🐝🕃👗🔴🐽🐘🌈📺👙🕝.
 
-<html lang="en">
-	<Head>
-		<meta charset="UTF-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Erika</title>
+<div onload="console.log('It really is.')"></div>
 
-		<link
-			rel="preload"
-			href="/assets/fonts/IBMPlexResult.woff2"
-			as="font"
-			type="font/woff2"
-			crossorigin
-		/>
-
-		<link
-			rel="preload"
-			href="/assets/fonts/InterResult.woff2"
-			as="font"
-			type="font/woff2"
-			crossorigin
-		/>
-
-		{preloadCatalogue && <link rel="preconnect" href="/api/catalogue" crossorigin />}
-
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="description" content={description ? description : "My personal website"} />
-		<meta property="og:title" content={title ? title : "Erika"} />
-		<meta property="og:description" content={description ? description : "My personal website"} />
-
-		<meta property="og:type" content="website" />
-		<meta property="og:site_name" content="erika.florist" />
-
-		<meta property="og:image" content={getBaseSiteURL() + "social-card.png"} />
-		<meta name="twitter:card" content="summary" />
-		<meta name="twitter:image" content={getBaseSiteURL() + "social-card.png"} />
-
-		<link
-			rel="alternate"
-			type="application/rss+xml"
-			title="Blog"
-			href={getBaseSiteURL() + "rss/blog"}
-		/>
-
-		<link
-			rel="alternate"
-			type="application/rss+xml"
-			title="Catalogue"
-			href={getBaseSiteURL() + "rss/catalogue"}
-		/>
-
-		<link rel="canonical" href={canonicalURL} />
-		<meta property="og:url" content={canonicalURL} />
-
-		<script src="../assets/scripts/main.ts"></script>
-	</Head>
-	<body class="bg-black-charcoal">
-		<script is:inline>
-			const theme = localStorage.getItem("theme"),
-				isSystemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-			theme === "dark" || (!theme && isSystemDark)
-				? document.documentElement.classList.add("dark")
-				: theme === "light"
-					? document.documentElement.classList.remove("dark")
-					: theme === "system" && isSystemDark && document.documentElement.classList.add("dark");
-		</script>
-		<div id="app" class="bg-white-sugar-cane">
-			<Header />
-
-			<main>
-				<slot />
-			</main>
-
-			<footer
-				class="m-12 flex justify-center bg-black-charcoal px-5 py-6 leading-tight text-white-sugar-cane sm:m-0 sm:mt-12 sm:px-0"
-			>
-				<section class="flex w-centered-width justify-between">
-					<Socials />
-
-					<div class="prose">
-						Powered by <a href="https://astro.build/">Astro</a><br />
-						<a href="https://github.com/Princesseuh/erika.florist">Source Code</a><br />
-						<a href="/changelog/">Changelog</a>
-					</div>
-				</section>
-			</footer>
-
-			<GoBackUp />
-			<MobileMenu />
-			<MobileMenuSide navMenu={navItems ?? []} />
-		</div>
-		<Spritesheet />
-	</body>
-</html>
-`
+Faucibus 🎈🐋🔄📇🐡💐 🎾🎩🔹🔣🎍🐸🌳 vestibulum, 🐢🌘🕜👂💬🎑🍪 📫📊🎅🌷📝🔰🏣💭👧👽🎒📕💓👯 🎎🍁🕥🕑💗🐌📩📧🍸🌙 🕝🐵🐀🐫🎫🔰👲🍛🔵🍪 🍳🏆🎷🐐 quam 💠🎈🕓🌴🌱🍨💢🍮🕡🔡💎🐍 imperdiet placerat 🔱🐑📔🔧🌍 nisl 📢🗻🐹🔏🕕🐐💦 📈🔵📴🍳📬💕📧📓🍚 📈🌸🔱💜💎🌐🍻📘🏠💵🏡🔌📦🐑🍩🔇👅📎🐆 🐌💞📺🐫🍷🌍💒🌸🔎🌇📠🔂🌼💎🍟 ut vel et 🎩👖💾👢🎵💂 🌂📱💳🐨🍲 🍔🔵🏃🎦🕐🌟🌐🔑 tristique vel 🌃💋👉🔰. Tortor sit 🌓👑🔓🐀🌹 tempus 🍸🍹📔🎂🍺🏀 consequat ornare 👽👽🍃📗🌘🍍 🔯🌲📝📥🍐🏣🐸 🍔📝📞🍣 💩🔥💨👋🔹 🌕💊🏪🕡 🏇🏉🐵👢🎳🕛🍸 🐈🏇🏭🕁🍬 rhoncus 📛🍁🔨💶 bibendum 🎋👲🏤📰🍐 🌸📙🍏🌠 🎿🎀👡💲📋💦🐵🔑🕡🕞🍥🍍👧🔘💡 arcu 💣👍🌶👬🌹🔒🌁📠🕖🎓📌🎩📫💬 👋🌚🌶💶🍊💫🔁📲🎺🐮💙🍟 🕦🌁🐡🍵🍒 🍁🍜🍪🔳📞💝💻🎶📦🔵📯🏦🐎 lobortis malesuada 💇💸🏰💅. 🌐🐕🐂📇 🎒💨🔙🐉🎹🔥🔗📴👥🎈📒🔸💍🔇🌙🕁🐊🏣💆💗🔽 tortor 🔵🐚🍓🌱🌆🐀🐻 🔓👦🍌🌔🍯👐🕣 🌅👇📝💰💝 condimentum 🍋💉🐞📆🍲👢🐬💌🎤 🎢👷👑👆 💱🎒🏬🎫 🗾💝👎👄 💊🔅🔙🐮🍗🐥 nulla adipiscing 🎦👿🐞🔋📜👵 🏄🐷🎵👾 🎿🍒🌲💄📚🌔📭👄👿🍱📷💮🔀🍄 velit.`
 	for i := 0; i < b.N; i++ {
 		h := handler.NewHandler(source, "AstroBenchmark")
 		var doc *astro.Node

--- a/internal/printer/print-to-tsx_test.go
+++ b/internal/printer/print-to-tsx_test.go
@@ -1,0 +1,147 @@
+package printer
+
+import (
+	"strings"
+	"testing"
+
+	astro "github.com/withastro/compiler/internal"
+	handler "github.com/withastro/compiler/internal/handler"
+	"github.com/withastro/compiler/internal/transform"
+)
+
+func BenchmarkPrintToTSX(b *testing.B) {
+	source := `---
+import MobileMenu from "$components/layout/MobileMenu.astro";
+import MobileMenuSide from "$components/layout/MobileMenuSide.astro";
+import Header from "$components/layout/Header.astro";
+import Socials from "$components/layout/Socials.astro";
+import { getBaseSiteURL } from "$utils";
+import { Head } from "astro-capo";
+import "src/assets/style/prin.css";
+import type { MenuItem } from "../data/sidebarMenu";
+import Spritesheet from "$components/Spritesheet.astro";
+import GoBackUp from "$components/layout/GoBackUp.astro";
+
+interface Props {
+	title?: string;
+	description?: string | undefined;
+	navItems?: MenuItem[];
+	preloadCatalogue?: boolean;
+}
+
+const { title, description, navItems, preloadCatalogue } = Astro.props;
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
+---
+
+<html lang="en">
+	<Head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Erika</title>
+
+		<link
+			rel="preload"
+			href="/assets/fonts/IBMPlexResult.woff2"
+			as="font"
+			type="font/woff2"
+			crossorigin
+		/>
+
+		<link
+			rel="preload"
+			href="/assets/fonts/InterResult.woff2"
+			as="font"
+			type="font/woff2"
+			crossorigin
+		/>
+
+		{preloadCatalogue && <link rel="preconnect" href="/api/catalogue" crossorigin />}
+
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="description" content={description ? description : "My personal website"} />
+		<meta property="og:title" content={title ? title : "Erika"} />
+		<meta property="og:description" content={description ? description : "My personal website"} />
+
+		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="erika.florist" />
+
+		<meta property="og:image" content={getBaseSiteURL() + "social-card.png"} />
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:image" content={getBaseSiteURL() + "social-card.png"} />
+
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="Blog"
+			href={getBaseSiteURL() + "rss/blog"}
+		/>
+
+		<link
+			rel="alternate"
+			type="application/rss+xml"
+			title="Catalogue"
+			href={getBaseSiteURL() + "rss/catalogue"}
+		/>
+
+		<link rel="canonical" href={canonicalURL} />
+		<meta property="og:url" content={canonicalURL} />
+
+		<script src="../assets/scripts/main.ts"></script>
+	</Head>
+	<body class="bg-black-charcoal">
+		<script is:inline>
+			const theme = localStorage.getItem("theme"),
+				isSystemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+			theme === "dark" || (!theme && isSystemDark)
+				? document.documentElement.classList.add("dark")
+				: theme === "light"
+					? document.documentElement.classList.remove("dark")
+					: theme === "system" && isSystemDark && document.documentElement.classList.add("dark");
+		</script>
+		<div id="app" class="bg-white-sugar-cane">
+			<Header />
+
+			<main>
+				<slot />
+			</main>
+
+			<footer
+				class="m-12 flex justify-center bg-black-charcoal px-5 py-6 leading-tight text-white-sugar-cane sm:m-0 sm:mt-12 sm:px-0"
+			>
+				<section class="flex w-centered-width justify-between">
+					<Socials />
+
+					<div class="prose">
+						Powered by <a href="https://astro.build/">Astro</a><br />
+						<a href="https://github.com/Princesseuh/erika.florist">Source Code</a><br />
+						<a href="/changelog/">Changelog</a>
+					</div>
+				</section>
+			</footer>
+
+			<GoBackUp />
+			<MobileMenu />
+			<MobileMenuSide navMenu={navItems ?? []} />
+		</div>
+		<Spritesheet />
+	</body>
+</html>
+`
+	for i := 0; i < b.N; i++ {
+		h := handler.NewHandler(source, "AstroBenchmark")
+		var doc *astro.Node
+		doc, err := astro.ParseWithOptions(strings.NewReader(source), astro.ParseOptionWithHandler(h), astro.ParseOptionEnableLiteral(true))
+		if err != nil {
+			h.AppendError(err)
+		}
+
+		PrintToTSX(source, doc, TSXOptions{
+			IncludeScripts: false,
+			IncludeStyles:  false,
+		}, transform.TransformOptions{
+			Filename: "AstroBenchmark",
+		}, h)
+	}
+}

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -124,6 +124,10 @@ export interface SourceMap {
 	version: number;
 }
 
+/**
+ * Represents a location in a TSX file.
+ * Both the `start` and `end` properties are 0-based, and are based off utf-16 code units. (i.e. JavaScript's `String.prototype.length`)
+ */
 export interface TSXLocation {
 	start: number;
 	end: number;


### PR DESCRIPTION
## Changes

Previously when extracting script and style tags, we tried to somewhat make it work with multibytes characters by counting them and skipping, not only was this cumbersome, it kinda didn't work because our loop would run multiple times over kinda the same characters, anyway it was annoying.

In this PR, I changed it so that we use the lineoffsets table from the sourcemapping logic to get the offsets. This is somewhat slower, especially in some extreme cases, but in most cases there's no difference, and at least it's now correct.

I also updated the frontmatter and body ranges extraction to use this method, as they suffered from the same problem

In theory, this is a breaking change, but the truth is that the numbers it'd spit out would be unusable in JS unless you did a lot of conversion yourself, now the numbers can be used as-is. Also, I doubt anyone other than me is using them...

Fixes https://github.com/withastro/language-tools/issues/921

## Testing

Tests should pass + updated some + added more

## Docs

N/A. Though I did a JSdoc comment on the type to say that it's UTF-16 based.