### PR TITLE
escape backslashes in JS string literal output

### DIFF
--- a/internal/printer/__printer_js__/component_attribute_with_backslash.snap
+++ b/internal/printer/__printer_js__/component_attribute_with_backslash.snap
@@ -1,0 +1,41 @@
+
+[TestPrinter/component_attribute_with_backslash - 1]
+## Input
+
+```
+<Component path='C:\dir\' name={x} />
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+
+export const $$metadata = $$createMetadata(import.meta.url, { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Component = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$renderComponent($$result,'Component',Component,{"path":"C:\\dir\\","name":(x)})}`;
+}, undefined, undefined);
+export default $$Component;
+```
+---

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -421,7 +421,7 @@ func (p *printer) printAttributesToObject(n *astro.Node) {
 			p.printf(`"%s"`, a.Key)
 			p.print(":")
 			p.addSourceMapping(a.ValLoc)
-			p.print(`"` + escapeDoubleQuote(escapeNewlines(a.Val)) + `"`)
+			p.print(`"` + escapeNewlines(escapeDoubleQuote(a.Val)) + `"`)
 		case astro.EmptyAttribute:
 			p.addSourceMapping(a.KeyLoc)
 			p.printf(`"%s"`, a.Key)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -391,6 +391,10 @@ import * as ns from '../components';
 			source: `<Component><div slot='"name"' /></Component>`,
 		},
 		{
+			name:   "component attribute with backslash",
+			source: `<Component path='C:\dir\' name={x} />`,
+		},
+		{
 			name:   "#955 ternary slot with text",
 			source: `<Component>Hello{isLeaf ? <p>Leaf</p> : <p>Branch</p>}world</Component>`,
 		},

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -87,10 +87,12 @@ func escapeBackticks(src string) string {
 }
 
 func escapeSingleQuote(str string) string {
+	str = strings.Replace(str, "\\", "\\\\", -1)
 	return strings.Replace(str, "'", "\\'", -1)
 }
 
 func escapeDoubleQuote(str string) string {
+	str = strings.Replace(str, "\\", "\\\\", -1)
 	return strings.Replace(str, `"`, "\\\"", -1)
 }
 


### PR DESCRIPTION
1. escapeDoubleQuote and escapeSingleQuote escape the closing quote but not the backslash, so a value ending in a backslash (or one before a quote) lands a `\` right against the closing quote the printer adds and breaks out of the JS string literal.
2. these feed the renderComponent props object, slot names and the hoisted script `src` metadata, all built from attribute values in the source.

A quoted attribute is the trigger. `<Component path='C:\dir\' />` currently emits `{"path":"C:\dir\"}` which node refuses to parse; a crafted trailing backslash terminates the string early and the following bytes are no longer inside it. Same story for `src` on a hoisted `<script>`.

Escaped the backslash first in both helpers. The one place escapeNewlines wraps the value I flipped the order so the `\n` it inserts isn't doubled. Added a snapshot covering a backslash attribute.
