### PR TITLE
fix: avoid re-scoping nested selectors without &

### DIFF
--- a/.changeset/warm-coins-clap.md
+++ b/.changeset/warm-coins-clap.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix scoped CSS nesting so descendant selectors without `&` inside nested rules are not incorrectly re-scoped.

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -303,7 +303,12 @@ func TestScopeStyle(t *testing.T) {
 		{
 			name:   "nesting without ampersand",
 			source: ".nesting-root{p{color:#123456}:global(h1){color:#abcdef}}",
-			want:   ".nesting-root:where(.astro-xxxxxx){p:where(.astro-xxxxxx){color:#123456}h1{color:#abcdef}}",
+			want:   ".nesting-root:where(.astro-xxxxxx){p{color:#123456}h1{color:#abcdef}}",
+		},
+		{
+			name:   "nested descendant selector should stay unscoped",
+			source: "nav{a{color:deeppink}}",
+			want:   "nav:where(.astro-xxxxxx){a{color:deeppink}}",
 		},
 		{
 			name: "@container",

--- a/lib/esbuild/css_printer/astro_features.go
+++ b/lib/esbuild/css_printer/astro_features.go
@@ -20,7 +20,7 @@ func (p *printer) printScopedSelector() bool {
 	return true
 }
 
-func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bool, isLast bool) {
+func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bool, isLast bool, shouldScope bool) {
 	scoped := false
 	if !isFirst && sel.Combinator == "" {
 		// A space is required in between compound selectors if there is no
@@ -52,7 +52,11 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 			whitespace = canDiscardWhitespaceAfter
 		}
 		if sel.TypeSelector.Name.Text == "*" {
-			scoped = p.printScopedSelector()
+			if shouldScope {
+				scoped = p.printScopedSelector()
+			} else {
+				p.printNamespacedName(*sel.TypeSelector, whitespace)
+			}
 		} else {
 			p.printNamespacedName(*sel.TypeSelector, whitespace)
 		}
@@ -60,7 +64,7 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 		case "body", "html":
 			scoped = true
 		default:
-			if !scoped {
+			if !scoped && shouldScope {
 				scoped = p.printScopedSelector()
 			}
 		}
@@ -83,19 +87,19 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 			// This deliberately does not use identHash. From the specification:
 			// "In <id-selector>, the <hash-token>'s value must be an identifier."
 			p.printIdent(s.Name, identNormal, whitespace)
-			if !scoped {
+			if !scoped && shouldScope {
 				scoped = p.printScopedSelector()
 			}
 
 		case *css_ast.SSClass:
 			p.print(".")
 			p.printIdent(s.Name, identNormal, whitespace)
-			if !scoped {
+			if !scoped && shouldScope {
 				scoped = p.printScopedSelector()
 			}
 
 		case *css_ast.SSAttribute:
-			if !scoped {
+			if !scoped && shouldScope {
 				scoped = p.printScopedSelector()
 			}
 			p.print("[")
@@ -141,7 +145,7 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 			}
 			// If there is no type selector and all subclass selectors are pseudo
 			// selectors, we need to add the scope before the first pseudo selector.
-			if !scoped && sel.TypeSelector == nil && *onlyPseudoSubclassSelectors && i == 0 && s.Name != "global" && s.Name != "root" {
+			if !scoped && shouldScope && sel.TypeSelector == nil && *onlyPseudoSubclassSelectors && i == 0 && s.Name != "global" && s.Name != "root" {
 				scoped = p.printScopedSelector()
 			}
 			p.printPseudoClassSelector(*s, whitespace)
@@ -151,7 +155,7 @@ func (p *printer) printCompoundSelector(sel css_ast.CompoundSelector, isFirst bo
 		}
 	}
 
-	if !scoped {
+	if !scoped && shouldScope {
 		p.printScopedSelector()
 	}
 

--- a/lib/esbuild/css_printer/css_printer.go
+++ b/lib/esbuild/css_printer/css_printer.go
@@ -21,6 +21,7 @@ type printer struct {
 	css                    []byte
 	extractedLegalComments map[string]bool
 	builder                sourcemap.ChunkBuilder
+	selectorRuleDepth      int
 }
 
 type ScopeStrategy uint8
@@ -208,7 +209,9 @@ func (p *printer) printRule(rule css_ast.Rule, indent int32, omitTrailingSemicol
 		if !p.options.MinifyWhitespace {
 			p.print(" ")
 		}
+		p.selectorRuleDepth++
 		p.printRuleBlock(r.Rules, indent)
+		p.selectorRuleDepth--
 
 	case *css_ast.RQualified:
 		hasWhitespaceAfter := p.printTokens(r.Prelude, printTokensOpts{})
@@ -322,7 +325,20 @@ func (p *printer) printComplexSelectors(selectors []css_ast.ComplexSelector, ind
 		}
 
 		for j, compound := range complex.Selectors {
-			p.printCompoundSelector(compound, (!hasAtNest || i != 0) && j == 0, j+1 == len(complex.Selectors))
+			shouldScope := true
+			if p.selectorRuleDepth > 0 {
+				hasNestingSelector := false
+				for _, part := range complex.Selectors {
+					if part.NestingSelector != css_ast.NestingSelectorNone {
+						hasNestingSelector = true
+						break
+					}
+				}
+				if !hasNestingSelector {
+					shouldScope = false
+				}
+			}
+			p.printCompoundSelector(compound, (!hasAtNest || i != 0) && j == 0, j+1 == len(complex.Selectors), shouldScope)
 		}
 	}
 }


### PR DESCRIPTION
## Changes

- Avoid injecting Astro scope for nested selector rules that omit `&`.
- Preserve expected output for cases like `nav { a { ... } }` (do not scope nested `a`).
- Add/adjust `ScopeStyle` regression tests and include a patch changeset.
- Fixes https://github.com/withastro/astro/issues/15907

## Testing

- `go test ./internal/transform -run TestScopeStyle`

## Docs

- Not needed (bug fix only).