### PR TITLE
fix: export w/ curly brace on next line, extra curly brace before def

### DIFF
--- a/.changeset/fast-lemons-pay.md
+++ b/.changeset/fast-lemons-pay.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Improves detection of function body opening curly brace for exported functions.

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -263,6 +263,116 @@ const b = await fetch()`,
 }`,
 		},
 		{
+			name: "getStaticPaths with curly brace on next line and destructured props",
+			source: `import { fn } from "package";
+export async function getStaticPaths({ paginate })
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export async function getStaticPaths({ paginate })
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and param definition type in curly braces",
+			source: `import { fn } from "package";
+export async function getStaticPaths(input: { paginate: any })
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export async function getStaticPaths(input: { paginate: any })
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and param definition type in square braces",
+			source: `import { fn } from "package";
+export async function getStaticPaths([{ stuff }])
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export async function getStaticPaths([{ stuff }])
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and type specified with square braces 1",
+			source: `import { fn } from "package";
+export const getStaticPaths: () => { params: any }[]
+= () =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export const getStaticPaths: () => { params: any }[]
+= () =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and type specified with square braces 2",
+			source: `import { fn } from "package";
+export const getStaticPaths: () => { params: any }[] =
+() =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export const getStaticPaths: () => { params: any }[] =
+() =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and type specified with square braces 3",
+			source: `import { fn } from "package";
+export const getStaticPaths: () => { params: any }[] = ()
+=>
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export const getStaticPaths: () => { params: any }[] = ()
+=>
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and type specified with square braces 4",
+			source: `import { fn } from "package";
+export const getStaticPaths: () => { params: any }[] = () =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export const getStaticPaths: () => { params: any }[] = () =>
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
+			name: "getStaticPaths with curly brace on next line and definition specified by anonymous function with destructured parameter",
+			source: `import { fn } from "package";
+export const getStaticPaths = function({ paginate })
+{
+	const content = Astro.fetchContent('**/*.md');
+}
+const b = await fetch()`,
+			want: `export const getStaticPaths = function({ paginate })
+{
+	const content = Astro.fetchContent('**/*.md');
+}`,
+		},
+		{
 			name: "getStaticPaths with comments",
 			source: `import { fn } from "package";
 export async function getStaticPaths() {

--- a/packages/compiler/test/basic/get-static-paths.ts
+++ b/packages/compiler/test/basic/get-static-paths.ts
@@ -25,6 +25,29 @@ export async function getStaticPaths()
 	);
 });
 
+test('getStaticPaths with braces on newline and destructured params', async () => {
+	const FIXTURE = `---
+import A from './A.astro';
+export async function getStaticPaths({ paginate })
+{
+  return [
+    { params: { id: '1' } },
+    { params: { id: '2' } },
+    { params: { id: '3' } }
+  ];
+}
+---
+
+<div></div>
+`;
+	const result = await transform(FIXTURE);
+	assert.match(
+		result.code,
+		'export async function getStaticPaths({ paginate })\n{',
+		'Expected output to contain getStaticPaths output'
+	);
+});
+
 test('getStaticPaths as const without braces', async () => {
 	const FIXTURE = `---
 import A from './A.astro';


### PR DESCRIPTION
## Changes
Closes https://github.com/withastro/astro/issues/13790, where a curly brace which is not the start of a function body is incorrectly classified as such.

This is just a patch for the case reported in this issue and a few other ones, such as:
- A curly brace appearing on the parameter type i.e. `export function getStaticPaths(input: { paginate: any })`
- A curly brace in the type definition of an arrow function i.e. `export const getStaticPaths: () => { params: any }[]`

There may be an additional case that I missed, please let me know if you can think of one!

### Note
Though I did not do this in this PR to minimize the surface area of the changes, in my opinion it would be worthwhile to pull in a full-fledged TS parser and operate on the AST for this export hoisting use case. Perhaps when the new TS Go compiler from Microsoft is stable the parser can be taken from there :shrug:

## Testing

Tests added to appropriate files

## Docs

Bug fix, no changes to public API