### PR TITLE
fix/class:list directive was not properly merging with the class attribute

### DIFF
--- a/.changeset/ten-melons-return.md
+++ b/.changeset/ten-melons-return.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Resolved the issue where the class:list directive was not properly merging with the class attribute.

--- a/.changeset/ten-melons-return.md
+++ b/.changeset/ten-melons-return.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": patch
 ---
 
-Resolved the issue where the class:list directive was not properly merging with the class attribute.
+Resolves an issue where the `class:list` directive was not correctly merging with the class attribute.


### PR DESCRIPTION
## Changes

Resolved an issue where the class:list directive was not properly merging with the class attribute.

Fixes [withastro/compiler/issues/998](https://github.com/withastro/compiler/issues/998)

## Testing

Added new tests to verify the correct merging of class and class:list attributes.
Manually tested the output to confirm that classes are accurately combined.

## Docs

No documentation updates were made, as this change addresses an existing bug and does not introduce new features or alter existing functionality.