### PR TITLE
Fix extra space in fragment

### DIFF
--- a/.changeset/tiny-buses-hide.md
+++ b/.changeset/tiny-buses-hide.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": patch
 ---
 
-Fix extra space in fragment tag in TSX output
+Fixes a bug caused by having an extra space in the fragment tag in the TSX output

--- a/.changeset/tiny-buses-hide.md
+++ b/.changeset/tiny-buses-hide.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix extra space in fragment tag in TSX output

--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -706,10 +706,7 @@ declare const Astro: Readonly<import('astro').AstroGlobal<%s, typeof %s`, propsI
 		}
 	}
 	if len(n.Attr) == 0 {
-		endLoc = n.Loc[0].Start + len(n.Data) - 1
-	}
-	if endLoc == -1 {
-		endLoc = 0
+		endLoc = n.Loc[0].Start + len(n.Data)
 	}
 	isSelfClosing := false
 	hasLeadingSpace := false

--- a/packages/compiler/test/tsx/basic.ts
+++ b/packages/compiler/test/tsx/basic.ts
@@ -259,4 +259,15 @@ export default function __AstroComponent_(_props: Record<string, any>): any {}\n
 	assert.snapshot(code, output, 'expected code to match snapshot');
 });
 
+test('fragment with leading linebreak', async () => {
+	const input = `
+<>Test123</>`;
+	const output = `${TSXPrefix}<Fragment>
+<>Test123</>
+</Fragment>
+export default function __AstroComponent_(_props: Record<string, any>): any {}\n`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.snapshot(code, output, 'expected code to match snapshot');
+});
+
 test.run();


### PR DESCRIPTION
## Changes

- closes #1053
- issue was caused by a line break token immediately before the fragment ([repro](https://live-astro-compiler.vercel.app/?editor-state=WzMxLDEzOSw4LDAsMTU2LDgwLDE2MiwxMDMsMiwzLDEwMSwxNDUsNzcsNzksMTk1LDQ4LDEyLDEzNCwyNTUsNzQsMjAxLDEzMywyMDMsNTgsMTkwLDExMCwyMTEsNTIsMTA1LDIyNiw3NSw3MiwyOCwyMDgsOTAsOTYsNyw0Niw4OSwyMjYsNjUsNjgsMjM0LDY4LDE0MiwyMDMsMTI4LDEwNSwyNTUsMjksMTgzLDI5LDEwOCwxNzIsMTgzLDIxNiwyMzksMTU1LDIzMSwxODEsMTQ3LDE4MSw1MCw1MywxNywzMiw5NSwxMzQsNDIsNTgsMTUsMjQ0LDQsMTQ4LDkyLDY0LDUzLDgyLDIzMSwxOTUsMTc5LDIxMSwyMjUsMTMzLDI2LDQwLDE5LDQ0LDcyLDYxLDE1OCw3NiwyNDEsNDMsMTA3LDEzOCw1Miw2MiwxNTMsMTQwLDM5LDIyOSwxNTUsNzUsMjE3LDQyLDIwOCwxMjMsODMsMTkwLDIyNCwxODIsOTcsMywzNiw2MCwyMzAsODYsMTA0LDI1MSwxNjIsMjgsMjI5LDEyMSwxMTgsMjUzLDI1LDksODIsMTMxLDIwNiwyNDIsOTIsMjE4LDIzNSwzLDE5Miw3MCwxMzAsMjI4LDEwOCwxNTksNzMsMTk5LDgsODYsMTQxLDE1MCwyMTgsMzksMjQsMTY4LDE3MCwxMSw0NywxMzksMTg1LDI0LDE2MiwxNjYsNCwxNSwzMyw1NywxMTAsNzEsMjIwLDkwLDE1Miw1MiwxNjYsMTAxLDE2MCwyMzQsMTQsMjUsOCwxODEsMTI3LDE1NiwyMjEsMjAzLDIxLDI0MSw0NywxMDEsMzUsMjEyLDE0OSwwLDE3NiwyNDYsMTI2LDE2MCw4MCw3NiwyMTgsMTg3LDExMSwxNzYsNTUsNywyMDIsMzEsMTYzLDgsNTMsMjUsMTY4LDExNiwyMzYsMjI3LDE2NywxMzcsNDEsMjIwLDI1MCwxNzYsMjA4LDEyNiw3NCwxNzUsMTY5LDEzOSwyMTYsMTY5LDEzNiwxMjksNTMsNjcsNywxMDQsMjQ4LDEyNSw2NiwyNDMsMjAwLDIxOCwxMTIsOTUsMTUyLDY1LDE3MCw2MSwyMywzOCwyMDAsMjM0LDEzMywxNSw1OSwxOTksMTM1LDEzMSwyMTMsMjEsMTc2LDIyLDE1NiwyMzcsNzYsMTQ2LDE4NywyMTMsMTgsMTIwLDQ4LDEyLDE4MiwyNTIsMTY1LDE0OCwxMjIsMzMsNjcsMTgxLDIyMywxODEsMTY3LDIyLDI0MywxMjcsMjUzLDE4OSw3NiwxODAsNjQsMTMzLDMzLDIzLDM3LDE0MywxNjksMTM0LDIwNSwxNSw0MiwxMDUsMTQ1LDEzNiwxNCwyLDAsMF0%3D)), which caused `hasLeadingSpace` to be true
- removing the `- 1` in line 709 fixes the issue, however I could not find any reason why it was subtracting 1 in the first place. Possible I've missed something
- doing this doesn't seem to break any other test cases, but fixes the problem

## Testing

- added test case to check that fragments are printed properly if they are preceded by a line break

## Docs

bug fix only
