### PR TITLE
Introduce asynchronous walk function

### DIFF
--- a/.changeset/tough-months-melt.md
+++ b/.changeset/tough-months-melt.md
@@ -2,4 +2,6 @@
 "@astrojs/compiler": minor
 ---
 
-Adds an `walkAsync` utility function that returns a Promise from the tree traversal process. Unlike the existing `walk` function which doesn't provide a way to wait for traversal completion, `walkAsync` allows consumers to `await` the full traversal of the AST
+Adds a `walkAsync` utility function that returns a Promise from the tree traversal process.
+
+Unlike the existing `walk` function which doesn't provide a way to wait for traversal completion, `walkAsync` allows consumers to `await` the full traversal of the AST.

--- a/.changeset/tough-months-melt.md
+++ b/.changeset/tough-months-melt.md
@@ -2,4 +2,4 @@
 "@astrojs/compiler": minor
 ---
 
-Add async walk utility, walkAsync
+Adds an `walkAsync` utility function that returns a Promise from the tree traversal process. Unlike the existing `walk` function which doesn't provide a way to wait for traversal completion, `walkAsync` allows consumers to `await` the full traversal of the AST

--- a/.changeset/tough-months-melt.md
+++ b/.changeset/tough-months-melt.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": minor
+---
+
+Add async walk utility, walkAsync

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -37,11 +37,11 @@ The Astro compiler can emit an AST using the `parse` method.
 
 - Position data is currently incomplete and in some cases incorrect. We're working on it!
 - A `TextNode` can represent both HTML `text` and JavaScript/TypeScript source code.
-- The `@astrojs/compiler/utils` entrypoint exposes a `walk` function that can be used to traverse the AST. It also exposes the `is` helper which can be used as guards to derive the proper types for each `node`.
+- The `@astrojs/compiler/utils` entrypoint exposes `walk` and `walkAsync` functions that can be used to traverse the AST. It also exposes the `is` helper which can be used as guards to derive the proper types for each `node`.
 
 ```js
 import { parse } from "@astrojs/compiler";
-import { walk, is } from "@astrojs/compiler/utils";
+import { walk, walkAsync, is } from "@astrojs/compiler/utils";
 
 const result = await parse(source, {
   position: false, // defaults to `true`
@@ -51,6 +51,12 @@ walk(result.ast, (node) => {
   // `tag` nodes are `element` | `custom-element` | `component`
   if (is.tag(node)) {
     console.log(node.name);
+  }
+});
+
+await walkAsync(result.ast, async (node) => {
+  if (is.tag(node)) {
+    node.value = await expensiveCalculation(node)
   }
 });
 ```

--- a/packages/compiler/src/browser/utils.ts
+++ b/packages/compiler/src/browser/utils.ts
@@ -71,6 +71,11 @@ export function walk(node: ParentNode, callback: Visitor): void {
 	walker.visit(node);
 }
 
+export function walkAsync(node: ParentNode, callback: Visitor): Promise<void> {
+	const walker = new Walker(callback);
+	return walker.visit(node);
+}
+
 function serializeAttributes(node: TagLikeNode): string {
 	let output = '';
 	for (const attr of node.attributes) {

--- a/packages/compiler/src/node/utils.ts
+++ b/packages/compiler/src/node/utils.ts
@@ -71,6 +71,11 @@ export function walk(node: ParentNode, callback: Visitor): void {
 	walker.visit(node);
 }
 
+export function walkAsync(node: ParentNode, callback: Visitor): Promise<void> {
+	const walker = new Walker(callback);
+	return walker.visit(node);
+}
+
 function serializeAttributes(node: TagLikeNode): string {
 	let output = '';
 	for (const attr of node.attributes) {


### PR DESCRIPTION
## Changes

- Adds `walkAsync`, which returns the already-async `Walker.visit`
- Inspired by https://github.com/MoustaphaDev/astro-default-prerender/blob/139e1574f621029293a53db8d8e3999be170be70/packages/integration/src/index.ts#L129-L131

## Testing

I did not see any tests for the base `walk` utilility.

## Docs

Yes, minor tweaks to the utils section of the Readme, with an example of when this would be useful.
