### PR TITLE
Fix: semantic props order override

### DIFF
--- a/.changeset/lucky-cloths-own.md
+++ b/.changeset/lucky-cloths-own.md
@@ -1,0 +1,10 @@
+---
+"@astrojs/compiler": patch
+---
+
+Use JSX/TSX style attribute deduplication
+
+Changed compiler to use the last occurrence of duplicate props instead of first, matching standard JSX semantics where later values override earlier ones. This ensures correct prop precedence for patterns like `<div {...props} className="override" />`.
+
+Before: <div a="1" a="2" /> → <div a="1" />
+After: <div a="1" a="2" /> → <div a="2" />

--- a/internal/printer/__printer_js__/complex_duplicate_scenario.snap
+++ b/internal/printer/__printer_js__/complex_duplicate_scenario.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/complex_duplicate_scenario - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class="a" id="1" class="b" title="x" id="2" class="c"></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div title="x" id="2" class="c"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_aria_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_aria_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_aria_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<button aria-label="first" aria-label="second"></button>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<button aria-label="second"></button>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_attributes_on_components.snap
+++ b/internal/printer/__printer_js__/duplicate_attributes_on_components.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_attributes_on_components - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<Component prop="a" prop="b"></Component>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$renderComponent($$result,'Component',Component,{"prop":"b"})}`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_attributes_with_expressions_and_strings.snap
+++ b/internal/printer/__printer_js__/duplicate_attributes_with_expressions_and_strings.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_attributes_with_expressions_and_strings - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div data-value="static" data-value={dynamic}></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute(dynamic, "data-value")}></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_data_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_data_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_data_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div data-test="a" data-test="b"></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div data-test="b"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_empty_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_empty_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_empty_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div disabled disabled></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div disabled></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_expression_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_expression_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_expression_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class={foo} class={bar}></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute(bar, "class")}></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_namespaced_attributes__SVG_.snap
+++ b/internal/printer/__printer_js__/duplicate_namespaced_attributes__SVG_.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_namespaced_attributes_(SVG) - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<svg xlink:href="a" xlink:href="b"></svg>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<svg xlink:href="b"></svg>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_quoted_attributes_-_last_wins.snap
+++ b/internal/printer/__printer_js__/duplicate_quoted_attributes_-_last_wins.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_quoted_attributes_-_last_wins - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class="foo" class="bar"></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div class="bar"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_shorthand_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_shorthand_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_shorthand_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {class} {class}></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute(class, "class")}></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/duplicate_template_literal_attributes.snap
+++ b/internal/printer/__printer_js__/duplicate_template_literal_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/duplicate_template_literal_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class={`${a}`} class={`${b}`}></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute(`${b}`, "class")}></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/interleaved_duplicates_preserve_order.snap
+++ b/internal/printer/__printer_js__/interleaved_duplicates_preserve_order.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/interleaved_duplicates_preserve_order - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div a="1" b="2" a="3" c="4"></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div b="2" a="3" c="4"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/mixed_attribute_types_for_same_key.snap
+++ b/internal/printer/__printer_js__/mixed_attribute_types_for_same_key.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/mixed_attribute_types_for_same_key - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class="foo" class={bar}></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute(bar, "class")}></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/multiple_duplicates_-_last_of_many_wins.snap
+++ b/internal/printer/__printer_js__/multiple_duplicates_-_last_of_many_wins.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/multiple_duplicates_-_last_of_many_wins - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div id="a" id="b" id="c"></div>
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div id="c"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/multiple_spreads_with_overrides.snap
+++ b/internal/printer/__printer_js__/multiple_spreads_with_overrides.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/multiple_spreads_with_overrides - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {...props1} class="middle" {...props2} id="last" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(props1,undefined,undefined,["class","id"])} class="middle"${$$spreadAttributes(props2,undefined,undefined,["id"])} id="last"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_before_and_after_regular_attributes.snap
+++ b/internal/printer/__printer_js__/spread_before_and_after_regular_attributes.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_before_and_after_regular_attributes - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div class="before" {...props} title="after" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div class="before"${$$spreadAttributes(props,undefined,undefined,["title"])} title="after"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_only_class_override.snap
+++ b/internal/printer/__printer_js__/spread_only_class_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_only_class_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {...Astro.props} class="my-class" />
 ```
 
 ## Output
@@ -38,7 +38,7 @@ const $$Component = $$createComponent(($$result, $$props, $$slots) => {
 const Astro = $$result.createAstro($$Astro, $$props, $$slots);
 Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,undefined,["class"])} class="my-class"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_aria_attribute_override.snap
+++ b/internal/printer/__printer_js__/spread_with_aria_attribute_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_aria_attribute_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<button {...props} aria-label="Custom Label" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<button${$$spreadAttributes(props,undefined,undefined,["aria-label"])} aria-label="Custom Label"></button>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_attribute_override.snap
+++ b/internal/printer/__printer_js__/spread_with_attribute_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_attribute_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {...props} class="override" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(props,undefined,undefined,["class"])} class="override"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_data_attribute_override.snap
+++ b/internal/printer/__printer_js__/spread_with_data_attribute_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_data_attribute_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {...props} data-testid="my-test-id" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(props,undefined,undefined,["data-testid"])} data-testid="my-test-id"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_multiple_attribute_overrides.snap
+++ b/internal/printer/__printer_js__/spread_with_multiple_attribute_overrides.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_multiple_attribute_overrides - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<div {...props} class="override" id="fixed" data-test="value" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(props,undefined,undefined,["class","id","data-test"])} class="override" id="fixed" data-test="value"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_namespace_attribute_override.snap
+++ b/internal/printer/__printer_js__/spread_with_namespace_attribute_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_namespace_attribute_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<svg {...props} xmlns:xlink="http://www.w3.org/1999/xlink" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<svg${$$spreadAttributes(props,undefined,undefined,["xmlns:xlink"])} xmlns:xlink="http://www.w3.org/1999/xlink"></svg>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/__printer_js__/spread_with_scoped_styles_and_attribute_override.snap
+++ b/internal/printer/__printer_js__/spread_with_scoped_styles_and_attribute_override.snap
@@ -1,9 +1,9 @@
 
-[TestPrinter/spread_with_style_but_no_explicit_class - 1]
+[TestPrinter/spread_with_scoped_styles_and_attribute_override - 1]
 ## Input
 
 ```
-<style>div { color: red; }</style><div {...Astro.props} />
+<style>div { color: red; }</style><div {...props} class="override" />
 ```
 
 ## Output
@@ -32,13 +32,9 @@ import {
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
 
-const $$Astro = $$createAstro('https://astro.build');
-const Astro = $$Astro;
 const $$Component = $$createComponent(($$result, $$props, $$slots) => {
-const Astro = $$result.createAstro($$Astro, $$props, $$slots);
-Astro.self = $$Component;
 
-return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(Astro.props,undefined,{"class":"astro-XXXX"}></div>`;
+return $$render`${$$maybeRenderHead($$result)}<div${$$spreadAttributes(props,undefined,undefined,["class"])} class="override astro-mli5oekz"></div>`;
 }, undefined, undefined);
 export default $$Component;
 ```

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1184,6 +1184,98 @@ import { Container, Col, Row } from 'react-bootstrap';
 			source: `<style>div { color: red; }</style><div {...Astro.props} />`,
 		},
 		{
+			name:   "spread with attribute override",
+			source: `<div {...props} class="override" />`,
+		},
+		{
+			name:   "spread with multiple attribute overrides",
+			source: `<div {...props} class="override" id="fixed" data-test="value" />`,
+		},
+		{
+			name:   "multiple spreads with overrides",
+			source: `<div {...props1} class="middle" {...props2} id="last" />`,
+		},
+		{
+			name:   "spread with namespace attribute override",
+			source: `<svg {...props} xmlns:xlink="http://www.w3.org/1999/xlink" />`,
+		},
+		{
+			name:   "spread before and after regular attributes",
+			source: `<div class="before" {...props} title="after" />`,
+		},
+		{
+			name:   "spread with scoped styles and attribute override",
+			source: `<style>div { color: red; }</style><div {...props} class="override" />`,
+		},
+		{
+			name:   "spread only class override",
+			source: `<div {...Astro.props} class="my-class" />`,
+		},
+		{
+			name:   "spread with aria attribute override",
+			source: `<button {...props} aria-label="Custom Label" />`,
+		},
+		{
+			name:   "spread with data attribute override",
+			source: `<div {...props} data-testid="my-test-id" />`,
+		},
+		{
+			name:   "duplicate quoted attributes - last wins",
+			source: `<div class="foo" class="bar"></div>`,
+		},
+		{
+			name:   "multiple duplicates - last of many wins",
+			source: `<div id="a" id="b" id="c"></div>`,
+		},
+		{
+			name:   "duplicate expression attributes",
+			source: `<div class={foo} class={bar}></div>`,
+		},
+		{
+			name:   "duplicate empty attributes",
+			source: `<div disabled disabled></div>`,
+		},
+		{
+			name:   "duplicate template literal attributes",
+			source: `<div class={` + BACKTICK + `${a}` + BACKTICK + `} class={` + BACKTICK + `${b}` + BACKTICK + `}></div>`,
+		},
+		{
+			name:   "mixed attribute types for same key",
+			source: `<div class="foo" class={bar}></div>`,
+		},
+		{
+			name:   "interleaved duplicates preserve order",
+			source: `<div a="1" b="2" a="3" c="4"></div>`,
+		},
+		{
+			name:   "duplicate namespaced attributes (SVG)",
+			source: `<svg xlink:href="a" xlink:href="b"></svg>`,
+		},
+		{
+			name:   "duplicate attributes on components",
+			source: `<Component prop="a" prop="b"></Component>`,
+		},
+		{
+			name:   "duplicate shorthand attributes",
+			source: `<div {class} {class}></div>`,
+		},
+		{
+			name:   "duplicate data attributes",
+			source: `<div data-test="a" data-test="b"></div>`,
+		},
+		{
+			name:   "duplicate aria attributes",
+			source: `<button aria-label="first" aria-label="second"></button>`,
+		},
+		{
+			name:   "complex duplicate scenario",
+			source: `<div class="a" id="1" class="b" title="x" id="2" class="c"></div>`,
+		},
+		{
+			name:   "duplicate attributes with expressions and strings",
+			source: `<div data-value="static" data-value={dynamic}></div>`,
+		},
+		{
 			name:   "Fragment",
 			source: `<body><Fragment><div>Default</div><div>Named</div></Fragment></body>`,
 		},

--- a/packages/compiler/test/parse/duplicate-attributes.ts
+++ b/packages/compiler/test/parse/duplicate-attributes.ts
@@ -1,0 +1,94 @@
+import { parse } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import type { ElementNode } from '../../types.js';
+
+test('duplicate attributes in AST - basic', async () => {
+	const input = `<div class="foo" class="bar"></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 1, 'Should have only 1 attribute');
+	assert.equal(element.attributes[0].name, 'class', 'Attribute should be "class"');
+	assert.equal(element.attributes[0].value, 'bar', 'Value should be "bar" (last wins)');
+});
+
+test('duplicate attributes in AST - multiple duplicates', async () => {
+	const input = `<div id="a" id="b" id="c"></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 1, 'Should have only 1 attribute');
+	assert.equal(element.attributes[0].name, 'id', 'Attribute should be "id"');
+	assert.equal(element.attributes[0].value, 'c', 'Value should be "c" (last of many wins)');
+});
+
+test('duplicate attributes in AST - interleaved', async () => {
+	const input = `<div a="1" b="2" a="3" c="4"></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 3, 'Should have 3 unique attributes');
+	assert.equal(element.attributes[0].name, 'b', 'First should be "b"');
+	assert.equal(element.attributes[0].value, '2');
+	assert.equal(element.attributes[1].name, 'a', 'Second should be "a"');
+	assert.equal(element.attributes[1].value, '3', 'Value should be "3" (last occurrence)');
+	assert.equal(element.attributes[2].name, 'c', 'Third should be "c"');
+	assert.equal(element.attributes[2].value, '4');
+});
+
+test('duplicate attributes with spread - spread is kept', async () => {
+	const input = `<div class="foo" {...props} class="bar"></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 2, 'Should have 2 items (spread + class)');
+	assert.equal(element.attributes[0].kind, 'spread', 'First should be spread');
+	assert.equal(element.attributes[1].name, 'class', 'Second should be "class"');
+	assert.equal(element.attributes[1].value, 'bar', 'Value should be "bar"');
+});
+
+test('duplicate namespaced attributes', async () => {
+	const input = `<svg xlink:href="a" xlink:href="b"></svg>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 1, 'Should have only 1 attribute');
+	assert.equal(element.attributes[0].name, 'xlink:href', 'Attribute should be "xlink:href"');
+	assert.equal(element.attributes[0].value, 'b', 'Value should be "b" (last wins)');
+});
+
+test('duplicate empty attributes', async () => {
+	const input = `<div disabled disabled></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 1, 'Should have only 1 attribute');
+	assert.equal(element.attributes[0].name, 'disabled', 'Attribute should be "disabled"');
+	assert.equal(element.attributes[0].kind, 'empty', 'Should be empty attribute');
+});
+
+test('case sensitivity - different cases kept separate', async () => {
+	const input = `<div class="foo" CLASS="bar"></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 2, 'Should have 2 attributes (case-sensitive)');
+	assert.equal(element.attributes[0].name, 'class');
+	assert.equal(element.attributes[0].value, 'foo');
+	assert.equal(element.attributes[1].name, 'CLASS');
+	assert.equal(element.attributes[1].value, 'bar');
+});
+
+test('duplicate expression attributes', async () => {
+	const input = `<div class={foo} class={bar}></div>`;
+	const { ast } = await parse(input);
+	const element = ast.children[0] as ElementNode;
+
+	assert.equal(element.attributes.length, 1, 'Should have only 1 attribute');
+	assert.equal(element.attributes[0].name, 'class');
+	assert.equal(element.attributes[0].kind, 'expression');
+	assert.equal(element.attributes[0].value, 'bar', 'Value should be "bar" (last wins)');
+});
+
+test.run();

--- a/packages/compiler/test/parse/duplicate-attributes.ts
+++ b/packages/compiler/test/parse/duplicate-attributes.ts
@@ -59,7 +59,7 @@ test('duplicate namespaced attributes', async () => {
 });
 
 test('duplicate empty attributes', async () => {
-	const input = `<div disabled disabled></div>`;
+	const input = '<div disabled disabled></div>';
 	const { ast } = await parse(input);
 	const element = ast.children[0] as ElementNode;
 
@@ -81,7 +81,7 @@ test('case sensitivity - different cases kept separate', async () => {
 });
 
 test('duplicate expression attributes', async () => {
-	const input = `<div class={foo} class={bar}></div>`;
+	const input = '<div class={foo} class={bar}></div>';
 	const { ast } = await parse(input);
 	const element = ast.children[0] as ElementNode;
 

--- a/packages/compiler/test/tsx/duplicate-attributes.ts
+++ b/packages/compiler/test/tsx/duplicate-attributes.ts
@@ -18,14 +18,14 @@ test('multiple duplicates - last of many wins', async () => {
 });
 
 test('duplicate expression attributes', async () => {
-	const input = `<div class={foo} class={bar}></div>`;
+	const input = '<div class={foo} class={bar}></div>';
 	const { code } = await convertToTSX(input, { sourcemap: 'external' });
 	assert.match(code, 'class={bar}');
 	assert.not.match(code, 'class={foo}');
 });
 
 test('duplicate empty attributes', async () => {
-	const input = `<div disabled disabled></div>`;
+	const input = '<div disabled disabled></div>';
 	const { code } = await convertToTSX(input, { sourcemap: 'external' });
 	// Should only appear once
 	const matches = code.match(/disabled/g);
@@ -125,7 +125,7 @@ test('spread before all named attrs', async () => {
 });
 
 test('spread with no conflicts', async () => {
-	const input = `<div {...props}></div>`;
+	const input = '<div {...props}></div>';
 	const { code } = await convertToTSX(input, { sourcemap: 'external' });
 	assert.match(code, '{...props}');
 });

--- a/packages/compiler/test/tsx/duplicate-attributes.ts
+++ b/packages/compiler/test/tsx/duplicate-attributes.ts
@@ -1,0 +1,133 @@
+import { convertToTSX } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+test('basic duplicate quoted attributes - last wins', async () => {
+	const input = `<div class="foo" class="bar"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'class="bar"');
+	assert.not.match(code, 'class="foo"');
+});
+
+test('multiple duplicates - last of many wins', async () => {
+	const input = `<div id="a" id="b" id="c"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'id="c"');
+	assert.not.match(code, 'id="a"');
+	assert.not.match(code, 'id="b"');
+});
+
+test('duplicate expression attributes', async () => {
+	const input = `<div class={foo} class={bar}></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'class={bar}');
+	assert.not.match(code, 'class={foo}');
+});
+
+test('duplicate empty attributes', async () => {
+	const input = `<div disabled disabled></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Should only appear once
+	const matches = code.match(/disabled/g);
+	assert.ok(matches, 'disabled should be present');
+	assert.is(matches.length, 1, 'disabled should appear exactly once');
+});
+
+test('duplicate template literal attributes', async () => {
+	const input = '<div class={`${a}`} class={`${b}`}></div>';
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'class={`${b}`}');
+	assert.not.match(code, 'class={`${a}`}');
+});
+
+test('mixed attribute types for same key', async () => {
+	const input = `<div class="foo" class={bar}></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'class={bar}');
+	assert.not.match(code, 'class="foo"');
+});
+
+test('interleaved duplicates preserve order', async () => {
+	const input = `<div a="1" b="2" a="3" c="4"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Should output in order: b="2" a="3" c="4"
+	const aIndex = code.indexOf('a="3"');
+	const bIndex = code.indexOf('b="2"');
+	const cIndex = code.indexOf('c="4"');
+	assert.ok(aIndex > 0, 'a="3" should be present');
+	assert.ok(bIndex > 0, 'b="2" should be present');
+	assert.ok(cIndex > 0, 'c="4" should be present');
+	assert.ok(bIndex < aIndex, 'b should come before a');
+	assert.ok(aIndex < cIndex, 'a should come before c');
+	assert.not.match(code, 'a="1"', 'a="1" should not be present');
+});
+
+test('spread attributes with later overrides', async () => {
+	const input = `<div class="foo" {...props} class="bar"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Spread should just be {...props} in TSX
+	assert.match(code, '{...props}');
+	assert.match(code, 'class="bar"');
+	assert.not.match(code, 'class="foo"');
+});
+
+test('complex spread scenario', async () => {
+	const input = `<div a="1" {...props} a="2" a="3"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Named attrs should be deduplicated to just a="3"
+	assert.match(code, 'a="3"');
+	assert.not.match(code, 'a="1"');
+	assert.not.match(code, 'a="2"');
+	// Spread remains as-is
+	assert.match(code, '{...props}');
+});
+
+test('multiple spreads with different exclusions', async () => {
+	const input = `<div a="1" {...props1} b="2" {...props2} a="3"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Both spreads remain
+	assert.match(code, '{...props1}');
+	assert.match(code, '{...props2}');
+	// Named attrs should be b="2" and a="3"
+	assert.match(code, 'b="2"');
+	assert.match(code, 'a="3"');
+	assert.not.match(code, 'a="1"');
+});
+
+test('namespaced attributes (SVG)', async () => {
+	const input = `<svg xlink:href="a" xlink:href="b"></svg>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'xlink:href="b"');
+	assert.not.match(code, 'xlink:href="a"');
+});
+
+test('duplicate attributes on components', async () => {
+	const input = `<Component prop="a" prop="b"></Component>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, 'prop="b"');
+	assert.not.match(code, 'prop="a"');
+});
+
+test('case sensitivity - different cases are different attributes', async () => {
+	const input = `<div class="foo" CLASS="bar"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Both should remain (case-sensitive)
+	assert.match(code, 'class="foo"');
+	assert.match(code, 'CLASS="bar"');
+});
+
+test('spread before all named attrs', async () => {
+	const input = `<div {...props} class="override"></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	// Spread remains as-is in TSX
+	assert.match(code, '{...props}');
+	assert.match(code, 'class="override"');
+});
+
+test('spread with no conflicts', async () => {
+	const input = `<div {...props}></div>`;
+	const { code } = await convertToTSX(input, { sourcemap: 'external' });
+	assert.match(code, '{...props}');
+});
+
+test.run();


### PR DESCRIPTION
## Changes

Adjusts astro compiler to adhere to JSX semantic prop overrides.


```astro
<!-- user html pre-compilation  -->
<div a="1" a="2" /> 

<!-- Currently results in ❌ -->
<div a="1" />

<!-- After this PR ✅ -->
<div a="2" />
```

Manually overriding like that is a rare occurance, but consider this far more common issue

```astro
---
const props = { class: "foo" } // obv. normally we'd use Astro.props but for keeping example concise
---
<!-- user html pre-compilation -->
<div {...props} class="bar" >

<!-- What you end up getting ❌ -->
<div class="foo" />

<!-- What most users expect they will get -- and will get after this PR ✅ -->
<div class="bar" />
```

## Testing
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

Added both ts and go tests for testing the compiler (parser/printer)  for deduping various example and cornercases like svg namespaces, multiple spreads, etc.

Tested via standard test workflow: 

```sh
pnpm build:all
UPDATE_SNAPS=true go test -v ./internal
pnpm test
```

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
Doesn't require any direct documentation changes imho, but does require a breaking change notice in the changelog / announcement post of the version *(even though majority of users should be unaffected by this change)*


## Closing remarks

Full disclosure, I have very limited `golang` experience. I did my best to address the necessary changes in a meaningful and performant way, but I wanted to make it explicitly clear -- My expertise is TypeScript with a hobbylang of Rust, so just so we're on the same page -- I did use AI to help me get this PR over the finish line to make up for my lack of go knowledge.

I did my best to verify everything and write a comprehensive test suite for it, but  it is more than likely that there may be something suboptimal given the scope of the compiler, the fact that it's my first change and that I have very limited go experience from a single sideproject ~2 years ago. 

Either way hopefully this should serve as a solid starting point and wanted to deliver you guys'n'gals bit of an early christmas present for all the hard work you've been putting in all this time. Have wonderful holidays 🎄


- [ ] Closes https://github.com/withastro/astro/issues/11920



