### PR TITLE
Expand `compact` option to support JSX-style whitespace stripping

### DIFF
--- a/.changeset/fluffy-eels-flash.md
+++ b/.changeset/fluffy-eels-flash.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": minor
+---
+
+Expand `compact` option to support JSX-style whitespace stripping

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -95,9 +95,12 @@ func makeTransformOptions(options js.Value) transform.TransformOptions {
 
 	astroGlobalArgs := jsString(options.Get("astroGlobalArgs"))
 
-	compact := false
-	if jsBool(options.Get("compact")) {
-		compact = true
+	compact := transform.CompactNone
+	compactVal := options.Get("compact")
+	if compactVal.Type() == js.TypeString && compactVal.String() == "jsx" {
+		compact = transform.CompactJSX
+	} else if jsBool(compactVal) {
+		compact = transform.CompactDefault
 	}
 
 	scopedSlot := false

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -3,8 +3,10 @@ package transform
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	astro "github.com/withastro/compiler/internal"
 	"github.com/withastro/compiler/internal/handler"
@@ -20,6 +22,14 @@ const DATA_ASTRO_RELOAD = "data-astro-reload"
 const TRANSITION_PERSIST_PROPS = "transition:persist-props"
 const SERVER_DEFER = "server:defer"
 
+type CompactMode uint8
+
+const (
+	CompactNone    CompactMode = iota
+	CompactDefault             // standard whitespace collapsing
+	CompactJSX                 // JSX-style whitespace stripping
+)
+
 type TransformOptions struct {
 	Scope                   string
 	Filename                string
@@ -28,7 +38,7 @@ type TransformOptions struct {
 	SourceMap               string
 	AstroGlobalArgs         string
 	ScopedStyleStrategy     string
-	Compact                 bool
+	Compact                 CompactMode
 	ResultScopedSlot        bool
 	TransitionsAnimationURL string
 	ResolvePath             func(string) string
@@ -104,7 +114,10 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 
 	TrimTrailingSpace(doc)
 
-	if opts.Compact {
+	switch opts.Compact {
+	case CompactJSX:
+		collapseWhitespaceJSX(doc)
+	case CompactDefault:
 		collapseWhitespace(doc)
 	}
 
@@ -301,12 +314,7 @@ func isRawElement(n *astro.Node) bool {
 		}
 	}
 	rawTags := []string{"pre", "listing", "iframe", "noembed", "noframes", "math", "plaintext", "script", "style", "textarea", "title", "xmp"}
-	for _, tag := range rawTags {
-		if n.Data == tag {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(rawTags, n.Data)
 }
 
 func isWhitespaceInsensitiveElement(n *astro.Node) bool {
@@ -378,6 +386,105 @@ func collapseWhitespace(doc *astro.Node) {
 					n.Data = n.Data + " "
 				}
 			}
+		}
+	})
+}
+
+// Strips whitespace from JSX text content, matching the de facto standard algorithm
+// used by all major JSX transpilers (Babel, TypeScript, SWC, esbuild).
+//
+// Rules:
+//   - First line: preserve leading whitespace, trim trailing whitespace
+//   - Middle lines: trim both leading and trailing whitespace
+//   - Last line: trim leading whitespace, preserve trailing whitespace
+//   - Non-empty lines are joined with a single space
+//   - Empty/whitespace-only lines contribute nothing
+//
+// Adapted from esbuild's fixWhitespaceAndDecodeJSXEntities (without entity decoding,
+// which is handled by our HTML parser):
+// https://github.com/evanw/esbuild/blob/9129e00/internal/js_lexer/js_lexer.go#L2135-L2188
+//
+// See also Babel's cleanJSXElementLiteralChild:
+// https://github.com/babel/babel/blob/8ddfe9c/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts#L5-L51
+func cleanJSXTextWhitespace(text string) string {
+	afterLastNonWhitespace := -1
+	firstNonWhitespace := 0 // 0 for first line (preserves leading whitespace)
+	var result strings.Builder
+	i := 0
+
+	for i < len(text) {
+		c, width := utf8.DecodeRuneInString(text[i:])
+
+		switch c {
+		// Line terminators: \r, \n, \u2028 (LS), \u2029 (PS)
+		// See: https://github.com/evanw/esbuild/blob/9129e00/internal/js_lexer/js_lexer.go#L2148
+		case '\r', '\n', '\u2028', '\u2029':
+			// Emit trimmed content from the current line
+			if firstNonWhitespace != -1 && afterLastNonWhitespace != -1 {
+				if result.Len() > 0 {
+					result.WriteByte(' ')
+				}
+				result.WriteString(text[firstNonWhitespace:afterLastNonWhitespace])
+			}
+			// Reset for next line
+			firstNonWhitespace = -1
+
+		// Simple whitespace
+		// See: https://github.com/evanw/esbuild/blob/9129e00/internal/js_lexer/js_lexer.go#L2162
+		case '\t', ' ':
+			// Whitespace: don't update tracking positions
+
+		default:
+			// Check for other Unicode whitespace (NBSP, etc.)
+			// See: https://github.com/evanw/esbuild/blob/9129e00/internal/js_lexer/js_lexer.go#L2167
+			if !unicode.IsSpace(c) {
+				afterLastNonWhitespace = i + width
+				if firstNonWhitespace == -1 {
+					firstNonWhitespace = i
+				}
+			}
+		}
+
+		i += width
+	}
+
+	// Handle last line: preserve trailing whitespace
+	// See: https://github.com/evanw/esbuild/blob/9129e00/internal/js_lexer/js_lexer.go#L2178-L2185
+	if firstNonWhitespace != -1 {
+		if result.Len() > 0 {
+			result.WriteByte(' ')
+		}
+		result.WriteString(text[firstNonWhitespace:])
+	}
+
+	return result.String()
+}
+
+// JSX-style whitespace stripping, matching the de facto standard used by Babel, TypeScript, SWC, and esbuild.
+func collapseWhitespaceJSX(doc *astro.Node) {
+	walk(doc, func(n *astro.Node) {
+		if n.Type == astro.TextNode {
+			// Don't trim any whitespace if the node or any of its ancestors is raw
+			if n.Closest(isRawElement) != nil {
+				return
+			}
+
+			// Trim the whitespace on each end of top-level expressions
+			if n.Parent != nil && n.Parent.Expression {
+				// Trim left whitespace in the first child
+				if n.PrevSibling == nil {
+					n.Data = strings.TrimLeftFunc(n.Data, unicode.IsSpace)
+				}
+				// Trim right whitespace in the last child
+				if n.NextSibling == nil {
+					n.Data = strings.TrimRightFunc(n.Data, unicode.IsSpace)
+				}
+				// Don't apply JSX text cleaning inside expressions
+				return
+			}
+
+			// Apply the standard JSX text whitespace algorithm
+			n.Data = cleanJSXTextWhitespace(n.Data)
 		}
 	})
 }

--- a/internal/transform/transform_test.go
+++ b/internal/transform/transform_test.go
@@ -523,10 +523,266 @@ func TestCompactTransform(t *testing.T) {
 				t.Error(err)
 			}
 			transformOptions := TransformOptions{
-				Compact: true,
+				Compact: CompactDefault,
 			}
 			ExtractStyles(doc, &transformOptions)
 			// Clear doc.Styles to avoid scoping behavior, we're not testing that here
+			doc.Styles = make([]*astro.Node, 0)
+			Transform(doc, transformOptions, &handler.Handler{})
+			astro.PrintToSource(&b, doc)
+			got := strings.TrimSpace(b.String())
+			if tt.want != got {
+				t.Errorf("\nFAIL: %s\n  want: %s\n  got:  %s", tt.name, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestCompactJSXTransform(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		// Newline handling
+		{
+			name:   "rule1_unix_newline",
+			source: "<div>Hello\nWorld</div>",
+			want:   "<div>Hello World</div>",
+		},
+		{
+			name:   "rule1_windows_newline",
+			source: "<div>Hello\r\nWorld</div>",
+			want:   "<div>Hello World</div>",
+		},
+		{
+			name:   "rule1_old_mac_newline",
+			source: "<div>Hello\rWorld</div>",
+			want:   "<div>Hello World</div>",
+		},
+
+		// Tabs are whitespace (preserved on single-line text, trimmed on interior lines)
+		{
+			name:   "rule2_tab_preserved_single_line",
+			source: "<div>\tHello\t</div>",
+			want:   "<div>\tHello\t</div>",
+		},
+		{
+			name:   "rule2_multiple_tabs_preserved",
+			source: "<div>\t\tHello\t\t</div>",
+			want:   "<div>\t\tHello\t\t</div>",
+		},
+
+		// Leading spaces on non-first lines
+		{
+			name:   "rule3_trim_leading_line2",
+			source: "<div>A\n   B</div>",
+			want:   "<div>A B</div>",
+		},
+		{
+			name:   "rule3_preserve_leading_line1",
+			source: "<div>   A\nB</div>",
+			want:   "<div>   A B</div>",
+		},
+		{
+			name:   "rule3_trim_leading_all_nonfirst",
+			source: "<div>A\n   B\n   C</div>",
+			want:   "<div>A B C</div>",
+		},
+
+		// Trailing spaces on non-last lines
+		{
+			name:   "rule4_trim_trailing_line1",
+			source: "<div>A   \nB</div>",
+			want:   "<div>A B</div>",
+		},
+		{
+			name:   "rule4_preserve_trailing_last",
+			source: "<div>A\nB   </div>",
+			want:   "<div>A B   </div>",
+		},
+		{
+			name:   "rule4_trim_trailing_all_nonlast",
+			source: "<div>A   \nB   \nC</div>",
+			want:   "<div>A B C</div>",
+		},
+
+		// Empty lines contribute nothing
+		{
+			name:   "rule5_empty_line_middle",
+			source: "<div>A\n\nB</div>",
+			want:   "<div>A B</div>",
+		},
+		{
+			name:   "rule5_multiple_empty_lines",
+			source: "<div>A\n\n\n\nB</div>",
+			want:   "<div>A B</div>",
+		},
+		{
+			name:   "rule5_whitespace_only_line",
+			source: "<div>A\n   \nB</div>",
+			want:   "<div>A B</div>",
+		},
+
+		// Lines joined with single space
+		{
+			name:   "rule6_two_lines_joined",
+			source: "<div>Hello\nWorld</div>",
+			want:   "<div>Hello World</div>",
+		},
+		{
+			name:   "rule6_no_trailing_space_after_last",
+			source: "<div>Hello\nWorld\n</div>",
+			want:   "<div>Hello World</div>",
+		},
+
+		// Empty result discards text node
+		{
+			name:   "rule7_only_spaces_single_line",
+			source: "<div>   </div>",
+			want:   "<div>   </div>",
+		},
+		{
+			name:   "rule7_only_newline",
+			source: "<div>\n</div>",
+			want:   "<div></div>",
+		},
+		{
+			name:   "rule7_only_whitespace_multiline",
+			source: "<div>\n   \n</div>",
+			want:   "<div></div>",
+		},
+		{
+			name:   "rule7_whitespace_between_elements",
+			source: "<div>\n  <p></p>\n</div>",
+			want:   "<div><p></p></div>",
+		},
+
+		// Single line preserves both ends
+		{
+			name:   "single_line_both_ends",
+			source: "<div>  Hello  </div>",
+			want:   "<div>  Hello  </div>",
+		},
+		{
+			name:   "single_line_tabs",
+			source: "<div>\t\tHello\t\t</div>",
+			want:   "<div>\t\tHello\t\t</div>",
+		},
+
+		// Text adjacent to elements
+		{
+			name:   "text_before_element_same_line",
+			source: "<div>Hello <span></span></div>",
+			want:   "<div>Hello <span></span></div>",
+		},
+		{
+			name:   "text_after_element_same_line",
+			source: "<div><span></span> World</div>",
+			want:   "<div><span></span> World</div>",
+		},
+		{
+			name:   "text_before_element_diff_line",
+			source: "<div>Hello\n<span></span></div>",
+			want:   "<div>Hello<span></span></div>",
+		},
+
+		// Expressions
+		{
+			name:   "whitespace_between_expr_same_line",
+			source: "<div>{x}  {y}</div>",
+			want:   "<div>{x}  {y}</div>",
+		},
+		{
+			name:   "whitespace_between_expr_same_line_tab",
+			source: "<div>{x}\t{y}</div>",
+			want:   "<div>{x}\t{y}</div>",
+		},
+		{
+			name:   "whitespace_between_expr_diff_lines",
+			source: "<div>\n  {x}\n  {y}\n</div>",
+			want:   "<div>{x}{y}</div>",
+		},
+		{
+			name:   "text_then_expression",
+			source: "<div>hello {x}</div>",
+			want:   "<div>hello {x}</div>",
+		},
+		{
+			name:   "expression_then_text",
+			source: "<div>{x} hello</div>",
+			want:   "<div>{x} hello</div>",
+		},
+
+		// Pre/raw element preservation
+		{
+			name:   "pre_preserved",
+			source: "<pre>  Hello\n  World  </pre>",
+			want:   "<pre>  Hello\n  World  </pre>",
+		},
+		{
+			name:   "textarea_preserved",
+			source: "<textarea>  Hello\n  World  </textarea>",
+			want:   "<textarea>  Hello\n  World  </textarea>",
+		},
+
+		// Expression trim behavior
+		{
+			name:   "expression_trim_first",
+			source: "<div>{\n() => {\n\t\treturn <span />}}</div>",
+			want:   "<div>{() => {\n\t\treturn <span></span>}}</div>",
+		},
+		{
+			name:   "expression_trim_last",
+			source: "<div>{() => {\n\t\treturn <span />}\n}</div>",
+			want:   "<div>{() => {\n\t\treturn <span></span>}}</div>",
+		},
+
+		// Complex multi-line indented content
+		{
+			name: "typical_component_children",
+			source: `<div>
+  <h1>Title</h1>
+  <p>Content</p>
+</div>`,
+			want: "<div><h1>Title</h1><p>Content</p></div>",
+		},
+		{
+			name: "mixed_text_and_elements",
+			source: `<p>
+  Hello
+  <strong>World</strong>
+</p>`,
+			want: "<p>Hello<strong>World</strong></p>",
+		},
+		{
+			name: "mixed_text_elements_and_expression_container",
+			source: `<p>
+  Hello{' '}
+  <strong>World</strong>
+</p>`,
+			want: "<p>Hello{' '}<strong>World</strong></p>",
+		},
+
+		// Attributes (should be unaffected)
+		{
+			name:   "attributes",
+			source: `<div    a="1"    b={0} />`,
+			want:   `<div a="1" b={0}></div>`,
+		},
+	}
+	var b strings.Builder
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b.Reset()
+			doc, err := astro.Parse(strings.NewReader(tt.source))
+			if err != nil {
+				t.Error(err)
+			}
+			transformOptions := TransformOptions{
+				Compact: CompactJSX,
+			}
+			ExtractStyles(doc, &transformOptions)
 			doc.Styles = make([]*astro.Node, 0)
 			Transform(doc, transformOptions, &handler.Handler{})
 			astro.PrintToSource(&b, doc)

--- a/packages/compiler/src/shared/types.ts
+++ b/packages/compiler/src/shared/types.ts
@@ -45,7 +45,7 @@ export interface TransformOptions {
 	normalizedFilename?: string;
 	sourcemap?: boolean | 'inline' | 'external' | 'both';
 	astroGlobalArgs?: string;
-	compact?: boolean;
+	compact?: boolean | 'jsx';
 	resultScopedSlot?: boolean;
 	scopedStyleStrategy?: 'where' | 'class' | 'attribute';
 	/**

--- a/packages/compiler/test/compact/jsx.ts
+++ b/packages/compiler/test/compact/jsx.ts
@@ -1,0 +1,66 @@
+import { transform } from '@astrojs/compiler';
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+async function jsxMinify(input: string) {
+	const code = (await transform(input, { compact: 'jsx' })).code;
+	return code.replace('${$$maybeRenderHead($$result)}', '');
+}
+
+test('jsx: basic text', async () => {
+	assert.match(
+		await jsxMinify('<div>Hello {value}!</div>'),
+		'$$render`<div>Hello ${value}!</div>`'
+	);
+});
+
+test('jsx: single line preserves spaces', async () => {
+	assert.match(await jsxMinify('<div>  Hello  </div>'), '$$render`<div>  Hello  </div>`');
+});
+
+test('jsx: multiline strips indentation', async () => {
+	assert.match(
+		await jsxMinify('<div>\n  Hello\n  World\n</div>'),
+		'$$render`<div>Hello World</div>`'
+	);
+});
+
+test('jsx: tabs preserved on single line', async () => {
+	assert.match(await jsxMinify('<div>\tHello\t</div>'), '$$render`<div>\tHello\t</div>`');
+});
+
+test('jsx: whitespace-only multiline is removed', async () => {
+	assert.match(await jsxMinify('<div>\n  <p>text</p>\n</div>'), '$$render`<div><p>text</p></div>`');
+});
+
+test('jsx: preservation', async () => {
+	assert.match(
+		await jsxMinify('<pre>  Hello\n  World  </pre>'),
+		'$$render`<pre>  Hello\n  World  </pre>`'
+	);
+	assert.match(
+		await jsxMinify('<textarea>  Hello\n  World  </textarea>'),
+		'$$render`<textarea>  Hello\n  World  </textarea>`'
+	);
+});
+
+test('jsx: expressions', async () => {
+	assert.match(await jsxMinify('<div>hello {x}</div>'), '$$render`<div>hello ${x}</div>`');
+	assert.match(await jsxMinify('<div>{x} hello</div>'), '$$render`<div>${x} hello</div>`');
+});
+
+test('jsx: expression trimming', async () => {
+	assert.match(
+		await jsxMinify('<div>{\n  expression\n}</div>'),
+		'$$render`<div>${expression}</div>`'
+	);
+});
+
+test('jsx: typical component children', async () => {
+	assert.match(
+		await jsxMinify('<div>\n  <h1>Title</h1>\n  <p>Content</p>\n</div>'),
+		'$$render`<div><h1>Title</h1><p>Content</p></div>`'
+	);
+});
+
+test.run();

--- a/packages/compiler/test/compact/minify.ts
+++ b/packages/compiler/test/compact/minify.ts
@@ -245,3 +245,5 @@ test('separated by newlines (#815)', async () => {
 
 	assert.match(result, output);
 });
+
+test.run();

--- a/packages/compiler/test/js-sourcemaps/complex-frontmatter.ts
+++ b/packages/compiler/test/js-sourcemaps/complex-frontmatter.ts
@@ -44,3 +44,5 @@ test('tracks foobar', async () => {
 	const loc = await testJSSourcemap(input, 'foobar');
 	assert.equal(loc, { source: 'index.astro', line: 6, column: 7, name: null });
 });
+
+test.run();

--- a/packages/compiler/test/parse/literal.ts
+++ b/packages/compiler/test/parse/literal.ts
@@ -68,3 +68,5 @@ test('preserve style tag position V', async () => {
 	assert.equal(lastChild.name, 'style', 'Expected last child node to be of type "style"');
 	assert.equal(lastChild.children[0].type, 'text', 'Expected last child node to be of type "text"');
 });
+
+test.run();

--- a/packages/compiler/test/stress/index.ts
+++ b/packages/compiler/test/stress/index.ts
@@ -247,3 +247,5 @@ function* throttle(max: number, tests: any) {
 }
 
 test();
+
+test.run();

--- a/packages/compiler/test/table/components.ts
+++ b/packages/compiler/test/table/components.ts
@@ -28,3 +28,5 @@ const  MyTableRow = "tr";
 	}
 	assert.equal(error, 0, 'compiler should generate valid code');
 });
+
+test.run();

--- a/packages/compiler/test/table/expressions.ts
+++ b/packages/compiler/test/table/expressions.ts
@@ -89,3 +89,5 @@ test('allows many expressions in table', async () => {
 	}
 	assert.equal(error, 0, 'compiler should generate valid code');
 });
+
+test.run();

--- a/packages/compiler/test/table/in-expression.ts
+++ b/packages/compiler/test/table/in-expression.ts
@@ -92,3 +92,5 @@ test('does not generate invalid markup on multiple tables', async () => {
 	}
 	assert.equal(error, 0, 'compiler should generate valid code');
 });
+
+test.run();

--- a/packages/compiler/test/tsx-sourcemaps/404.ts
+++ b/packages/compiler/test/tsx-sourcemaps/404.ts
@@ -8,3 +8,5 @@ test('404 generates a valid identifier', async () => {
 	const output = await convertToTSX(input, { filename: '404.astro', sourcemap: 'inline' });
 	assert.match(output.code, 'export default function __AstroComponent_');
 });
+
+test.run();

--- a/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
+++ b/packages/compiler/test/tsx-sourcemaps/unfinished-literal.ts
@@ -41,3 +41,5 @@ test('does not panic on unfinished single quoted attribute', async () => {
 
 	assert.equal(error, 0, 'compiler should not have panicked');
 });
+
+test.run();


### PR DESCRIPTION
## Changes

In this PR I’ve expanded the `compact` option to support a new string value, `"jsx"`. This allows users to enable JSX style whitespace stripping in Astro. Handy for folks like me who often pair Astro and React. No more mental shift when jumping between components… all my JSX code looks and behaves the same way. If you all are more curious about rationale, please let me know, I’ve got more to say about the topic but didn’t want to clog up the PR description.

The [JSX spec](https://facebook.github.io/jsx/) unfortunately doesn’t specify [how whitespace is dealt with in JSX](https://github.com/facebook/jsx/issues/6), but JS tooling has landed on [Babel’s whitespace handling](https://github.com/babel/babel/blob/8ddfe9c/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts#L5-L51) as a kind of standard.

The implementation is based on esbuild’s JSX whitespace handling, which is an exact implementation of TypeScript’s JSX whitespace handling, which in turn is an implementation of Babel’s whitespace handling.

I did this work with some serious assistance from Claude Code + Opus, but I have read each line of code and gone through the tests as well.

While working on this I (well, claude 🫣) noticed that minify tests weren’t running due to a missing `test.run()`. That has been fixed in this PR, as well as the missing `test.run()` calls from a few other test files (second commit).

## Testing

New tests added

## Docs

https://github.com/withastro/docs/pull/13326