### PR TITLE
feat: head propagation for server islands

### DIFF
--- a/.changeset/soft-adults-switch.md
+++ b/.changeset/soft-adults-switch.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": minor
+---
+
+Add head propagation metadata to server islands

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -18,6 +18,7 @@ const TRANSITION_NAME = "transition:name"
 const TRANSITION_PERSIST = "transition:persist"
 const DATA_ASTRO_RELOAD = "data-astro-reload"
 const TRANSITION_PERSIST_PROPS = "transition:persist-props"
+const SERVER_DEFER = "server:defer"
 
 type TransformOptions struct {
 	Scope                   string
@@ -51,7 +52,7 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		if shouldScope {
 			ScopeElement(n, opts)
 		}
-		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) || HasAttr(n, TRANSITION_PERSIST) {
+		if HasAttr(n, TRANSITION_ANIMATE) || HasAttr(n, TRANSITION_NAME) || HasAttr(n, TRANSITION_PERSIST) || HasAttr(n, SERVER_DEFER) {
 			doc.Transition = true
 			doc.HeadPropagation = true
 			getOrCreateTransitionScope(n, &opts, i)

--- a/packages/compiler/test/server-islands/meta.ts
+++ b/packages/compiler/test/server-islands/meta.ts
@@ -27,6 +27,10 @@ test('component metadata added', () => {
 	assert.equal(result.serverComponents.length, 2);
 });
 
+test('component should contain head propagation', () => {
+	assert.equal(result.propagation, true);
+});
+
 test('path resolved to the filename', () => {
 	const m = result.serverComponents[0];
 	assert.ok(m.specifier !== m.resolvedPath);


### PR DESCRIPTION
## Changes

This PR adds head propagation for server island directives.

We need head propagation because the server islands generate some script during the rendering phase, and if we want to support CSP, we need to hash the rendered script and then render the meta tag inside the `head` element.

This is exactly the same thing that we already do with view transitions.

## Testing

Added a new test

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
