### PR TITLE
Fix(js_scanner): import hoisting corruption when import.meta.env …

### DIFF
--- a/.changeset/mighty-moments-begin.md
+++ b/.changeset/mighty-moments-begin.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix (js_scanner): import hoisting corruption when import.meta.env precedes import statements (#944)

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -804,7 +804,9 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 				if next == js.DotToken {
 					isMeta := false
 					for {
-						next, _ := l.Next()
+						next, nextInnerValue := l.Next()
+						i += len(nextInnerValue)
+						text = append(text, nextInnerValue...)
 						if next == js.MetaToken {
 							isMeta = true
 						}
@@ -919,6 +921,7 @@ func NextImportStatement(source []byte, pos int) (int, ImportStatement) {
 					break
 				}
 			}
+			continue
 		}
 
 		i += len(value)

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -263,6 +263,20 @@ import Test from "../components/Test.astro";`,
 			want: `import Test from "../components/Test.astro";`,
 		},
 		{
+			name: "import.meta.env before import",
+			source: `export const prerender = import.meta.env.MY_VAR !== 'true';
+import { nanoid } from 'nanoid';`,
+			want: `import { nanoid } from 'nanoid';`,
+		},
+		{
+			name: "import.meta.env before multiple imports",
+			source: `export const prerender = import.meta.env.PUBLIC_PRERENDER;
+import { foo } from 'foo';
+import { bar } from 'bar';`,
+			want: `import { foo } from 'foo';
+import { bar } from 'bar';`,
+		},
+		{
 			name: "import/export",
 			source: `import { fn } from "package";
 export async fn() {}


### PR DESCRIPTION
…precedes import statements (#944)

## Changes

  - Fix position tracking in the DotToken handler sub-loop within NextImportStatement (js_scanner.go)
  - The sub-loop consumed tokens (meta, ., etc.) via l.Next() without updating the position counter i, causing subsequent import statement spans to be calculated with an offset
  - This corrupted hoisted output when import.meta.env.* appeared before import statements in Astro frontmatter
  - Add continue after the ImportToken block to prevent double-counting i += len(value) for the import keyword


## Testing

  Added 2 test cases to js_scanner_test.go:
  - import.meta.env before import — single import after import.meta.env expression
  - import.meta.env before multiple imports — two imports after bare import.meta.env reference


##  Docs

  Bug fix only — no public API changes.
