### PR TITLE
fix: parse `select` correctly when it contains HTML element

### DIFF
--- a/.changeset/large-mangos-look.md
+++ b/.changeset/large-mangos-look.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": patch
 ---
 
-fix: correctly parse select elements containing HTML, preventing elements from being incorrectly nested
+Fixes a bug where the compiler couldn't correctly parse `select` elements, preventing elements from being incorrectly nested

--- a/.changeset/large-mangos-look.md
+++ b/.changeset/large-mangos-look.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+fix: correctly parse select elements containing HTML, preventing elements from being incorrectly nested

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2319,6 +2319,8 @@ func inSelectIM(p *parser) bool {
 			p.resetInsertionMode()
 		case a.Template:
 			return inHeadIM(p)
+		default:
+			return inBodyIM(p)
 		}
 	case CommentToken:
 		p.addChild(&Node{

--- a/internal/printer/__printer_js__/select_with_2_options_containing_element.snap
+++ b/internal/printer/__printer_js__/select_with_2_options_containing_element.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/select_with_2_options_containing_element - 1]
+## Input
+
+```
+<select><option><span>Lemon</span></option><option><span>Lime</span></option></select>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<select><option><span>Lemon</span></option><option><span>Lime</span></option></select>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/select_with_2_options_containing_element_with_div_sibling.snap
+++ b/internal/printer/__printer_js__/select_with_2_options_containing_element_with_div_sibling.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/select_with_2_options_containing_element_with_div_sibling - 1]
+## Input
+
+```
+<select><option><span>Lemon</span></option><option><span>Lime</span></option></select><div>Orange</div>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<select><option><span>Lemon</span></option><option><span>Lime</span></option></select><div>Orange</div>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/select_with_option_containing_element.snap
+++ b/internal/printer/__printer_js__/select_with_option_containing_element.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/select_with_option_containing_element - 1]
+## Input
+
+```
+<select><option><span>Lemon</span></option></select>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<select><option><span>Lemon</span></option></select>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/select_with_option_containing_element_and_button_containing_selected_content.snap
+++ b/internal/printer/__printer_js__/select_with_option_containing_element_and_button_containing_selected_content.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/select_with_option_containing_element_and_button_containing_selected_content - 1]
+## Input
+
+```
+<select><button><selectedcontent></selectedcontent></button><option><span>Lemon</span></option></select>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<select><button><selectedcontent></selectedcontent></button><option><span>Lemon</span></option></select>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/select_with_option_containing_element_with_div_sibling.snap
+++ b/internal/printer/__printer_js__/select_with_option_containing_element_with_div_sibling.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/select_with_option_containing_element_with_div_sibling - 1]
+## Input
+
+```
+<select><option><span>Lemon</span></option></select><div>Orange</div>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<select><option><span>Lemon</span></option></select><div>Orange</div>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1234,19 +1234,19 @@ import { Container, Col, Row } from 'react-bootstrap';
 			source: `<body><Component><Fragment slot=named><div>Default</div><div>Named</div></Fragment></Component></body>`,
 		},
 		{
-			name:  "Fragment with await",
+			name:   "Fragment with await",
 			source: `<body><Fragment> { await Promise.resolve("Awaited") } </Fragment></body>`,
 		},
 		{
-			name:  "Fragment shorthand with await",
+			name:   "Fragment shorthand with await",
 			source: `<body><> { await Promise.resolve("Awaited") } </></body>`,
 		},
 		{
-			name:  "Fragment wrapping link with awaited href",
+			name:   "Fragment wrapping link with awaited href",
 			source: `<head><Fragment><link rel="preload" href={(await import('../fonts/some-font.woff2')).default} as="font" crossorigin /></Fragment></head>`,
 		},
 		{
-			name:  "Component with await",
+			name:   "Component with await",
 			source: `<body><Component> { await Promise.resolve("Awaited") } </Component></body>`,
 		},
 		{
@@ -2091,6 +2091,26 @@ const meta = { title: 'My App' };
 		{
 			name:   "namespace is preserved when inside an expression",
 			source: `<svg>{<image />}</svg>`,
+		},
+		{
+			name:   "select with option containing element",
+			source: `<select><option><span>Lemon</span></option></select>`,
+		},
+		{
+			name:   "select with 2 options containing element",
+			source: `<select><option><span>Lemon</span></option><option><span>Lime</span></option></select>`,
+		},
+		{
+			name:   "select with option containing element with div sibling",
+			source: `<select><option><span>Lemon</span></option></select><div>Orange</div>`,
+		},
+		{
+			name:   "select with 2 options containing element with div sibling",
+			source: `<select><option><span>Lemon</span></option><option><span>Lime</span></option></select><div>Orange</div>`,
+		},
+		{
+			name:   "select with option containing element and button containing selected content",
+			source: `<select><button><selectedcontent></selectedcontent></button><option><span>Lemon</span></option></select>`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #1069. Select was the problem not options, but that issue was prior to me looking at the WHATWG documentation and the Astro parser.

## Changes

- This fixes parsing of `select` elements when they contain HTML elements.
- The issue is specifically with how End Tags were being handle when `inSelect` mode
  - Only `option`, `optgroup`, `select`, and `template` end tags were being handled.
  - Others were unhandled, this PR just changes so that if the end tag is not any of the ones from the previous bullet point, the parser should treat the tag as if it were `inBody`.
  - Start tag handles it this way already.
- Previously the compiler could correctly produce a `select` containing a single HTML element, which I'll refer to as *X*, or a `select` containing an `option` containing a single *X*.
- However if a HTML element, *Y*, is added as the next sibling to either the `select`, `option`, or *X*, *Y* will cannibalized by *X* becoming its child. Each subsequent element(child or sibling) will have whatever element was preceding it as its parent.

ie:
```astro
<select id="select-span-sibling">
  <span>Lemon</span>
  <option>Lime</option>
</select>
<div><span>Orange</span></div>
<div>Melon</div>
```
produces (formatted for readability):
```html
<select id="select-span-sibling">
  <span>
    Lemon
    <option>
      Lime
    </option>
    <div>
      <span>
        Orange
        <div>
          Melon
        </div>
      </span>
    </div>
  </span>
</select>
```
- This change fixes it so that the previous example now produces the expected output:
```html
<select id="select-span-sibling">
  <span>Lemon</span> 
  <option>Lime</option>
</select>
<div><span>Orange</span></div>
<div>Melon</div>
```
- I briefly tested the compiled WASM in a local Astro project and the generated HTML from the `.astro` was matching the expected/"correct" output.
- I don't know if there are additional changes needed to be made to handle special cases or better match the spec or if this somehow broke how people were previously using it, but I believe this PR produces a more correct output than before.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
I wasn't sure where best to do testing so I just added to `test_printer` where I could most immediately observe outputs. Additionally I wasn't sure what was the appropriate amount of tests I should add or how verbose to be with the naming, so I added only a few to cover some limited scenarios and it's far from exhaustive. I can add, remove, or change them if it is desired. 

## Docs

I did not change any documentation as I believe it's only a bugfix.
<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
