### PR TITLE
fix: infer numbers as strings in `Astro.params`

### DIFF
--- a/internal/printer/print-to-tsx.go
+++ b/internal/printer/print-to-tsx.go
@@ -395,15 +395,13 @@ func renderTsx(p *printer, n *Node, o *TSXOptions) {
 
 		p.print(fmt.Sprintf("export default function %s%s(_props: %s%s): any {}\n", componentName, props.Statement, propsIdent, props.Generics))
 		if hasGetStaticPaths {
-			// Convert a string|number|undefined type to a string|undefined type
-			p.println("type ASTRO__STRINGIFY_VALUE<T> = Extract<T, string | undefined> | T extends number ? string : never")
-			// Convert a Record<string, string|number|undefined> type to a Record<string, string|undefined> type
-			p.println("type ASTRO__STRINGIFY_PARAMS<T> = T extends Record<string, any> ? { [K in keyof T]: ASTRO__STRINGIFY_VALUE<T[K]> } : T")
-			p.printf(`type ASTRO__ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+			p.println(`type ASTRO__ArrayElement<ArrayType extends readonly unknown[]> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
 type ASTRO__Flattened<T> = T extends Array<infer U> ? ASTRO__Flattened<U> : T;
 type ASTRO__InferredGetStaticPath = ASTRO__Flattened<ASTRO__ArrayElement<Awaited<ReturnType<typeof getStaticPaths>>>>;
 type ASTRO__MergeUnion<T, K extends PropertyKey = T extends unknown ? keyof T : never> = T extends unknown ? T & { [P in Exclude<K, keyof T>]?: never } extends infer O ? { [P in keyof O]: O[P] } : never : never;
-type ASTRO__Get<T, K> = T extends undefined ? undefined : K extends keyof T ? T[K] : never;%s`, "\n")
+type ASTRO__STRINGIFY_VALUE<T> = Extract<T, string | undefined> | T extends number ? string : never
+type ASTRO__STRINGIFY_PARAMS<T> = T extends Record<string, any> ? { [K in keyof T]: ASTRO__STRINGIFY_VALUE<T[K]> } : T;
+type ASTRO__Get<T, K> = T extends undefined ? undefined : K extends keyof T ? T[K] : never;`)
 		}
 
 		if propsIdent != "Record<string, any>" {


### PR DESCRIPTION
## Changes

- What does this change?
- Be short and concise. Bullet points can help!
- Before/after screenshots can be helpful as well.

All values in `Astro.params` must be undefined or string. Astro allows numeric returned value from `getStaticPaths()` since https://github.com/withastro/astro/pull/3087, and those numeric values will be converted into string during runtime [here](https://github.com/ocavue/astro/blob/23f28016a2e1063b3d95e3913f47821bb450b6c3/packages/astro/src/core/routing/params.ts#L17C64-L17C78). 


This PR updates the generate tsx code to match the runtime behaviors.  

## Testing

I ran `go test -v ./internal/...` locally.

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
