### PR TITLE
Reverse order of styles & scripts

### DIFF
--- a/.changeset/olive-beds-happen.md
+++ b/.changeset/olive-beds-happen.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix the order that styles & scripts are rendered

--- a/.changeset/olive-beds-happen.md
+++ b/.changeset/olive-beds-happen.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": patch
 ---
 
-Fix the order that styles & scripts are rendered
+Add an experimental flag `experimentalScriptOrder` that corrects the order styles & scripts are rendered within a component. When enabled, the order styles & scripts are rendered will be consistent with the order they are defined.

--- a/.changeset/olive-beds-happen.md
+++ b/.changeset/olive-beds-happen.md
@@ -1,5 +1,5 @@
 ---
-"@astrojs/compiler": patch
+"@astrojs/compiler": minor
 ---
 
 Add an experimental flag `experimentalScriptOrder` that corrects the order styles & scripts are rendered within a component. When enabled, the order styles & scripts are rendered will be consistent with the order they are defined.

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -138,6 +138,11 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		renderScript = true
 	}
 
+	experimentalScriptOrder := false
+	if jsBool(options.Get("experimentalScriptOrder")) {
+		experimentalScriptOrder = true
+	}
+
 	return transform.TransformOptions{
 		Filename:                filename,
 		NormalizedFilename:      normalizedFilename,
@@ -152,6 +157,7 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		TransitionsAnimationURL: transitionsAnimationURL,
 		AnnotateSourceFile:      annotateSourceFile,
 		RenderScript:            renderScript,
+		ExperimentalScriptOrder: experimentalScriptOrder,
 	}
 }
 
@@ -336,7 +342,7 @@ func Transform() any {
 				}
 
 				// Hoist styles and scripts to the top-level
-				transform.ExtractStyles(doc)
+				transform.ExtractStyles(doc, &transformOptions)
 
 				// Pre-process styles
 				// Important! These goroutines need to be spawned from this file or they don't work

--- a/internal/printer/__printer_js__/multiple_define_vars_on_style.snap
+++ b/internal/printer/__printer_js__/multiple_define_vars_on_style.snap
@@ -34,7 +34,7 @@ export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydra
 
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 
-const $$definedVars = $$defineStyleVars([{color:'red'},{color:'green'}]);
+const $$definedVars = $$defineStyleVars([{color:'green'},{color:'red'}]);
 return $$render`${$$maybeRenderHead($$result)}<h1 class="astro-6oxbqcst"${$$addAttribute($$definedVars, "style")}>foo</h1><h2 class="astro-6oxbqcst"${$$addAttribute($$definedVars, "style")}>bar</h2>`;
 }, undefined, undefined);
 export default $$Component;

--- a/internal/printer/__printer_js__/script_multiple__renderScript__true_.snap
+++ b/internal/printer/__printer_js__/script_multiple__renderScript__true_.snap
@@ -30,7 +30,7 @@ import {
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
 
-export const $$metadata = $$createMetadata("/src/pages/index.astro", { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [{ type: 'inline', value: `console.log("World");` }, { type: 'inline', value: `console.log("Hello");` }] });
+export const $$metadata = $$createMetadata("/src/pages/index.astro", { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [{ type: 'inline', value: `console.log("Hello");` }, { type: 'inline', value: `console.log("World");` }] });
 
 const $$Index = $$createComponent(($$result, $$props, $$slots) => {
 

--- a/internal/printer/printer_css_test.go
+++ b/internal/printer/printer_css_test.go
@@ -87,8 +87,9 @@ func TestPrinterCSS(t *testing.T) {
 			}
 
 			hash := astro.HashString(code)
-			transform.ExtractStyles(doc)
-			transform.Transform(doc, transform.TransformOptions{Scope: hash, ScopedStyleStrategy: scopedStyleStrategy}, handler.NewHandler(code, "/test.astro")) // note: we want to test Transform in context here, but more advanced cases could be tested separately
+			opts := transform.TransformOptions{Scope: hash, ScopedStyleStrategy: scopedStyleStrategy, ExperimentalScriptOrder: true}
+			transform.ExtractStyles(doc, &opts)
+			transform.Transform(doc, opts, handler.NewHandler(code, "/test.astro")) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintCSS(code, doc, transform.TransformOptions{
 				Scope:       "astro-XXXX",
 				InternalURL: "http://localhost:3000/",

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2066,12 +2066,13 @@ const meta = { title: 'My App' };
 			}
 
 			hash := astro.HashString(code)
-			transform.ExtractStyles(doc)
 			// combine from tt.transformOptions
 			transformOptions := transform.TransformOptions{
-				Scope:        hash,
-				RenderScript: tt.transformOptions.RenderScript,
+				Scope:                   hash,
+				RenderScript:            tt.transformOptions.RenderScript,
+				ExperimentalScriptOrder: true,
 			}
+			transform.ExtractStyles(doc, &transformOptions)
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 
 			result := PrintToJS(code, doc, 0, transform.TransformOptions{

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -125,7 +125,7 @@ func ExtractStyles(doc *astro.Node) {
 			if !IsHoistable(n) {
 				return
 			}
-			// prepend node to maintain authored order
+			// append node to maintain authored order
 			doc.Styles = append(doc.Styles, n)
 		}
 	})
@@ -434,7 +434,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 				}
 			}
 
-			// prepend node to maintain authored order
+			// append node to maintain authored order
 			if shouldAdd {
 				doc.Scripts = append(doc.Scripts, n)
 				n.HandledScript = true

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -126,7 +126,7 @@ func ExtractStyles(doc *astro.Node) {
 				return
 			}
 			// prepend node to maintain authored order
-			doc.Styles = append([]*astro.Node{n}, doc.Styles...)
+			doc.Styles = append(doc.Styles, n)
 		}
 	})
 	// Important! Remove styles from original location *after* walking the doc
@@ -436,7 +436,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 
 			// prepend node to maintain authored order
 			if shouldAdd {
-				doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
+				doc.Scripts = append(doc.Scripts, n)
 				n.HandledScript = true
 			}
 		} else {

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -34,6 +34,7 @@ type TransformOptions struct {
 	PreprocessStyle         interface{}
 	AnnotateSourceFile      bool
 	RenderScript            bool
+	ExperimentalScriptOrder bool
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -115,7 +116,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 	return doc
 }
 
-func ExtractStyles(doc *astro.Node) {
+func ExtractStyles(doc *astro.Node, opts *TransformOptions) {
 	walk(doc, func(n *astro.Node) {
 		if n.Type == astro.ElementNode && n.DataAtom == a.Style {
 			if HasSetDirective(n) || HasInlineDirective(n) {
@@ -126,7 +127,11 @@ func ExtractStyles(doc *astro.Node) {
 				return
 			}
 			// append node to maintain authored order
-			doc.Styles = append(doc.Styles, n)
+			if opts.ExperimentalScriptOrder {
+				doc.Styles = append(doc.Styles, n)
+			} else {
+				doc.Styles = append([]*astro.Node{n}, doc.Styles...)
+			}
 		}
 	})
 	// Important! Remove styles from original location *after* walking the doc
@@ -436,7 +441,11 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 
 			// append node to maintain authored order
 			if shouldAdd {
-				doc.Scripts = append(doc.Scripts, n)
+				if opts.ExperimentalScriptOrder {
+					doc.Scripts = append(doc.Scripts, n)
+				} else {
+					doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
+				}
 				n.HandledScript = true
 			}
 		} else {

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -182,7 +182,6 @@ func TestTransformScoping(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			ExtractStyles(doc)
 			var scopeStyle string
 			if tt.scopeStyle == "attribute" {
 				scopeStyle = "attribute"
@@ -191,7 +190,9 @@ func TestTransformScoping(t *testing.T) {
 			} else {
 				scopeStyle = "where"
 			}
-			Transform(doc, TransformOptions{Scope: "xxxxxx", ScopedStyleStrategy: scopeStyle}, handler.NewHandler(tt.source, "/test.astro"))
+			transformOptions := TransformOptions{Scope: "xxxxxx", ScopedStyleStrategy: scopeStyle}
+			ExtractStyles(doc, &transformOptions)
+			Transform(doc, transformOptions, handler.NewHandler(tt.source, "/test.astro"))
 			astro.PrintToSource(&b, doc.LastChild.FirstChild.NextSibling.FirstChild)
 			got := b.String()
 			if tt.want != got {
@@ -211,8 +212,9 @@ func FuzzTransformScoping(f *testing.F) {
 		if err != nil {
 			t.Skip("Invalid parse, skipping rest of fuzz test")
 		}
-		ExtractStyles(doc)
-		Transform(doc, TransformOptions{Scope: "xxxxxx"}, handler.NewHandler(source, "/test.astro"))
+		transformOptions := TransformOptions{Scope: "xxxxxx"}
+		ExtractStyles(doc, &transformOptions)
+		Transform(doc, transformOptions, handler.NewHandler(source, "/test.astro"))
 		var b strings.Builder
 		astro.PrintToSource(&b, doc.LastChild.FirstChild.NextSibling.FirstChild)
 		got := b.String()
@@ -297,10 +299,11 @@ func TestFullTransform(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			ExtractStyles(doc)
+			transformOptions := TransformOptions{}
+			ExtractStyles(doc, &transformOptions)
 			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
 			doc.Styles = make([]*astro.Node, 0)
-			Transform(doc, TransformOptions{}, handler.NewHandler(tt.source, "/test.astro"))
+			Transform(doc, transformOptions, handler.NewHandler(tt.source, "/test.astro"))
 			astro.PrintToSource(&b, doc)
 			got := strings.TrimSpace(b.String())
 			if tt.want != got {
@@ -345,10 +348,11 @@ func TestTransformTrailingSpace(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			ExtractStyles(doc)
+			transformOptions := TransformOptions{}
+			ExtractStyles(doc, &transformOptions)
 			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
 			doc.Styles = make([]*astro.Node, 0)
-			Transform(doc, TransformOptions{}, handler.NewHandler(tt.source, "/test.astro"))
+			Transform(doc, transformOptions, handler.NewHandler(tt.source, "/test.astro"))
 			astro.PrintToSource(&b, doc)
 			got := b.String()
 			if tt.want != got {
@@ -463,12 +467,13 @@ func TestCompactTransform(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
-			ExtractStyles(doc)
+			transformOptions := TransformOptions{
+				Compact: true,
+			}
+			ExtractStyles(doc, &transformOptions)
 			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
 			doc.Styles = make([]*astro.Node, 0)
-			Transform(doc, TransformOptions{
-				Compact: true,
-			}, &handler.Handler{})
+			Transform(doc, transformOptions, &handler.Handler{})
 			astro.PrintToSource(&b, doc)
 			got := strings.TrimSpace(b.String())
 			if tt.want != got {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -65,6 +65,7 @@ export interface TransformOptions {
 	 * @experimental
 	 */
 	renderScript?: boolean;
+	experimentalScriptOrder?: boolean;
 }
 
 export type ConvertToTSXOptions = Pick<

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -3,9 +3,14 @@ import { test } from 'uvu';
 import * as assert from 'uvu/assert';
 
 test('outputs scripts in expected order', async () => {
-	const result = await transform(`
+	const result = await transform(
+		`
     <script>console.log(1)</script>
-    <script>console.log(2)</script>`);
+    <script>console.log(2)</script>`,
+		{
+			experimentalScriptOrder: true,
+		}
+	);
 
 	const scripts = result.scripts;
 

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -4,14 +4,17 @@ import * as assert from 'uvu/assert';
 
 test('outputs scripts in expected order', async () => {
 	const result = await transform(`
-    <script type="module">console.log(1)</script>
-    <script type="module">console.log(2)</script>`);
-	const matches = result.code.match(/console\.log\((\d)\)/g);
+    <script>console.log(1)</script>
+    <script>console.log(2)</script>`);
 
-	if (!matches) throw new Error('No matches');
+	const scripts = result.scripts
 
-	assert.match(matches[0], '1');
-	assert.match(matches[1], '2');
+	// for typescript
+	if (scripts[0].type === 'external') throw new Error("Script is external")
+	if (scripts[1].type === 'external') throw new Error("Script is external")
+
+	assert.match(scripts[0].code, 'console.log(1)');
+	assert.match(scripts[1].code, 'console.log(2)');
 });
 
 test.run();

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -7,11 +7,11 @@ test('outputs scripts in expected order', async () => {
     <script>console.log(1)</script>
     <script>console.log(2)</script>`);
 
-	const scripts = result.scripts
+	const scripts = result.scripts;
 
 	// for typescript
-	if (scripts[0].type === 'external') throw new Error("Script is external")
-	if (scripts[1].type === 'external') throw new Error("Script is external")
+	if (scripts[0].type === 'external') throw new Error('Script is external');
+	if (scripts[1].type === 'external') throw new Error('Script is external');
 
 	assert.match(scripts[0].code, 'console.log(1)');
 	assert.match(scripts[1].code, 'console.log(2)');

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -1,0 +1,17 @@
+import { transform } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+test('outputs scripts in expected order', async () => {
+	const result = await transform(`
+    <script type="module">console.log(1)</script>
+    <script type="module">console.log(2)</script>`);
+	const matches = result.code.match(/console\.log\((\d)\)/g);
+
+	if (!matches) throw new Error('No matches');
+
+	assert.match(matches[0], '1');
+	assert.match(matches[1], '2');
+});
+
+test.run();

--- a/packages/compiler/test/styles/sass.ts
+++ b/packages/compiler/test/styles/sass.ts
@@ -37,15 +37,15 @@ test.before(async () => {
 });
 
 test('transforms scss one', () => {
-	assert.match(
-		result.css[result.css.length - 1],
-		'color:red',
-		'Expected "color:red" to be present.'
-	);
+	assert.match(result.css[0], 'color:red', 'Expected "color:red" to be present.');
 });
 
 test('transforms scss two', () => {
-	assert.match(result.css[0], 'color:green', 'Expected "color:green" to be present.');
+	assert.match(
+		result.css[result.css.length - 1],
+		'color:green',
+		'Expected "color:green" to be present.'
+	);
 });
 
 test.run();

--- a/packages/compiler/test/styles/sass.ts
+++ b/packages/compiler/test/styles/sass.ts
@@ -33,6 +33,7 @@ test.before(async () => {
 	result = await transform(FIXTURE, {
 		sourcemap: true,
 		preprocessStyle,
+		experimentalScriptOrder: true,
 	});
 });
 


### PR DESCRIPTION
## Changes

- Fixes https://github.com/withastro/astro/issues/12264 (See https://github.com/withastro/astro/issues/12264#issuecomment-2544037010 for more info)

For example, with component like the follow:

```html
<style>
  body {
    background-color: red;
  }
</style>
<style>
  body {
    background-color: yellow;
  }
</style>
```

The current compiler output would render `red` last, even though `yellow` was the last style-tag defined.

```html
<style>
  body {
    background-color: yellow;
  }
  body {
    background-color: red;
  }
</style>
```

Enabling the `experimentalScriptOrder` flag will respect the order style & script tags are defined.

```html
<style>
  body {
    background-color: red;
  }
  body {
    background-color: yellow;
  }
</style>
```


## Testing

- Updated existing styles test
- Added test for scripts order

## Docs

- Will require a section for the new experimental flag once implemented in withastro/astro.
