### PR TITLE
fix: remove test.run() from stress test

### DIFF
--- a/packages/compiler/test/stress/index.ts
+++ b/packages/compiler/test/stress/index.ts
@@ -247,5 +247,3 @@ function* throttle(max: number, tests: any) {
 }
 
 test();
-
-test.run();


### PR DESCRIPTION
## Changes

Not needed in this file, it has its own test thing

## Testing

Should pass

## Docs

N/A
