### PR TITLE
Fix line returns segments being one character too long on Windows

### DIFF
--- a/.changeset/eleven-planets-camp.md
+++ b/.changeset/eleven-planets-camp.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fixes sourcemapping for CRLF line endings wrongfully including the last character

--- a/packages/compiler/test/tsx-sourcemaps/template-windows.ts
+++ b/packages/compiler/test/tsx-sourcemaps/template-windows.ts
@@ -3,6 +3,17 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 import { testTSXSourcemap } from '../utils.js';
 
+test('last character does not end up in middle of CRLF', async () => {
+	const input = "---\r\nimport { Meta } from '$lib/components/Meta.astro';\r\n---\r\n";
+	const output = await testTSXSourcemap(input, ';');
+	assert.equal(output, {
+		source: 'index.astro',
+		line: 2,
+		column: 50,
+		name: null,
+	});
+});
+
 test('template expression basic', async () => {
 	const input = '<div>{\r\nnonexistent\r\n}</div>';
 


### PR DESCRIPTION
## Changes

Previously, due to how we skipped over CRLF, we'd end up with a mapping that looks like this:

```
Original:  ;    \n
Mapping : [;\r][\n]
```

Where the first segment would contain both the last character of the line, and the `\r`. This is fine, albeit wonky, however this ends up breaking downstream in libraries that are line-ending agnostic because they don't expect than an offset would end up after a line ending, even less so in the middle of a two-characters one. (the main culprit here is https://github.com/microsoft/vscode-languageserver-node/tree/main/textDocument, see https://github.com/microsoft/vscode-languageserver-node/issues/1285)

This PR fixes this by handling it like this instead:

```
Original:  ;  \n
Mapping : [;][\r\n]
```

That way, asking for the last segment of a line will instead result on the `;`, or before the two line endings, depending on which one you ask for, but nothing after or in the middle of it.

## Testing

Added a test

## Docs

N/A
