### PR TITLE
feat: emit template depth tracking instructions

### DIFF
--- a/.changeset/forty-cars-lick.md
+++ b/.changeset/forty-cars-lick.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": minor
+---
+
+Calling `templateEnter` / `templateExit` when emitting `<template>`

--- a/.changeset/forty-cars-lick.md
+++ b/.changeset/forty-cars-lick.md
@@ -1,5 +1,5 @@
 ---
-"@astrojs/compiler": minor
+"@astrojs/compiler": major
 ---
 
 Calling `templateEnter` / `templateExit` when emitting `<template>`

--- a/internal/node.go
+++ b/internal/node.go
@@ -101,6 +101,7 @@ type Node struct {
 	HydrationDirectives      map[string]bool
 	ServerComponents         []*HydratedComponentMetadata
 	ContainsHead             bool
+	ContainsTemplateElement  bool
 	HeadPropagation          bool
 
 	Type      NodeType

--- a/internal/printer/__printer_js__/HTML_template_element_emits_depth_tracking.snap
+++ b/internal/printer/__printer_js__/HTML_template_element_emits_depth_tracking.snap
@@ -1,0 +1,43 @@
+
+[TestPrinter/HTML_template_element_emits_depth_tracking - 1]
+## Input
+
+```
+<template id="tpl"><div>hello</div></template>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  templateEnter as $$templateEnter,
+  templateExit as $$templateExit,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`<template id="tpl">${$$templateEnter($$result)}${$$maybeRenderHead($$result)}<div>hello</div>${$$templateExit($$result)}</template>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/nested_HTML_template_elements_emit_depth_tracking.snap
+++ b/internal/printer/__printer_js__/nested_HTML_template_elements_emit_depth_tracking.snap
@@ -1,0 +1,43 @@
+
+[TestPrinter/nested_HTML_template_elements_emit_depth_tracking - 1]
+## Input
+
+```
+<template><template><div>inner</div></template></template>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  templateEnter as $$templateEnter,
+  templateExit as $$templateExit,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`<template>${$$templateEnter($$result)}<template>${$$templateEnter($$result)}${$$maybeRenderHead($$result)}<div>inner</div>${$$templateExit($$result)}</template>${$$templateExit($$result)}</template>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -47,10 +47,11 @@ import (
 // becomes "<html><head><head/><body>abc</body></html>".
 func PrintToJS(sourcetext string, n *Node, cssLen int, opts transform.TransformOptions, h *handler.Handler) PrintResult {
 	p := &printer{
-		sourcetext: sourcetext,
-		opts:       opts,
-		builder:    sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(sourcetext, len(strings.Split(sourcetext, "\n")))),
-		handler:    h,
+		sourcetext:         sourcetext,
+		opts:               opts,
+		builder:            sourcemap.MakeChunkBuilder(nil, sourcemap.GenerateLineOffsetTables(sourcetext, len(strings.Split(sourcetext, "\n")))),
+		handler:            h,
+		hasTemplateElement: n.ContainsTemplateElement,
 	}
 	return printToJs(p, n, cssLen, opts)
 }
@@ -531,6 +532,12 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 		return
 	}
 
+	// Emit template depth tracking for HTML <template> elements
+	if n.DataAtom == atom.Template && n.Data == "template" && !isComponent {
+		p.addNilSourceMapping()
+		p.print(fmt.Sprintf("${%s(%s)}", TEMPLATE_ENTER, RESULT))
+	}
+
 	// Add initial newline where there is danger of a newline beging ignored.
 	if c := n.FirstChild; c != nil && c.Type == TextNode && strings.HasPrefix(c.Data, "\n") {
 		switch n.Data {
@@ -796,6 +803,10 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 	}
 	if n.DataAtom == atom.Script || n.DataAtom == atom.Style {
 		p.printDefineVarsClose(n)
+	}
+	if n.DataAtom == atom.Template && n.Data == "template" && !isComponent {
+		p.addNilSourceMapping()
+		p.print(fmt.Sprintf("${%s(%s)}", TEMPLATE_EXIT, RESULT))
 	}
 	if isComponent || isSlot {
 		p.print(")}")

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -33,6 +33,7 @@ type printer struct {
 	hasInternalImports bool
 	hasCSSImports      bool
 	needsTransitionCSS bool
+	hasTemplateElement bool
 
 	// Optional, used only for TSX output
 	ranges TSXRanges
@@ -55,6 +56,8 @@ var DEFINE_STYLE_VARS = "$$defineStyleVars"
 var DEFINE_SCRIPT_VARS = "$$defineScriptVars"
 var CREATE_METADATA = "$$createMetadata"
 var RENDER_SCRIPT = "$$renderScript"
+var TEMPLATE_ENTER = "$$templateEnter"
+var TEMPLATE_EXIT = "$$templateExit"
 var METADATA = "$$metadata"
 var RESULT = "$$result"
 var SLOTS = "$$slots"
@@ -215,6 +218,12 @@ func (p *printer) printInternalImports(importSpecifier string, opts *RenderOptio
 	p.print("createTransitionScope as " + CREATE_TRANSITION_SCOPE + ",\n  ")
 	p.addNilSourceMapping()
 	p.print("renderScript as " + RENDER_SCRIPT + ",\n  ")
+	if p.hasTemplateElement {
+		p.addNilSourceMapping()
+		p.print("templateEnter as " + TEMPLATE_ENTER + ",\n  ")
+		p.addNilSourceMapping()
+		p.print("templateExit as " + TEMPLATE_EXIT + ",\n  ")
+	}
 
 	// Only needed if using fallback `resolvePath` as it calls `$$metadata.resolvePath`
 	if opts.opts.ResolvePath == nil {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -47,11 +47,11 @@ var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro('https://astro.build');\n
 var RENDER_HEAD_RESULT = "${$$renderHead($$result)}"
 
 type testcase struct {
-	name             string
-	source           string
-	only             bool
-	transitions      bool
-	filename         string
+	name        string
+	source      string
+	only        bool
+	transitions bool
+	filename    string
 }
 
 type jsonTestcase struct {
@@ -844,28 +844,28 @@ import Widget2 from '../components/Widget2.astro';
 			source: `<script>Here</script><div></div>`,
 		},
 		{
-			name:   "script",
-			source: `<main><script>console.log("Hello");</script>`,
+			name:     "script",
+			source:   `<main><script>console.log("Hello");</script>`,
 			filename: "/src/pages/index.astro",
 		},
 		{
-			name:   "script multiple",
-			source: `<main><script>console.log("Hello");</script><script>console.log("World");</script>`,
+			name:     "script multiple",
+			source:   `<main><script>console.log("Hello");</script><script>console.log("World");</script>`,
 			filename: "/src/pages/index.astro",
 		},
 		{
-			name:   "script external",
-			source: `<main><script src="./hello.js"></script>`,
+			name:     "script external",
+			source:   `<main><script src="./hello.js"></script>`,
 			filename: "/src/pages/index.astro",
 		},
 		{
-			name:   "script external in expression",
-			source: `<main>{<script src="./hello.js"></script>}`,
+			name:     "script external in expression",
+			source:   `<main>{<script src="./hello.js"></script>}`,
 			filename: "/src/pages/index.astro",
 		},
 		{
-			name:   "script in expression",
-			source: `<main>{true && <script>console.log("hello")</script>}`,
+			name:     "script in expression",
+			source:   `<main>{true && <script>console.log("hello")</script>}`,
 			filename: "/src/pages/index.astro",
 		},
 		{
@@ -873,8 +873,8 @@ import Widget2 from '../components/Widget2.astro';
 			source: `<main><script is:inline type="module">console.log("Hello");</script>`,
 		},
 		{
-			name:   "script mixed handled and inline",
-			source: `<main><script>console.log("Hello");</script><script is:inline>console.log("World");</script>`,
+			name:     "script mixed handled and inline",
+			source:   `<main><script>console.log("Hello");</script><script is:inline>console.log("World");</script>`,
 			filename: "/src/pages/index.astro",
 		},
 		{
@@ -2070,10 +2070,18 @@ import Analytics from '../components/Analytics.astro';
 		<meta charset="UTF-8" />
 	</head>
 </html>`,
-    },
-    {
+		},
+		{
 			name:   "multiline class attribute on component",
 			source: "<Component class=\"some-class\n  another-class\n  third-class\">content</Component>",
+		},
+		{
+			name:   "HTML template element emits depth tracking",
+			source: `<template id="tpl"><div>hello</div></template>`,
+		},
+		{
+			name:   "nested HTML template elements emit depth tracking",
+			source: `<template><template><div>inner</div></template></template>`,
 		},
 	}
 	for _, tt := range tests {
@@ -2098,7 +2106,7 @@ import Analytics from '../components/Analytics.astro';
 
 			hash := astro.HashString(code)
 			transformOptions := transform.TransformOptions{
-				Scope:                   hash,
+				Scope: hash,
 			}
 			transform.ExtractStyles(doc, &transformOptions)
 			transform.Transform(doc, transformOptions, h) // note: we want to test Transform in context here, but more advanced cases could be tested separately

--- a/internal/transform/transform.go
+++ b/internal/transform/transform.go
@@ -69,6 +69,9 @@ func Transform(doc *astro.Node, opts TransformOptions, h *handler.Handler) *astr
 		if n.DataAtom == a.Head && !IsImplicitNode(n) {
 			doc.ContainsHead = true
 		}
+		if n.DataAtom == a.Template && n.Data == "template" && !n.Component && !n.Fragment {
+			doc.ContainsTemplateElement = true
+		}
 		if opts.AnnotateSourceFile {
 			AnnotateElement(n, opts)
 		}


### PR DESCRIPTION
This PR adds a special handling for `<template>` tags, so they call special `templateEnter` and `templateExit` functions. It's necessary for https://github.com/withastro/astro/pull/15980 PR.

## Changes

- `print-to-js.go` now detects `template` nodes and adds `templateEnter` / `templateExit` calls inside. 
- `transform/transform.go` now fills `ContainsTemplateElement` flag to be able to dynamically include imports later.

## Testing

- Added two snap tests to confirm the behavior: simple `<template>` case and nested case

## Docs

I'm unsure whether it should be documented. I can add the documentation somewhere if needed.