### PR TITLE
fix: strip dead imports for client:only components

### DIFF
--- a/.changeset/long-swans-smoke.md
+++ b/.changeset/long-swans-smoke.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+fix: strip dead imports for client:only components

--- a/internal/printer/__printer_js__/client_only_component__default_.snap
+++ b/internal/printer/__printer_js__/client_only_component__default_.snap
@@ -39,7 +39,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import Component from '../components';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_component__multiple_.snap
+++ b/internal/printer/__printer_js__/client_only_component__multiple_.snap
@@ -41,7 +41,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import Component from '../components';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_component__named_.snap
+++ b/internal/printer/__printer_js__/client_only_component__named_.snap
@@ -39,7 +39,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import { Component } from '../components';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_component__namespace_.snap
+++ b/internal/printer/__printer_js__/client_only_component__namespace_.snap
@@ -39,7 +39,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import * as components from '../components';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_component__namespaced_default_.snap
+++ b/internal/printer/__printer_js__/client_only_component__namespaced_default_.snap
@@ -39,7 +39,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import defaultImport from '../components/ui-1';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components/ui-1'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_component__namespaced_named_.snap
+++ b/internal/printer/__printer_js__/client_only_component__namespaced_named_.snap
@@ -39,7 +39,6 @@ import {
   renderScript as $$renderScript,
   createMetadata as $$createMetadata
 } from "http://localhost:3000/";
-import { namedImport } from '../components/ui-2';
 
 export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components/ui-2'], hydrationDirectives: new Set(['only']), hoisted: [] });
 

--- a/internal/printer/__printer_js__/client_only_preserves_import_when_binding_used_in_frontmatter.snap
+++ b/internal/printer/__printer_js__/client_only_preserves_import_when_binding_used_in_frontmatter.snap
@@ -1,0 +1,48 @@
+
+[TestPrinter/client:only_preserves_import_when_binding_used_in_frontmatter - 1]
+## Input
+
+```
+/-/-/-/
+import Component from '../components';
+console.log(Component.name);
+/-/-/-/
+<Component client:only />
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+import Component from '../components';
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+console.log(Component.name);
+
+return $$render`${$$renderComponent($$result,'Component',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/client_only_preserves_mixed_binding_import.snap
+++ b/internal/printer/__printer_js__/client_only_preserves_mixed_binding_import.snap
@@ -1,0 +1,50 @@
+
+[TestPrinter/client:only_preserves_mixed_binding_import - 1]
+## Input
+
+```
+/-/-/-/
+import Component, { helper } from '../components';
+const data = helper();
+/-/-/-/
+<Component client:only />
+<div>{data}</div>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+import Component, { helper } from '../components';
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+const data = helper();
+
+return $$render`${$$renderComponent($$result,'Component',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+${$$maybeRenderHead($$result)}<div>${data}</div>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/__printer_js__/client_only_preserves_mixed_import_from_same_specifier.snap
+++ b/internal/printer/__printer_js__/client_only_preserves_mixed_import_from_same_specifier.snap
@@ -1,0 +1,53 @@
+
+[TestPrinter/client:only_preserves_mixed_import_from_same_specifier - 1]
+## Input
+
+```
+/-/-/-/
+import Component from '../components';
+import { helper } from '../components';
+const data = helper();
+/-/-/-/
+<Component client:only />
+<div>{data}</div>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+import { helper } from '../components';
+
+import * as $$module1 from '../components';
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [{ module: $$module1, specifier: '../components', assert: {} }], hydratedComponents: [], clientOnlyComponents: ['../components'], hydrationDirectives: new Set(['only']), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+const data = helper();
+
+return $$render`${$$renderComponent($$result,'Component',null,{"client:only":true,"client:component-hydration":"only","client:component-path":($$metadata.resolvePath("../components")),"client:component-export":"default"})}
+${$$maybeRenderHead($$result)}<div>${data}</div>`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -7,6 +7,7 @@ package printer
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -188,6 +189,17 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 						}
 						delete(clientOnlyBindings, name)
 					}
+					// Also exclude server-rendered components (no client: directive)
+					for _, comp := range n.Parent.ServerComponents {
+						name := comp.LocalName
+						if name == "" {
+							name = comp.Specifier
+						}
+						if idx := strings.Index(name, "."); idx != -1 {
+							name = name[:idx]
+						}
+						delete(clientOnlyBindings, name)
+					}
 
 					// Collect frontmatter body text to check for binding usage
 					var bodyText []byte
@@ -213,7 +225,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 										allDead = false
 										break
 									}
-									if bytes.Contains(bodyText, []byte(imp.LocalName)) {
+									if regexp.MustCompile(`\b` + regexp.QuoteMeta(imp.LocalName) + `\b`).Match(bodyText) {
 										allDead = false
 										break
 									}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -168,35 +168,59 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				}
 				render := js_scanner.HoistImports([]byte(c.Data))
 				if len(render.Hoisted) > 0 {
-					// Build set of specifiers used exclusively by client:only
-					// components. These imports are dead code in the prerender
-					// output (the compiler passes null to $$renderComponent) so
-					// we skip them to keep the module out of Rollup's graph.
-					clientOnlySpecifiers := make(map[string]bool)
-					for _, comp := range n.Parent.ClientOnlyComponents {
-						clientOnlySpecifiers[comp.Specifier] = true
+					// Build set of local binding names used exclusively by
+					// client:only components. The compiler passes null to
+					// $$renderComponent for these, so the import is dead code
+					// and can be stripped to keep Rollup from traversing the
+					// component's dependency tree during prerender.
+					clientOnlyBindings := make(map[string]bool)
+					for _, node := range n.Parent.ClientOnlyComponentNodes {
+						name := node.Data
+						if idx := strings.Index(name, "."); idx != -1 {
+							name = name[:idx]
+						}
+						clientOnlyBindings[name] = true
 					}
-					for _, comp := range n.Parent.HydratedComponents {
-						delete(clientOnlySpecifiers, comp.Specifier)
+					for _, node := range n.Parent.HydratedComponentNodes {
+						name := node.Data
+						if idx := strings.Index(name, "."); idx != -1 {
+							name = name[:idx]
+						}
+						delete(clientOnlyBindings, name)
 					}
-					for _, comp := range n.Parent.ServerComponents {
-						delete(clientOnlySpecifiers, comp.Specifier)
+
+					// Collect frontmatter body text to check for binding usage
+					var bodyText []byte
+					if len(clientOnlyBindings) > 0 {
+						for _, b := range render.Body {
+							bodyText = append(bodyText, b...)
+						}
 					}
 
 					for i, hoisted := range render.Hoisted {
 						if len(bytes.TrimSpace(hoisted)) == 0 {
 							continue
 						}
-						// Skip imports that exist solely for a client:only component.
-						// Only safe when: (1) the specifier is client-only-exclusive,
-						// (2) the import has exactly one binding (no mixed exports like
-						// `import Repl, { getMeta } from './Repl'`), and (3) the import
-						// is not a bare side-effect import (`import './Repl'`).
-						if len(clientOnlySpecifiers) > 0 {
+						// Strip an import only when every binding it introduces
+						// is a client-only-exclusive component identifier that
+						// does not appear in the frontmatter body.
+						if len(clientOnlyBindings) > 0 {
 							_, stmt := js_scanner.NextImportStatement(hoisted, 0)
-							if stmt.Specifier != "" && clientOnlySpecifiers[stmt.Specifier] &&
-								len(stmt.Imports) == 1 && !stmt.IsType {
-								continue
+							if len(stmt.Imports) > 0 && !stmt.IsType {
+								allDead := true
+								for _, imp := range stmt.Imports {
+									if !clientOnlyBindings[imp.LocalName] {
+										allDead = false
+										break
+									}
+									if bytes.Contains(bodyText, []byte(imp.LocalName)) {
+										allDead = false
+										break
+									}
+								}
+								if allDead {
+									continue
+								}
 							}
 						}
 						hoistedLoc := render.HoistedLocs[i]

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -168,9 +168,36 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				}
 				render := js_scanner.HoistImports([]byte(c.Data))
 				if len(render.Hoisted) > 0 {
+					// Build set of specifiers used exclusively by client:only
+					// components. These imports are dead code in the prerender
+					// output (the compiler passes null to $$renderComponent) so
+					// we skip them to keep the module out of Rollup's graph.
+					clientOnlySpecifiers := make(map[string]bool)
+					for _, comp := range n.Parent.ClientOnlyComponents {
+						clientOnlySpecifiers[comp.Specifier] = true
+					}
+					for _, comp := range n.Parent.HydratedComponents {
+						delete(clientOnlySpecifiers, comp.Specifier)
+					}
+					for _, comp := range n.Parent.ServerComponents {
+						delete(clientOnlySpecifiers, comp.Specifier)
+					}
+
 					for i, hoisted := range render.Hoisted {
 						if len(bytes.TrimSpace(hoisted)) == 0 {
 							continue
+						}
+						// Skip imports that exist solely for a client:only component.
+						// Only safe when: (1) the specifier is client-only-exclusive,
+						// (2) the import has exactly one binding (no mixed exports like
+						// `import Repl, { getMeta } from './Repl'`), and (3) the import
+						// is not a bare side-effect import (`import './Repl'`).
+						if len(clientOnlySpecifiers) > 0 {
+							_, stmt := js_scanner.NextImportStatement(hoisted, 0)
+							if stmt.Specifier != "" && clientOnlySpecifiers[stmt.Specifier] &&
+								len(stmt.Imports) == 1 && !stmt.IsType {
+								continue
+							}
 						}
 						hoistedLoc := render.HoistedLocs[i]
 						p.printTextWithSourcemap(string(hoisted)+"\n", loc.Loc{Start: start + hoistedLoc.Start})

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -509,6 +509,33 @@ import Component from '../components';
 </html>`,
 		},
 		{
+			name: "client:only preserves mixed import from same specifier",
+			source: `---
+import Component from '../components';
+import { helper } from '../components';
+const data = helper();
+---
+<Component client:only />
+<div>{data}</div>`,
+		},
+		{
+			name: "client:only preserves import when binding used in frontmatter",
+			source: `---
+import Component from '../components';
+console.log(Component.name);
+---
+<Component client:only />`,
+		},
+		{
+			name: "client:only preserves mixed binding import",
+			source: `---
+import Component, { helper } from '../components';
+const data = helper();
+---
+<Component client:only />
+<div>{data}</div>`,
+		},
+		{
 			name:   "iframe",
 			source: `<iframe src="something" />`,
 		},


### PR DESCRIPTION
## Changes

Strips dead imports for `client:only` components from the compiled `.astro` output. The compiler emits `import Foo from './Foo'` for `client:only` components but passes `null` to `$$renderComponent` — the import value is dead code in the prerender environment. However, Rollup still resolves the import and traverses the component's dependency tree (e.g. React, CodeMirror), inflating prerender build time for island-heavy sites.

### What this PR does

In `print-to-js.go`, before printing hoisted imports, builds a set of specifiers that appear exclusively in `ClientOnlyComponents` (not also in `HydratedComponents` or `ServerComponents`). For each hoisted import matching that set, skips it if:

1. The import has **exactly one binding** (not mixed like `import Repl, { getMeta } from './Repl'`)
2. The import is **not** a type-only import
3. The import is **not** a bare side-effect import (`import './Repl'`)

The `clientOnlyComponents` metadata in the compiled output is preserved — only the dead import statement is removed.

### Why this is safe

- The compiler already passes `null` to `$$renderComponent` for `client:only`: the import value is provably unused in the render path
- Mixed imports are preserved (guard: `len(stmt.Imports) == 1`)
- Side-effect imports are preserved (guard: `len(stmt.Imports) == 0` → not matched)
- Type imports are preserved (guard: `!stmt.IsType`)
- Dual-use components (same specifier in both `ClientOnlyComponents` and `HydratedComponents`) are preserved (specifier removed from the skip set)

### Known limitation

If frontmatter code references the imported binding for non-component purposes (e.g. `const Alias = Repl`), the import would be incorrectly removed. This is an unlikely pattern for `client:only` components (which by definition have no server-side use), but could be addressed with binding usage analysis if needed.

### Measured impact

906-page static site (Astro 6.1.2), 472 pages with 2,055 `client:only` React islands:

| Experiment | Pages | Prerender (ms) | Delta |
|---|---|---|---|
| Baseline | 906 | 4,338 | — |
| Remove reading pages entirely | 433 | 1,012 | -3,326 (-77%) |
| **Trivial reading pages (no React imports)** | **906** | **2,203** | **-2,135 (-49%)** |
| Switch to `client:only="react"` | 906 | 4,390 | +52 (noise) |

The trivial-pages experiment (same page count, no React imports) confirms ~2,135ms of prerender time is attributable to dead `client:only` import graph traversal.

### Compiled output before/after

**Before:**
```javascript
import Repl from './Repl';
$$renderComponent($$result, 'Repl', null, {"client:only":"react", ...})
```

**After:**
```javascript
$$renderComponent($$result, 'Repl', null, {"client:only":"react", ...})
```

The `clientOnlyComponents` metadata array is unchanged.

## Testing

All 6 client:only snapshot tests updated and passing. Full internal test suite passes.

Previously opened (and closed) [withastro/astro#16634](https://github.com/withastro/astro/pull/16634) with a Vite plugin approach, but moved to the compiler as the cleaner fix point.