### PR TITLE
fix: escape quoted transition attribute value in convertAttributeValue

### DIFF
--- a/.changeset/escape-transition-attr-value.md
+++ b/.changeset/escape-transition-attr-value.md
@@ -1,0 +1,5 @@
+---
+"@astrojs/compiler": patch
+---
+
+Escape quoted `transition:name` and `transition:animate` attribute values when emitting the `renderTransition` call, so a value containing a double quote no longer breaks out of the generated JS string literal.

--- a/internal/printer/__printer_js__/transition_name_with_a_quote_in_the_value.snap
+++ b/internal/printer/__printer_js__/transition_name_with_a_quote_in_the_value.snap
@@ -1,0 +1,42 @@
+
+[TestPrinter/transition:name_with_a_quote_in_the_value - 1]
+## Input
+
+```
+<div transition:name='one"two'></div>
+```
+
+## Output
+
+```js
+import {
+  Fragment,
+  render as $$render,
+  createAstro as $$createAstro,
+  createComponent as $$createComponent,
+  renderComponent as $$renderComponent,
+  renderHead as $$renderHead,
+  maybeRenderHead as $$maybeRenderHead,
+  unescapeHTML as $$unescapeHTML,
+  renderSlot as $$renderSlot,
+  mergeSlots as $$mergeSlots,
+  addAttribute as $$addAttribute,
+  spreadAttributes as $$spreadAttributes,
+  defineStyleVars as $$defineStyleVars,
+  defineScriptVars as $$defineScriptVars,
+  renderTransition as $$renderTransition,
+  createTransitionScope as $$createTransitionScope,
+  renderScript as $$renderScript,
+  createMetadata as $$createMetadata
+} from "http://localhost:3000/";
+import "transitions.css";
+
+export const $$metadata = $$createMetadata("/projects/app/src/pages/page.astro", { modules: [], hydratedComponents: [], clientOnlyComponents: [], hydrationDirectives: new Set([]), hoisted: [] });
+
+const $$Page = $$createComponent(($$result, $$props, $$slots) => {
+
+return $$render`${$$maybeRenderHead($$result)}<div${$$addAttribute($$renderTransition($$result, "p7yz7w6s", "", "one\"two"), "data-astro-transition-scope")}></div>`;
+}, '/projects/app/src/pages/page.astro', 'self');
+export default $$Page;
+```
+---

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1997,6 +1997,12 @@ const items = ["Dog", "Cat", "Platipus"];
 			transitions: true,
 		},
 		{
+			name:        "transition:name with a quote in the value",
+			source:      `<div transition:name='one"two'></div>`,
+			filename:    "/projects/app/src/pages/page.astro",
+			transitions: true,
+		},
+		{
 			name:        "transition:animate with an expression",
 			source:      "<div transition:animate={slide({duration:15})}></div>",
 			filename:    "/projects/app/src/pages/page.astro",

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -110,7 +110,7 @@ func convertAttributeValue(n *astro.Node, attrName string) string {
 		attr := transform.GetAttr(n, attrName)
 		switch attr.Type {
 		case astro.QuotedAttribute:
-			expr = fmt.Sprintf(`"%s"`, attr.Val)
+			expr = fmt.Sprintf(`"%s"`, escapeDoubleQuote(escapeNewlines(attr.Val)))
 		case astro.ExpressionAttribute:
 			expr = fmt.Sprintf(`(%s)`, attr.Val)
 		case astro.TemplateLiteralAttribute:


### PR DESCRIPTION
## Changes

- root cause: `convertAttributeValue` wraps a quoted `transition:name` / `transition:animate` value in a JS string literal but never escapes it, unlike every other quoted-value path in the printer which goes through `escapeDoubleQuote`.
- a single-quoted `.astro` attribute value can legally contain a `"`, so `transition:name='x"+(expr)+"y'` breaks out of the string in the emitted `$$renderTransition(...)` call and injects arbitrary js into the generated module.
- escape the value with `escapeDoubleQuote(escapeNewlines(...))`, matching `printAttributesToObject` and the slot paths.

## Testing

- added a snapshot case `transition:name with a quote in the value`; it emits the value as `"one\"two"`, and reverting the one-line change fails it. found while auditing the printer's quoted-value emission sites.

## Docs

- bug fix only.