### PR TITLE
Fix expression parsing in foreign context

### DIFF
--- a/.changeset/plenty-geese-laugh.md
+++ b/.changeset/plenty-geese-laugh.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fixes an issue when parsing elements inside foreign content (e.g. SVG), when they were inside an expression

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -391,6 +391,7 @@ func (p *parser) addExpression() {
 		CustomElement: false,
 		HandledScript: false,
 		Loc:           p.generateLoc(),
+		Namespace:     p.top().Namespace,
 	})
 
 }

--- a/internal/printer/__printer_js__/namespace_is_preserved_when_inside_an_expression.snap
+++ b/internal/printer/__printer_js__/namespace_is_preserved_when_inside_an_expression.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/namespace_is_preserved_when_inside_an_expression - 1]
+## Input
+
+```
+<svg>{<image />}</svg>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<svg>${$$render`<image></image>`}</svg>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -905,8 +905,8 @@ import Widget2 from '../components/Widget2.astro';
 		{
 			// maintain the original behavior, though it may be
 			// unneeded as renderScript is now on by default
-			name:   "script external in expression (renderScript: false)",
-			source: `<main>{<script src="./hello.js"></script>}`,
+			name:     "script external in expression (renderScript: false)",
+			source:   `<main>{<script src="./hello.js"></script>}`,
 			filename: "/src/pages/index.astro",
 		},
 		{
@@ -2071,6 +2071,10 @@ const meta = { title: 'My App' };
 		<h1>My App</h1>
 	</body>
 </html>`,
+		},
+		{
+			name:   "namespace is preserved when inside an expression",
+			source: `<svg>{<image />}</svg>`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- closes https://github.com/withastro/compiler/issues/1063

This PR adds the current `Namespace` to the expression Node.

When writing an expression inside foreign content (i.e. SVG) the astro compiler did not persist the namespace and therefore parsed the contained nodes in normal HTML mode. This lead to `<image>` tags incorrectly being transformed to `<img>` tags, but could also have caused other Problems.

## Testing

- added printer test to validate correct parsing of `{<image />}` inside svg

## Docs

bug fix only
