### PR TITLE
Fix crash on Props generic containing a shift or comparison operator

### DIFF
--- a/.changeset/fix-generic-props-operator-crash.md
+++ b/.changeset/fix-generic-props-operator-crash.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Fix a crash when converting a component to TSX whose `Props` generic contains an operator that the lexer emits as a single `<`/`>` token, such as `interface Props<T extends number = (1 << 2)>`. These operators were mistaken for generic angle brackets, desyncing the bracket-depth tracking and panicking with a slice bounds error.

--- a/internal/js_scanner/js_scanner.go
+++ b/internal/js_scanner/js_scanner.go
@@ -479,6 +479,22 @@ type Props struct {
 	Generics  string
 }
 
+// isClosingAngleRun reports whether value is a non-empty run of `>` characters,
+// i.e. one of the `>`, `>>` or `>>>` tokens the lexer emits when several
+// generics close at once (`Foo<Bar<T>>`). It deliberately excludes operators
+// like `>=` and `>>=` that merely contain a `>`.
+func isClosingAngleRun(value []byte) bool {
+	if len(value) == 0 {
+		return false
+	}
+	for _, c := range value {
+		if c != '>' {
+			return false
+		}
+	}
+	return true
+}
+
 func GetPropsType(source []byte) Props {
 	defaultPropType := "Record<string, any>"
 	ident := defaultPropType
@@ -577,7 +593,13 @@ outer:
 			continue
 		}
 
-		if bytes.ContainsAny(value, "<>") {
+		// Only a bare `<` opens a generic, and only a run of `>` (e.g. `>>`
+		// closing `Foo<Bar<T>>`) closes one. Operators such as `<<`, `<=`,
+		// `>=` or `>>=` contain `<`/`>` but are not generic brackets, so they
+		// must be skipped here. Treating them as brackets previously desynced
+		// the `pairs['<']` depth and the `i` offset, which made `source[start:end]`
+		// panic on otherwise valid generic Props (e.g. `Props<T = (1 << 2)>`).
+		if bytes.Equal(value, []byte("<")) || isClosingAngleRun(value) {
 			if len(idents) > 0 && idents[len(idents)-1] == "Props" {
 				start = i
 				ident = "Props"

--- a/internal/js_scanner/js_scanner_test.go
+++ b/internal/js_scanner/js_scanner_test.go
@@ -984,6 +984,35 @@ func getPropsTypeTestCases() []propsTestCase {
 			want: makeProps("Props", "<T>", "<T>"),
 		},
 
+		// Issue #16232: operators that the lexer emits as a single token
+		// containing `<` or `>` (e.g. `<<`, `<=`, `>>=`) must not be mistaken
+		// for generic angle brackets. Previously they desynced the bracket
+		// depth and offset tracking, crashing on otherwise valid Props.
+		{
+			name: "Props generic with left-shift default - issue #16232",
+			source: `interface Props<T extends number = (1 << 2)> {
+				foo: T;
+			}`,
+			want: makeProps("Props", "<T extends number = (1 << 2)>", "<T>"),
+		},
+		{
+			name: "Props generic with comparison default - issue #16232",
+			source: `interface Props<T extends number = (1 <= 2 ? 0 : 1)> {
+				foo: T;
+			}`,
+			want: makeProps("Props", "<T extends number = (1 <= 2 ? 0 : 1)>", "<T>"),
+		},
+
+		// Nested generics close with a `>>`/`>>>` token, which must still be
+		// counted as several closing brackets.
+		{
+			name: "Props with nested generics",
+			source: `interface Props<T extends Map<string, Array<number>>> {
+				foo: T;
+			}`,
+			want: makeProps("Props", "<T extends Map<string, Array<number>>>", "<T>"),
+		},
+
 		// Issue #927: 'as' prop name handling
 		{
 			name: "destructuring with 'as' prop name without type assertion - issue #927",


### PR DESCRIPTION
While converting a component to TSX, `GetPropsType` panics with a slice-bounds error on valid TypeScript like:

```ts
interface Props<T extends number = (1 << 2)> {
  count: T;
}
```

The scanner walks the generic parameter list tracking angle-bracket depth, but it treated *any* token containing `<` or `>` as a generic bracket. The lexer emits operators such as `<<`, `<=` and `>>=` as a single token, so each one bumped the bracket depth and the byte offset the wrong way. The offset then ran past the end of the source and `source[start:end]` panicked, which surfaces as "There was an error transforming … to TSX. An empty file will be returned" in the language server.

The fix narrows the bracket handling: only a bare `<` opens a generic, and only a run of `>` (the `>>` / `>>>` tokens used to close nested generics like `Foo<Bar<T>>`) closes one. Real operators are left untouched, so the depth and offset stay in sync.

Tested by adding cases to `TestGetPropsType` for a left-shift default, a comparison default and a nested-generic close; the first two panic on `main` and pass with the fix, and the nested-generic case guards against regressing the `>>` handling. `go test ./internal/...`, `go vet` and `gofmt` are clean, and the wasm build succeeds.

Fixes withastro/compiler-rs#78