### PR TITLE
Fix LSP warnings and navigation on JS-related code

### DIFF
--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -1,3 +1,5 @@
+//go:build js && wasm
+
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/withastro/compiler
 go 1.21
 
 require (
+	github.com/gkampitakis/go-snaps v0.5.2
 	github.com/google/go-cmp v0.5.9
 	github.com/iancoleman/strcase v0.2.0
 	github.com/lithammer/dedent v1.1.0
@@ -15,7 +16,6 @@ require (
 require (
 	github.com/gkampitakis/ciinfo v0.3.0 // indirect
 	github.com/gkampitakis/go-diff v1.3.2 // indirect
-	github.com/gkampitakis/go-snaps v0.5.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/maruel/natural v1.1.1 // indirect

--- a/internal_wasm/utils/utils.go
+++ b/internal_wasm/utils/utils.go
@@ -1,3 +1,5 @@
+//go:build js && wasm
+
 package wasm_utils
 
 import (


### PR DESCRIPTION
## Changes

Mark files that rely on `syscall/js` with build tags targeting JS and WASM, the same as the `syscall/js` package itself.

GoPls shows this warning when working on the project locally so things get annoying with tools that aim to keep the project always green like preventing commits in a broken state without extra confirmation jumping to definitions to explore the codebase since it consider those references broken.

<img width="1382" height="158" alt="image" src="https://github.com/user-attachments/assets/51a8b2ef-260e-4393-932a-57edeb179806" />

Which then makes GoPls consider all the imports that are JS-only as exporting nothing:

<img width="1512" height="110" alt="image" src="https://github.com/user-attachments/assets/ad33cf09-4f5b-4cfa-92a5-03198eb608d3" />

Additionally, `go.mod` had a dependency marked as indirect but it is actually used directly by our tests. So just running `go mod tidy` causes the changes committed there.