### PR TITLE
feat: remove experimentalScriptOrder option

### DIFF
--- a/.changeset/silver-deers-buy.md
+++ b/.changeset/silver-deers-buy.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": major
+---
+
+Removes `experimentalScriptOrder` from `TransformOptions`. It is now the default and only behavior

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -140,11 +140,6 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		renderScript = true
 	}
 
-	experimentalScriptOrder := false
-	if jsBool(options.Get("experimentalScriptOrder")) {
-		experimentalScriptOrder = true
-	}
-
 	return transform.TransformOptions{
 		Filename:                filename,
 		NormalizedFilename:      normalizedFilename,
@@ -159,7 +154,6 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 		TransitionsAnimationURL: transitionsAnimationURL,
 		AnnotateSourceFile:      annotateSourceFile,
 		RenderScript:            renderScript,
-		ExperimentalScriptOrder: experimentalScriptOrder,
 	}
 }
 

--- a/internal/printer/printer_css_test.go
+++ b/internal/printer/printer_css_test.go
@@ -87,7 +87,7 @@ func TestPrinterCSS(t *testing.T) {
 			}
 
 			hash := astro.HashString(code)
-			opts := transform.TransformOptions{Scope: hash, ScopedStyleStrategy: scopedStyleStrategy, ExperimentalScriptOrder: true}
+			opts := transform.TransformOptions{Scope: hash, ScopedStyleStrategy: scopedStyleStrategy}
 			transform.ExtractStyles(doc, &opts)
 			transform.Transform(doc, opts, handler.NewHandler(code, "/test.astro")) // note: we want to test Transform in context here, but more advanced cases could be tested separately
 			result := PrintCSS(code, doc, transform.TransformOptions{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -2109,7 +2109,6 @@ import Analytics from '../components/Analytics.astro';
 			transformOptions := transform.TransformOptions{
 				Scope:                   hash,
 				RenderScript:            tt.transformOptions.RenderScript,
-				ExperimentalScriptOrder: true,
 			}
 			transform.ExtractStyles(doc, &transformOptions)
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -35,7 +35,6 @@ type TransformOptions struct {
 	PreprocessStyle         interface{}
 	AnnotateSourceFile      bool
 	RenderScript            bool
-	ExperimentalScriptOrder bool
 }
 
 func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astro.Node {
@@ -128,11 +127,7 @@ func ExtractStyles(doc *astro.Node, opts *TransformOptions) {
 				return
 			}
 			// append node to maintain authored order
-			if opts.ExperimentalScriptOrder {
-				doc.Styles = append(doc.Styles, n)
-			} else {
-				doc.Styles = append([]*astro.Node{n}, doc.Styles...)
-			}
+			doc.Styles = append(doc.Styles, n)
 		}
 	})
 	// Important! Remove styles from original location *after* walking the doc
@@ -443,11 +438,7 @@ func ExtractScript(doc *astro.Node, n *astro.Node, opts *TransformOptions, h *ha
 
 			// append node to maintain authored order
 			if shouldAdd {
-				if opts.ExperimentalScriptOrder {
-					doc.Scripts = append(doc.Scripts, n)
-				} else {
-					doc.Scripts = append([]*astro.Node{n}, doc.Scripts...)
-				}
+				doc.Scripts = append(doc.Scripts, n)
 				n.HandledScript = true
 			}
 		} else {

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -65,7 +65,6 @@ export interface TransformOptions {
 	 * @experimental
 	 */
 	renderScript?: boolean;
-	experimentalScriptOrder?: boolean;
 }
 
 export type ConvertToTSXOptions = Pick<

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -7,9 +7,6 @@ test('outputs scripts in expected order', async () => {
 		`
     <script>console.log(1)</script>
     <script>console.log(2)</script>`,
-		{
-			experimentalScriptOrder: true,
-		}
 	);
 
 	const scripts = result.scripts;

--- a/packages/compiler/test/scripts/order.ts
+++ b/packages/compiler/test/scripts/order.ts
@@ -6,7 +6,7 @@ test('outputs scripts in expected order', async () => {
 	const result = await transform(
 		`
     <script>console.log(1)</script>
-    <script>console.log(2)</script>`,
+    <script>console.log(2)</script>`
 	);
 
 	const scripts = result.scripts;

--- a/packages/compiler/test/styles/sass.ts
+++ b/packages/compiler/test/styles/sass.ts
@@ -33,7 +33,6 @@ test.before(async () => {
 	result = await transform(FIXTURE, {
 		sourcemap: true,
 		preprocessStyle,
-		experimentalScriptOrder: true,
 	});
 });
 


### PR DESCRIPTION
## Changes

- It is now the default

## Testing

Should pass

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

Changeset

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
